### PR TITLE
Catch query errors when provided invalid attributes

### DIFF
--- a/nmdc_server/errors.py
+++ b/nmdc_server/errors.py
@@ -4,10 +4,18 @@ from fastapi import FastAPI
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from .query import InvalidAttributeException
 from .utils import log_extras, logger
 
 
 def attach_error_handlers(app: FastAPI) -> None:
+    @app.exception_handler(InvalidAttributeException)
+    async def invalid_attribute_handler(req: Request, exc: Exception) -> JSONResponse:
+        exception_id = str(uuid.uuid4())
+        logger.exception("Unhandled exception, ID=%s.", exception_id, extra=log_extras(req))
+
+        return JSONResponse(status_code=400, content={"detail": {"msg": str(exc),}},)
+
     @app.exception_handler(Exception)
     async def internal_exception_handler(req: Request, exc: Exception) -> JSONResponse:
         exception_id = str(uuid.uuid4())

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -391,3 +391,17 @@ def test_pipeline_query(db: Session, table):
         conditions=[{"table": q.table.value, "field": "name", "value": f"{table}1"}]
     )
     assert ["project1"] == [r.name for r in q.execute(db).all()]
+
+
+def test_query_invalid_attribute(db: Session):
+    q = query.ReadsQCQuerySchema(
+        conditions=[{"table": "reads_qc", "field": "bad value", "value": ""}]
+    )
+    with pytest.raises(query.InvalidAttributeException):
+        q.execute(db)
+
+
+def test_facet_invalid_attribute(db: Session):
+    q = query.ReadsQCQuerySchema()
+    with pytest.raises(query.InvalidAttributeException):
+        q.facet(db, "bad value")


### PR DESCRIPTION
This would be better placed on the schema, but with dynamic attributes
in "annotations" it can't really be done.

Fixes #63