### PR TITLE
Add the ability to query association proxy fields

### DIFF
--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -65,12 +65,10 @@ def get_table_summary(db: Session, model: models.ModelType) -> schemas.TableSumm
             count=get_column_count(db, models.Biosample.env_broad_scale_id),
             type=schemas.AttributeType.string,
         )
-    # TODO: enable when query works
-    # if model == models.Study:
-    #     attributes["principal_investigator_name"] = schemas.AttributeSummary(
-    #         count=count,
-    #         type=schemas.AttributeType.string,
-    #     )
+    if model == models.Study:
+        attributes["principal_investigator_name"] = schemas.AttributeSummary(
+            count=count, type=schemas.AttributeType.string,
+        )
 
     return schemas.TableSummary(total=count, attributes=attributes)
 


### PR DESCRIPTION
Done to enable querying by principal investigator name.  Like with the envo fields, the code to do it is a bit ugly because you can't group_by and association proxy field.  This is making clear that there needs to be better hooks for per-attribute query customization in a future refactor.

Fixes #74