### PR TITLE
Fix docker env vars

### DIFF
--- a/.docker-env
+++ b/.docker-env
@@ -1,6 +1,6 @@
 POSTGRES_PASSWORD=postgres
 PGHOST=db
 PGUSER=postgres
-PGPASSWORD="${POSTGRES_PASSWORD}"
+PGPASSWORD=postgres
 PGDATABASE=nmdc
-POSTGRES_URI="postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}"
+POSTGRES_URI="postgresql://postgres:postgres@postgres/nmdc"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
   web:
     depends_on: 
       - backend
+    env_file:
+      - .docker-env
     environment:
       BACKEND_URL: "http://backend:8000"
     build:


### PR DESCRIPTION
Not sure what the intention was here, but right now the docker-compose stack won't start because the password is missing.  Docker-compose won't interpolate strings defined elsewhere in the .env, you can check with `docker inspect`:

```
                "PGUSER=postgres",
                "PGDATA=/var/lib/postgresql/data/pgdata",
                "PGDATABASE=nmdc",
                "PGHOST=db",
                "POSTGRES_URI=\"postgresql://${PGUSER}:${PGPASSWORD}@${PGHOST}/${PGDATABASE}\"",
                "POSTGRES_PASSWORD=postgres",
                "PGPASSWORD=\"${POSTGRES_PASSWORD}\"",
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin",
                "GOSU_VERSION=1.12",
                "LANG=en_US.utf8",
                "PG_MAJOR=12",
                "PG_VERSION=12.3-1.pgdg100+1"
```