### PR TITLE
Add authentication related endpoints using ORCID as a provider

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -1,13 +1,18 @@
 import typing
 
 from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware
 
-from . import __version__, api, errors
+from nmdc_server import __version__, api, auth, errors
+from nmdc_server.config import settings
 
 
 def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     app = FastAPI(title="NMDC Dataset API", version=__version__,)
+
     errors.attach_error_handlers(app)
     app.include_router(api.router, prefix="/api")
+    app.include_router(auth.router, prefix="")
+    app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
 
     return app

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -1,0 +1,94 @@
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from authlib.integrations import starlette_client
+from fastapi import APIRouter, Depends, HTTPException, Security, status
+from fastapi.security.oauth2 import OAuth2AuthorizationCodeBearer
+from pydantic import BaseModel
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+
+from nmdc_server.config import settings, starlette_config
+
+
+# The type is added to get around an error related to:
+#   https://github.com/python/mypy/issues/8477
+login_required_responses: Dict[Any, Any] = {
+    "401": {"description": "Login required"},
+    "403": {"description": "Insufficient permissions"},
+}
+oauth2_client = starlette_client.OAuth(starlette_config)
+oauth2_client.register(
+    name="orcid",
+    client_id=settings.client_id,
+    client_secret=settings.client_secret,
+    server_metadata_url=settings.open_id_config_url,
+    client_kwargs={"scope": settings.oauth_scope,},
+)
+
+oauth2_scheme = OAuth2AuthorizationCodeBearer(
+    authorizationUrl=settings.oauth_authorization_endpoint,
+    tokenUrl=settings.oauth_token_endpoint,
+    scopes={"authorization": settings.oauth_scope},
+    auto_error=False,
+)
+
+
+class Token(BaseModel):
+    access_token: UUID
+    token_type: str
+    refresh_token: UUID
+    expires_in: int
+    scope: str
+    name: str
+    orcid: str
+    expires_at: int
+
+
+async def get_token(
+    request: Request, access_token: Dict[str, Any] = Security(oauth2_scheme)
+) -> Optional[Token]:
+    token = request.session.get("token")
+    if token:
+        return Token(**token)
+    return None
+
+
+async def get_current_user(token: Optional[Token] = Depends(get_token)) -> Optional[str]:
+    if token:
+        return token.name
+    return None
+
+
+async def login_required(token: Optional[Token] = Depends(get_token)) -> Token:
+    if token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Login required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return token
+
+
+router = APIRouter()
+
+
+# authentication
+@router.post("/login", include_in_schema=False)
+async def login_via_orcid(request: Request):
+    redirect_uri = request.url_for("token")
+    return await oauth2_client.orcid.authorize_redirect(request, redirect_uri)
+
+
+@router.get("/token", name="token", include_in_schema=False)
+async def authorize(request: Request):
+    token = await oauth2_client.orcid.authorize_access_token(request)
+    request.session["token"] = token
+    return RedirectResponse(url="/")
+
+
+@router.post(
+    "/logout", tags=["user"], name="Log out of the current session",
+)
+async def logout(request: Request):
+    request.session.pop("token", None)

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -1,11 +1,19 @@
 import os
 
 from pydantic import BaseSettings
+from starlette.config import Config
 
 
 class Settings(BaseSettings):
     database_uri: str = "postgresql:///nmdc"
     testing_database_uri: str = "postgresql:///nmdc_testing"
+    secret_key: str = "secret"
+    client_id: str = "oauth client id"
+    client_secret: str = "oauth secret key"
+    open_id_config_url: str = "https://orcid.org/.well-known/openid-configuration"
+    oauth_scope: str = "/authenticate"
+    oauth_authorization_endpoint: str = "https://orcid.org/oauth/authorize"
+    oauth_token_endpoint: str = "https://orcid.org/oauth/token"
 
     class Config:
         env_prefix = "nmdc_"
@@ -13,3 +21,4 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+starlette_config = Config(environ=settings.dict())  # for authlib, incompatible with pydantic config

--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -1,14 +1,14 @@
 from collections import OrderedDict
 from datetime import datetime
 from typing import Dict
-from uuid import uuid4
+from uuid import UUID, uuid4
 
-from factory import Faker, post_generation, SubFactory
+from factory import Factory, Faker, post_generation, SubFactory
 from factory.alchemy import SQLAlchemyModelFactory
 from faker.providers import BaseProvider, date_time, geo, internet, lorem, misc, person, python
 from sqlalchemy.orm.scoping import scoped_session
 
-from nmdc_server import models
+from nmdc_server import auth, models
 from nmdc_server.database import SessionLocal
 from nmdc_server.schemas import AnnotationValue
 
@@ -33,6 +33,20 @@ Faker.add_provider(lorem)
 Faker.add_provider(misc)
 Faker.add_provider(person)
 Faker.add_provider(python)
+
+
+class TokenFactory(Factory):
+    class Meta:
+        model = auth.Token
+
+    access_token: UUID = Faker("uuid")
+    refresh_token: UUID = Faker("uuid")
+    token_type: str = "bearer"
+    expires_in: int = Faker("pyint", min_value=10000, max_value=99999)
+    scope: str = "/authorize"
+    name: str = Faker("name")
+    orcid: str = Faker("pystr")
+    expires_at: int = Faker("pyint", min_value=10000, max_value=99999)
 
 
 class AnnotatedFactory(SQLAlchemyModelFactory):

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,15 @@ setup(
     python_requires=">=3.6.0",
     install_requires=[
         "alembic",
+        "authlib",
         "fastapi",
         "factory-boy",
+        "httpx",
+        "itsdangerous",
         "psycopg2-binary",
         "python-dotenv",
         "sqlalchemy",
+        "starlette",
         "typing-extensions",
     ],
 )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,27 @@
+from starlette.testclient import TestClient
+
+from nmdc_server.auth import Token
+from nmdc_server.config import settings
+
+
+def test_login(client: TestClient):
+    resp = client.request(method="post", url="/login", allow_redirects=False)
+
+    assert resp.status_code == 302
+    assert resp.next.url.startswith(settings.oauth_authorization_endpoint)  # type: ignore
+
+
+def test_current_user(client: TestClient, token: Token):
+    resp = client.get("/api/me")
+    assert resp.json() == token.name
+
+
+def test_logout(client: TestClient, token: Token):
+    client.post("/logout")
+    resp = client.get("/api/me")
+    assert resp.json() == None
+
+
+def test_login_required(client: TestClient):
+    resp = client.post("/api/study", json={"doi": "abc"})
+    assert resp.status_code == 401


### PR DESCRIPTION
This is mostly a placeholder as we aren't yet storing user information into the database.  It relies on a signed session cookie to ensure authentication is valid.  No attempt is made at refreshing expired oauth tokens.

The only endpoints affected by this change are the unused resource creation endpoints.