### PR TITLE
Convert strings to numbers if required

### DIFF
--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -106,7 +106,7 @@ export interface MetagenomeAnnotationResult extends DerivedDataResult {
 
 export type MetaproteomicAnalysisResult = DerivedDataResult
 
-interface AttributeSummary {
+export interface AttributeSummary {
   count: number;
   type: 'string' | 'date' | 'integer' | 'float';
   min?: string | number;

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -14,9 +14,6 @@ Vue.config.productionTip = false;
 
 sync(store, router);
 
-// Only call this once at page load
-store.dispatch('load');
-
 new Vue({
   router,
   store,


### PR DESCRIPTION
@jbeezley because the URL query string causes all numbers to be converted to strings, on page reload, if you had a numeric condition, the value would become a string.

It seems like the server is handling this, but I thought it wasn't, and wrote this to deal with it.  I don't really like this solution, because it relies on loading the results from `/api/summmary` to get the type info before the search can be dispatched.

LMK what you think.