### PR TITLE
Handle missing envo terms in biosample response

### DIFF
--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -207,9 +207,9 @@ class Biosample(BiosampleBase):
     env_broad_scale: Optional[EnvoTerm]
     env_local_scale: Optional[EnvoTerm]
     env_medium: Optional[EnvoTerm]
-    env_broad_scale_terms: List[str]
-    env_local_scale_terms: List[str]
-    env_medium_terms: List[str]
+    env_broad_scale_terms: List[str] = []
+    env_local_scale_terms: List[str] = []
+    env_medium_terms: List[str] = []
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
Fixes a 500 error that was sometimes occurring.