### PR TITLE
Add a new endpoint that accumulates stats to be shown on the main page

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -31,6 +31,13 @@ async def get_database_summary(db: Session = Depends(get_db)):
     return crud.get_database_summary(db)
 
 
+@router.get(
+    "/stats", response_model=schemas.AggregationSummary, tags=["summary"],
+)
+async def get_aggregated_stats(db: Session = Depends(get_db)):
+    return crud.get_aggregated_stats(db)
+
+
 # biosample
 @router.post(
     "/biosample", response_model=schemas.Biosample, tags=["biosample"],

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -23,7 +23,7 @@ def get_or_create(
         return instance, True
 
 
-# summary
+# summaries
 def get_database_summary(db: Session) -> schemas.DatabaseSummary:
     return schemas.DatabaseSummary(
         study=aggregations.get_table_summary(db, models.Study),
@@ -34,6 +34,10 @@ def get_database_summary(db: Session) -> schemas.DatabaseSummary:
         metagenome_annotation=aggregations.get_table_summary(db, models.MetagenomeAnnotation),
         metaproteomic_analysis=aggregations.get_table_summary(db, models.MetaproteomicAnalysis),
     )
+
+
+def get_aggregated_stats(db: Session) -> schemas.AggregationSummary:
+    return aggregations.get_aggregation_summary(db)
 
 
 # study

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -90,6 +90,19 @@ class DatabaseSummary(BaseModel):
     metaproteomic_analysis: TableSummary
 
 
+class AggregationSummary(BaseModel):
+    studies: int
+    locations: int
+    habitats: int
+    data_size: int
+    metagenomes: int
+    metatranscriptomes: int
+    proteomics: int
+    metabolomics: int
+    lipodomics: int
+    organic_matter_characterization: int
+
+
 # study
 class StudyBase(AnnotatedBase):
     principal_investigator_websites: List[str] = []
@@ -127,8 +140,8 @@ class Study(StudyBase):
 # project
 class ProjectBase(AnnotatedBase):
     study_id: str
-    add_date: datetime
-    mod_date: datetime
+    add_date: Optional[datetime]
+    mod_date: Optional[datetime]
 
 
 class ProjectCreate(ProjectBase):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,3 +60,16 @@ def test_api_faceting(db: Session, client: TestClient):
     resp = client.post("/api/biosample/facet", json={"conditions": [], "attribute": "key2"})
     assert_status(resp)
     assert resp.json()["facets"] == {"value2": 2, "value3": 1}
+
+
+def test_api_summary(db: Session, client: TestClient):
+    # TODO: This would be better queried against the real data
+    for _ in range(10):
+        fakes.BiosampleFactory()
+        fakes.MetagenomeAnnotationFactory()
+        fakes.MetagenomeAssemblyFactory()
+        fakes.MetaproteomicAnalysisFactory()
+        fakes.DataObjectFactory()
+    db.commit()
+    assert_status(client.get("/api/summary"))
+    assert_status(client.get("/api/stats"))


### PR DESCRIPTION
Adding this new endpoint so that the aggregations can be optimized at some point in the future.
```
GET /api/stats

=> {
    "data_size": 9971939611997,
    "habitats": 21,
    "lipodomics": 0,
    "locations": 23,
    "metabolomics": 0,
    "metagenomes": 834,
    "metatranscriptomes": 130,
    "organic_matter_characterization": 0,
    "proteomics": 0,
    "studies": 13
}
```