### PR TITLE
Force nginx to update dns on spin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - .docker-env
     environment:
       BACKEND_URL: "http://backend:8000"
+      DNS_ADDRESS: "127.0.0.11"
     build:
       context: web/
       dockerfile: Dockerfile

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,6 +8,8 @@ RUN yarn run build
 FROM nginx:stable-alpine as production-stage
 RUN rm -v /etc/nginx/nginx.conf
 ADD nginx.conf.template /etc/nginx/
+ADD start.sh /app/start.sh
+RUN chmod +x /app/start.sh
 COPY --from=build-stage /app/dist /www/data
 EXPOSE 80
-CMD /bin/sh -c "DOLLAR='$' envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
+CMD /app/start.sh

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -21,8 +21,11 @@ http {
             add_header Cache-Control no-cache;
         }
 
+        # https://stackoverflow.com/a/52319161
         location ~ ^/(api|docs|openapi.json) {
-            proxy_pass ${BACKEND_URL};
+            resolver $DNS_ADDRESS;
+            set ${DOLLAR}backend ${BACKEND_URL};
+            proxy_pass ${DOLLAR}backend;
         }
     }
 }

--- a/web/start.sh
+++ b/web/start.sh
@@ -1,0 +1,6 @@
+set -e
+export DOLLAR='$'
+export DNS_ADDRESS=$(grep -m 1 ^nameserver /etc/resolv.conf | sed -E -n 's/\D*(\d+\.\d+\.\d+\.\d+)\D*/\1/p')
+
+envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+nginx -g 'daemon off;'


### PR DESCRIPTION
Taken from https://serverfault.com/a/593003 with some additional logic to avoid hard coding the DNS server which could change on spi.  That line might break in some cases (especially if using `--network host`), but this is the only solution I could come up with that doesn't involve commercially licensed nginx modules.  For the moment, it appears to be working both through docker-compose and the production deployment.