### PR TITLE
Deprecate python 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.egg-info/
 .mypy_cache/
 .tox/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ View swagger page at `http://localhost:8000/docs`.
 
 ### Development Installation
 
-Requires Python 3.6+
+Requires Python 3.7+
 
 ```
 pip install -e .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, lint, typecheck, black
+envlist = py37, py38, lint, typecheck, black
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Remove Python 3.6 from tox and readme. Fixes #16.