### PR TITLE
Guard against invalid association proxy queries on unrelated tables

### DIFF
--- a/create_database.py
+++ b/create_database.py
@@ -194,6 +194,7 @@ def ingest_projects(db: Session, data) -> Dict[str, str]:
         project = load_common_fields(p)
         project["study_id"] = coerce_id(p.pop("part_of")[0])
         data_objects = p.pop("has_output", [])
+        p.pop("principal_investigator_name", None)
         for id in p.pop("has_input", []):
             biosample_projects[id] = project["id"]
 

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -348,7 +348,10 @@ class BaseQuerySchema(BaseModel):
             join_envo = True
         elif attribute in inspect(model).columns.keys():
             column = getattr(model, attribute)
-        elif attribute in _association_proxy_keys:
+        elif (
+            attribute in _association_proxy_keys
+            and self.table.model == _association_proxy_keys[attribute][0]
+        ):
             model, column = _association_proxy_keys[attribute]
             join_ap = True
         elif hasattr(model, "annotations"):


### PR DESCRIPTION
Also removes principal investigator from the project because it exists
on the study.