### PR TITLE
Prevent errors when faceting over an attribute in a foreign table

### DIFF
--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -217,9 +217,11 @@ class BaseQuerySchema(BaseModel):
 
     def facet(self, db: Session, attribute: str,) -> Dict[schemas.AnnotationValue, int]:
         model = self.table.model
-        if attribute in _special_keys:
-            table, field = _special_keys[attribute]
+        join_envo = False
+        if attribute in _envo_keys and self.table == Table.biosample:
+            table, field = _envo_keys[attribute]
             column = getattr(table.model, field)
+            join_envo = True
         else:
             if attribute in model.__table__.columns:
                 column = getattr(model, attribute)
@@ -228,7 +230,7 @@ class BaseQuerySchema(BaseModel):
 
         subquery = self.query(db).subquery()
         query = db.query(column, func.count(column))
-        if attribute in _envo_keys:
+        if join_envo:
             query = query.join(
                 models.Biosample, getattr(models.Biosample, f"{attribute}_id") == table.model.id
             )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -257,3 +257,16 @@ def test_facet_envo(db: Session):
         "local1": 1,
         "local2": 2,
     }
+
+
+def test_facet_foreign_table(db: Session):
+    env_local1 = fakes.EnvoTermFactory(label="local1")
+    env_local2 = fakes.EnvoTermFactory(label="local2")
+    fakes.BiosampleFactory(id="sample1", env_local_scale=env_local1)
+    fakes.BiosampleFactory(id="sample2", env_local_scale=env_local2)
+    fakes.BiosampleFactory(id="sample3", env_local_scale=env_local2)
+    db.commit()
+
+    q = query.StudyQuerySchema(conditions=[])
+    assert q.facet(db, "env_local_scale") == {}
+    assert q.facet(db, "sample_id") == {}


### PR DESCRIPTION
The faceting query should always return counts of fields in the current table.  There were cases when a faceting operation was throwing an error due to invalid join condition in the main query.  The correct behavior is to return an empty dictionary.  For example, faceting on the 'study` table over the attribute `biosample_id` returns no results because no studies contain that field.