### PR TITLE
Return attribute types in database summary

### DIFF
--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -1,0 +1,72 @@
+from typing import cast, Dict, Type
+
+from sqlalchemy import Column, func
+from sqlalchemy.orm import Session
+
+from nmdc_server import models, schemas
+
+
+def get_annotation_summary(
+    db: Session, model: Type[models.AnnotatedModel],
+) -> Dict[str, schemas.AttributeSummary]:
+    attribute = func.jsonb_object_keys(model.annotations)
+
+    # TODO: Figure out the correct type, or remove json aggregations
+    q = db.query(attribute, func.count(),).group_by(attribute)
+
+    attributes: Dict[str, schemas.AttributeSummary] = {}
+    for r in q:
+        attributes[r[0]] = schemas.AttributeSummary(count=r[1], type=schemas.AttributeType.string,)
+
+    return attributes
+
+
+def get_column_count(db: Session, column: Column) -> int:
+    return db.query(func.count()).filter(column != None).scalar()
+
+
+def get_table_summary(db: Session, model: models.ModelType) -> schemas.TableSummary:
+    count = db.query(model).count()
+    attributes: Dict[str, schemas.AttributeSummary] = {}
+    if isinstance(model(), models.AnnotatedModel):
+        attributes.update(get_annotation_summary(db, cast(Type[models.AnnotatedModel], model)))
+
+    for column in model.__table__.columns:
+        if (
+            column.name not in ["id", "annotations", "alternate_identifiers"]
+            and "_id" not in column.name
+        ):
+            type_ = schemas.AttributeType.from_column(column)
+            if type_ == schemas.AttributeType.string:
+                attributes[column.name] = schemas.AttributeSummary(
+                    count=get_column_count(db, column),
+                    type=schemas.AttributeType.from_column(column),
+                )
+            else:
+                count, min, max = (
+                    db.query(func.count(), func.min(column), func.max(column))
+                    .filter(column != None)
+                    .first()
+                )
+                attributes[column.name] = schemas.AttributeSummary(
+                    count=get_column_count(db, column),
+                    min=min,
+                    max=max,
+                    type=schemas.AttributeType.from_column(column),
+                )
+
+    if model == models.Biosample:
+        attributes["env_medium"] = schemas.AttributeSummary(
+            count=get_column_count(db, models.Biosample.env_medium_id),
+            type=schemas.AttributeType.string,
+        )
+        attributes["env_local_scale"] = schemas.AttributeSummary(
+            count=get_column_count(db, models.Biosample.env_local_scale_id),
+            type=schemas.AttributeType.string,
+        )
+        attributes["env_broad_scale"] = schemas.AttributeSummary(
+            count=get_column_count(db, models.Biosample.env_broad_scale_id),
+            type=schemas.AttributeType.string,
+        )
+
+    return schemas.TableSummary(total=count, attributes=attributes)

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -21,7 +21,12 @@ def get_db(settings: Settings = Depends(get_settings)):
 
 
 # database summary
-@router.get("/summary", response_model=schemas.DatabaseSummary, tags=["summary"])
+@router.get(
+    "/summary",
+    response_model=schemas.DatabaseSummary,
+    tags=["summary"],
+    response_model_exclude_unset=True,
+)
 async def get_database_summary(db: Session = Depends(get_db)):
     return crud.get_database_summary(db)
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -31,17 +31,17 @@ def get_table_summary(db: Session, model: models.ModelType) -> schemas.TableSumm
     annotations = getattr(model, "annotations", None)
     if annotations:
         attribute = func.jsonb_object_keys(annotations)
-        q = db.query(attribute, func.count()).group_by(attribute)
-        attributes.update({row[0]: row[1] for row in q})
+        q = db.query(attribute).group_by(attribute)
+        attributes.update({row[0]: schemas.AttributeType.string for row in q})
 
     for column in model.__table__.columns:
         if column.name not in ["annotations", "alternate_identifiers"] and "_id" not in column.name:
-            attributes[column.name] = count
+            attributes[column.name] = schemas.AttributeType.from_column(column)
 
     if model == models.Biosample:
-        attributes["env_medium"] = count
-        attributes["env_local_scale"] = count
-        attributes["env_broad_scale"] = count
+        attributes["env_medium"] = schemas.AttributeType.string
+        attributes["env_local_scale"] = schemas.AttributeType.string
+        attributes["env_broad_scale"] = schemas.AttributeType.string
 
     return schemas.TableSummary(total=count, attributes=attributes)
 

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -68,8 +68,15 @@ class AnnotatedBase(BaseModel):
 
 
 # summary
+class AttributeSummary(BaseModel):
+    count: int
+    min: Optional[Union[float, datetime]]
+    max: Optional[Union[float, datetime]]
+    type: AttributeType
+
+
 class TableSummary(BaseModel):
-    attributes: Dict[str, AttributeType]
+    attributes: Dict[str, AttributeSummary]
     total: int
 
 

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -1,7 +1,9 @@
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, validator
+from sqlalchemy import BigInteger, Column, DateTime, Float, String
 
 from nmdc_server import models
 
@@ -28,6 +30,25 @@ class InternalErrorSchema(ErrorSchema):
     )
 
 
+class AttributeType(Enum):
+    string = "string"
+    integer = "integer"
+    float_ = "float"
+    date = "date"
+
+    @classmethod
+    def from_column(cls, column: Column) -> "AttributeType":
+        if isinstance(column.type, DateTime):
+            return AttributeType.date
+        elif isinstance(column.type, Float):
+            return AttributeType.float_
+        elif isinstance(column.type, BigInteger):
+            return AttributeType.integer
+        elif isinstance(column.type, String):
+            return AttributeType.string
+        raise Exception("Unknown column type")
+
+
 class EnvoTerm(BaseModel):
     id: str
     label: str
@@ -48,7 +69,7 @@ class AnnotatedBase(BaseModel):
 
 # summary
 class TableSummary(BaseModel):
-    attributes: Dict[str, int]
+    attributes: Dict[str, AttributeType]
     total: int
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,5 @@ ignore =
     W503  # conflicts with black
     N805  # conflicts with pydantic validators
     N815  # conflicts with nmdc column names
+    E711  # conflicts with sqlalchemy comparisons
 application-import-names = nmdc_server


### PR DESCRIPTION
@subdavis This updates the summary response to include the attribute type.  I replaced the per attribute count because I'm not sure it's that useful, but I can make it a nested object type if needed.