### PR TITLE
Add server side binning for numeric and date attributes

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -119,6 +119,16 @@ async def facet_biosample(query: query.FacetQuery, db: Session = Depends(get_db)
     return crud.facet_biosample(db, query.attribute, query.conditions)
 
 
+@router.post(
+    "/biosample/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["biosample"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_biosample(query: query.BinnedFacetQuery, db: Session = Depends(get_db)):
+    return crud.binned_facet_biosample(db, **query.dict())
+
+
 @router.get(
     "/biosample/{biosample_id}",
     response_model=schemas.Biosample,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -191,6 +191,16 @@ async def facet_study(query: query.FacetQuery, db: Session = Depends(get_db)):
     return crud.facet_study(db, query.attribute, query.conditions)
 
 
+@router.post(
+    "/study/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["study"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_study(query: query.BinnedFacetQuery, db: Session = Depends(get_db)):
+    return crud.binned_facet_study(db, **query.dict())
+
+
 @router.get(
     "/study/{study_id}",
     response_model=schemas.Study,
@@ -251,6 +261,16 @@ async def search_project(
 )
 async def facet_project(query: query.FacetQuery, db: Session = Depends(get_db)):
     return crud.facet_project(db, query.attribute, query.conditions)
+
+
+@router.post(
+    "/project/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["project"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_project(query: query.BinnedFacetQuery, db: Session = Depends(get_db)):
+    return crud.binned_facet_project(db, **query.dict())
 
 
 @router.get(
@@ -346,6 +366,16 @@ async def facet_data_object(query: query.FacetQuery, db: Session = Depends(get_d
     return crud.facet_data_object(db, query.attribute, query.conditions)
 
 
+@router.post(
+    "/data_object/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["data_object"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_data_object(query: query.BinnedFacetQuery, db: Session = Depends(get_db)):
+    return crud.binned_facet_data_object(db, **query.dict())
+
+
 # reads_qc
 @router.post(
     "/reads_qc/search",
@@ -370,6 +400,16 @@ async def search_reads_qc(
 )
 async def facet_reads_qc(query: query.FacetQuery, db: Session = Depends(get_db)):
     return crud.facet_reads_qc(db, query.attribute, query.conditions)
+
+
+@router.post(
+    "/reads_qc/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["reads_qc"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_reads_qc(query: query.BinnedFacetQuery, db: Session = Depends(get_db)):
+    return crud.binned_facet_reads_qc(db, **query.dict())
 
 
 @router.get(
@@ -417,6 +457,18 @@ async def search_metagenome_assembly(
 )
 async def facet_metagenome_assembly(query: query.FacetQuery, db: Session = Depends(get_db)):
     return crud.facet_metagenome_assembly(db, query.attribute, query.conditions)
+
+
+@router.post(
+    "/metagenome_assembly/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["metagenome_assembly"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_metagenome_assembly(
+    query: query.BinnedFacetQuery, db: Session = Depends(get_db)
+):
+    return crud.binned_facet_metagenome_assembly(db, **query.dict())
 
 
 @router.get(
@@ -468,6 +520,18 @@ async def facet_metagenome_annotation(query: query.FacetQuery, db: Session = Dep
     return crud.facet_metagenome_annotation(db, query.attribute, query.conditions)
 
 
+@router.post(
+    "/metagenome_annotation/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["metagenome_annotation"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_metagenome_annotation(
+    query: query.BinnedFacetQuery, db: Session = Depends(get_db)
+):
+    return crud.binned_facet_metagenome_annotation(db, **query.dict())
+
+
 @router.get(
     "/metagenome_annotation/{metagenome_annotation_id}",
     response_model=schemas.MetagenomeAnnotation,
@@ -515,6 +579,18 @@ async def search_metaproteomic_analysis(
 )
 async def facet_metaproteomic_analysis(query: query.FacetQuery, db: Session = Depends(get_db)):
     return crud.facet_metaproteomic_analysis(db, query.attribute, query.conditions)
+
+
+@router.post(
+    "/metaproteomic_analysis/binned_facet",
+    response_model=query.BinnedFacetResponse,
+    tags=["metaproteomic_analysis"],
+    name="Get all values of a non-string attribute with binning",
+)
+async def binned_facet_metaproteomic_analysis(
+    query: query.BinnedFacetQuery, db: Session = Depends(get_db)
+):
+    return crud.binned_facet_metaproteomic_analysis(db, **query.dict())
 
 
 @router.get(

--- a/nmdc_server/binning.py
+++ b/nmdc_server/binning.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+from enum import Enum
+from math import floor
+from typing import List, TypeVar
+
+from dateutil.relativedelta import relativedelta, SU
+
+BinnableValue = TypeVar("BinnableValue", float, int, datetime)
+
+
+class DateBinResolution(Enum):
+    day = "day"
+    week = "week"
+    month = "month"
+    year = "year"
+
+
+def range_bins(min_: BinnableValue, max_: BinnableValue, num_bins: int) -> List[BinnableValue]:
+    """Get equal length bins for a given numeric range."""
+    if max_ <= min_:
+        raise ValueError("expected min_ < max_")
+    if num_bins <= 0:
+        raise ValueError("expected positive number of bins")
+    step = (max_ - min_) / num_bins
+    if isinstance(min_, int):
+        step = floor(step)
+        if step <= 0:
+            raise ValueError("num_bins too large for numeric range")
+    return [min_ + step * i for i in range(num_bins)] + [max_]
+
+
+def datetime_bins(min_: datetime, max_: datetime, resolution: DateBinResolution) -> List[datetime]:
+    """Get date range bins of various size."""
+    min_date = min_.date()
+    max_date = max_.date() + relativedelta(days=1)
+
+    # expand min/max date to be a round value at the binning resultion requested
+    if resolution == DateBinResolution.day:
+        delta = relativedelta(days=1)
+    elif resolution == DateBinResolution.week:
+        min_date += relativedelta(weekday=SU(-1))
+        max_date += relativedelta(weekday=SU)
+        delta = relativedelta(weeks=1, weekday=SU)
+    elif resolution == DateBinResolution.month:
+        min_date += relativedelta(day=1)
+        max_date += relativedelta(months=1, day=1)
+        delta = relativedelta(months=1, day=1)
+    elif resolution == DateBinResolution.year:
+        min_date += relativedelta(month=1, day=1)
+        max_date += relativedelta(years=1, month=1, day=1)
+        delta = relativedelta(years=1, day=1, month=1)
+    else:
+        raise ValueError("Invalid date bin category")
+
+    if max_date <= min_date:
+        raise ValueError("expected non-empty date range")
+
+    d = min_date
+    dates = []
+    min_time = datetime.min.time()
+    while d <= max_date:
+        dates.append(datetime.combine(d, min_time))
+        d += delta
+    return dates

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -100,6 +100,18 @@ def facet_study(
     return query.FacetResponse(facets=facets)
 
 
+def binned_facet_study(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.StudyQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
+
+
 # project
 def get_project(db: Session, project_id: str) -> Optional[models.Project]:
     return db.query(models.Project).filter(models.Project.id == project_id).first()
@@ -127,6 +139,18 @@ def facet_project(
 ) -> query.FacetResponse:
     facets = query.ProjectQuerySchema(conditions=conditions).facet(db, attribute)
     return query.FacetResponse(facets=facets)
+
+
+def binned_facet_project(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.ProjectQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
 
 
 def list_project_data_objects(db: Session, id: str) -> Query:
@@ -207,6 +231,18 @@ def facet_data_object(
     return query.FacetResponse(facets=facets)
 
 
+def binned_facet_data_object(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.DataObjectQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
+
+
 # readsqc
 def get_reads_qc(db: Session, reads_qc_id: str) -> Optional[models.ReadsQC]:
     return db.query(models.ReadsQC).filter(models.ReadsQC.id == reads_qc_id).first()
@@ -221,6 +257,18 @@ def facet_reads_qc(
 ) -> query.FacetResponse:
     facets = query.ReadsQCQuerySchema(conditions=conditions).facet(db, attribute)
     return query.FacetResponse(facets=facets)
+
+
+def binned_facet_reads_qc(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.ReadsQCQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
 
 
 def list_reads_qc_data_objects(db: Session, id: str) -> Query:
@@ -253,6 +301,18 @@ def facet_metagenome_assembly(
     return query.FacetResponse(facets=facets)
 
 
+def binned_facet_metagenome_assembly(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.MetagenomeAssemblyQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
+
+
 def list_metagenome_assembly_data_objects(db: Session, id: str) -> Query:
     return (
         db.query(models.DataObject)
@@ -283,6 +343,18 @@ def facet_metagenome_annotation(
     return query.FacetResponse(facets=facets)
 
 
+def binned_facet_metagenome_annotation(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.MetagenomeAnnotationQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
+
+
 def list_metagenome_annotation_data_objects(db: Session, id: str) -> Query:
     return (
         db.query(models.DataObject)
@@ -311,6 +383,18 @@ def facet_metaproteomic_analysis(
 ) -> query.FacetResponse:
     facets = query.MetaproteomicAnalysisQuerySchema(conditions=conditions).facet(db, attribute)
     return query.FacetResponse(facets=facets)
+
+
+def binned_facet_metaproteomic_analysis(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.MetaproteomicAnalysisQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
 
 
 def list_metaproteomic_analysis_data_objects(db: Session, id: str) -> Query:

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Query, Session
 
 from nmdc_server import aggregations, models, query, schemas
 
+NumericValue = query.NumericValue
 T = TypeVar("T", bound=models.Base)
 
 
@@ -159,10 +160,22 @@ def search_biosample(db: Session, conditions: List[query.ConditionSchema]) -> Qu
 
 
 def facet_biosample(
-    db: Session, attribute: str, conditions: List[query.ConditionSchema]
+    db: Session, attribute: str, conditions: List[query.ConditionSchema], **kwargs
 ) -> query.FacetResponse:
     facets = query.BiosampleQuerySchema(conditions=conditions).facet(db, attribute)
     return query.FacetResponse(facets=facets)
+
+
+def binned_facet_biosample(
+    db: Session,
+    attribute: str,
+    conditions: List[query.ConditionSchema],
+    **kwargs,
+) -> query.BinnedFacetResponse:
+    bins, facets = query.BiosampleQuerySchema(conditions=conditions).binned_facet(
+        db, attribute, **kwargs
+    )
+    return query.BinnedFacetResponse(bins=bins, facets=facets)
 
 
 # data object

--- a/nmdc_server/errors.py
+++ b/nmdc_server/errors.py
@@ -4,13 +4,12 @@ from fastapi import FastAPI
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from .query import InvalidAttributeException
+from .query import InvalidAttributeException, InvalidFacetException
 from .utils import log_extras, logger
 
 
 def attach_error_handlers(app: FastAPI) -> None:
-    @app.exception_handler(InvalidAttributeException)
-    async def invalid_attribute_handler(req: Request, exc: Exception) -> JSONResponse:
+    async def handle_custom_validation_error(req: Request, exc: Exception) -> JSONResponse:
         exception_id = str(uuid.uuid4())
         logger.exception("Unhandled exception, ID=%s.", exception_id, extra=log_extras(req))
 
@@ -22,6 +21,9 @@ def attach_error_handlers(app: FastAPI) -> None:
                 }
             },
         )
+
+    app.exception_handler(InvalidAttributeException)(handle_custom_validation_error)
+    app.exception_handler(InvalidFacetException)(handle_custom_validation_error)
 
     @app.exception_handler(Exception)
     async def internal_exception_handler(req: Request, exc: Exception) -> JSONResponse:

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         "httpx",
         "itsdangerous",
         "psycopg2-binary",
+        "python-dateutil",
         "python-dotenv",
         "sqlalchemy",
         "starlette==0.13.6",

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -1,0 +1,126 @@
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+import pytest
+from sqlalchemy.orm.session import Session
+
+from nmdc_server import fakes, query
+from nmdc_server.binning import DateBinResolution
+
+
+@pytest.fixture
+def biosamples(db: Session):
+    depths = [1, 2, 3, 11, 12, 22]
+    dates = [
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 2),
+        datetime(2020, 1, 8),
+        datetime(2020, 1, 3),
+        datetime(2020, 2, 9),
+        datetime(2020, 2, 10),
+    ]
+    for depth, date in zip(depths, dates):
+        fakes.BiosampleFactory(depth=depth, collection_date=date)
+    db.commit()
+
+
+def test_range_bins(db: Session, biosamples):
+    q = query.BiosampleQuerySchema()
+    bins, result = q.binned_facet(db, "depth", minimum=0, maximum=30, num_bins=3)
+    assert bins == [0, 10, 20, 30]
+    assert result == {0: 3, 1: 2, 2: 1}
+
+
+def test_range_bins_default_min_max(db: Session, biosamples):
+    q = query.BiosampleQuerySchema()
+    bins, result = q.binned_facet(db, "depth", num_bins=3)
+    assert bins == [1, 8, 15, 22]
+    assert result == {0: 3, 1: 2, 2: 1}
+
+
+def test_date_range_bins_week(db: Session, biosamples):
+    q = query.BiosampleQuerySchema()
+    bins, result = q.binned_facet(db, "collection_date", resolution=DateBinResolution.week)
+    print(bins)
+    assert len(bins) == 8
+    assert bins[0] <= datetime(2020, 1, 1)  # type: ignore
+    assert result == {0: 3, 1: 1, 6: 2}
+
+
+def test_date_range_bins_month(db: Session, biosamples):
+    q = query.BiosampleQuerySchema()
+    bins, result = q.binned_facet(db, "collection_date", resolution=DateBinResolution.month)
+    assert len(bins) == 3
+    assert bins[0] <= datetime(2020, 1, 1)  # type: ignore
+    assert result == {0: 4, 1: 2}
+
+
+def test_date_range_bins_year(db: Session, biosamples):
+    q = query.BiosampleQuerySchema()
+    bins, result = q.binned_facet(db, "collection_date", resolution=DateBinResolution.year)
+    assert len(bins) == 2
+    assert result == {0: 6}
+
+
+def test_filtered_bins(db: Session, biosamples):
+    q = query.BiosampleQuerySchema(
+        conditions=[
+            {
+                "table": "biosample",
+                "field": "depth",
+                "op": "<",
+                "value": 20,
+            }
+        ]
+    )
+    bins, result = q.binned_facet(db, "depth", num_bins=2)
+    assert bins == [1, 6.5, 12]
+    assert result == {0: 3, 1: 2}
+
+
+def test_filtered_bins_api(client: TestClient, biosamples):
+    resp = client.post(
+        "/api/biosample/binned_facet",
+        json={
+            "attribute": "depth",
+            "num_bins": 2,
+            "conditions": [
+                {
+                    "table": "biosample",
+                    "field": "depth",
+                    "op": "<",
+                    "value": 20,
+                }
+            ],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "bins": [1, 6.5, 12],
+        "facets": {"0": 3, "1": 2},
+    }
+
+
+def test_binned_api(client: TestClient, biosamples):
+    resp = client.post("/api/biosample/binned_facet", json={"attribute": "depth", "num_bins": 3})
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "bins": [1, 8, 15, 22],
+        "facets": {"0": 3, "1": 2, "2": 1},
+    }
+
+
+def test_binned_date_api(client: TestClient, biosamples):
+    resp = client.post(
+        "/api/biosample/binned_facet", json={"attribute": "collection_date", "resolution": "month"}
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["bins"]) == 3
+    assert resp.json()["facets"] == {"0": 4, "1": 2}
+
+
+def test_invalid_date_api(client: TestClient, biosamples):
+    resp = client.post(
+        "/api/biosample/binned_facet", json={"attribute": "depth", "resolution": "month"}
+    )
+    assert resp.status_code == 400

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -28,23 +28,22 @@ def test_range_bins(db: Session, biosamples):
     q = query.BiosampleQuerySchema()
     bins, result = q.binned_facet(db, "depth", minimum=0, maximum=30, num_bins=3)
     assert bins == [0, 10, 20, 30]
-    assert result == {0: 3, 1: 2, 2: 1}
+    assert result == [3, 2, 1]
 
 
 def test_range_bins_default_min_max(db: Session, biosamples):
     q = query.BiosampleQuerySchema()
     bins, result = q.binned_facet(db, "depth", num_bins=3)
     assert bins == [1, 8, 15, 22]
-    assert result == {0: 3, 1: 2, 2: 1}
+    assert result == [3, 2, 1]
 
 
 def test_date_range_bins_week(db: Session, biosamples):
     q = query.BiosampleQuerySchema()
     bins, result = q.binned_facet(db, "collection_date", resolution=DateBinResolution.week)
-    print(bins)
     assert len(bins) == 8
     assert bins[0] <= datetime(2020, 1, 1)  # type: ignore
-    assert result == {0: 3, 1: 1, 6: 2}
+    assert result == [3, 1, 0, 0, 0, 0, 2]
 
 
 def test_date_range_bins_month(db: Session, biosamples):
@@ -52,14 +51,14 @@ def test_date_range_bins_month(db: Session, biosamples):
     bins, result = q.binned_facet(db, "collection_date", resolution=DateBinResolution.month)
     assert len(bins) == 3
     assert bins[0] <= datetime(2020, 1, 1)  # type: ignore
-    assert result == {0: 4, 1: 2}
+    assert result == [4, 2]
 
 
 def test_date_range_bins_year(db: Session, biosamples):
     q = query.BiosampleQuerySchema()
     bins, result = q.binned_facet(db, "collection_date", resolution=DateBinResolution.year)
     assert len(bins) == 2
-    assert result == {0: 6}
+    assert result == [6]
 
 
 def test_filtered_bins(db: Session, biosamples):
@@ -75,7 +74,7 @@ def test_filtered_bins(db: Session, biosamples):
     )
     bins, result = q.binned_facet(db, "depth", num_bins=2)
     assert bins == [1, 6.5, 12]
-    assert result == {0: 3, 1: 2}
+    assert result == [3, 2]
 
 
 def test_filtered_bins_api(client: TestClient, biosamples):
@@ -97,7 +96,7 @@ def test_filtered_bins_api(client: TestClient, biosamples):
     assert resp.status_code == 200
     assert resp.json() == {
         "bins": [1, 6.5, 12],
-        "facets": {"0": 3, "1": 2},
+        "facets": [3, 2],
     }
 
 
@@ -106,7 +105,7 @@ def test_binned_api(client: TestClient, biosamples):
     assert resp.status_code == 200
     assert resp.json() == {
         "bins": [1, 8, 15, 22],
-        "facets": {"0": 3, "1": 2, "2": 1},
+        "facets": [3, 2, 1],
     }
 
 
@@ -116,7 +115,7 @@ def test_binned_date_api(client: TestClient, biosamples):
     )
     assert resp.status_code == 200
     assert len(resp.json()["bins"]) == 3
-    assert resp.json()["facets"] == {"0": 4, "1": 2}
+    assert resp.json()["facets"] == [4, 2]
 
 
 def test_invalid_date_api(client: TestClient, biosamples):
@@ -137,5 +136,5 @@ def test_metagenome_api(client: TestClient, db: Session):
     assert resp.status_code == 200
     assert resp.json() == {
         "bins": [0, 10, 20],
-        "facets": {"0": 2, "1": 2},
+        "facets": [2, 2],
     }

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -124,3 +124,18 @@ def test_invalid_date_api(client: TestClient, biosamples):
         "/api/biosample/binned_facet", json={"attribute": "depth", "resolution": "month"}
     )
     assert resp.status_code == 400
+
+
+def test_metagenome_api(client: TestClient, db: Session):
+    for c in [0, 1, 10, 20]:
+        fakes.MetagenomeAssemblyFactory(contigs=c)
+    db.commit()
+    resp = client.post(
+        "/api/metagenome_assembly/binned_facet",
+        json={"attribute": "contigs", "num_bins": 2},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "bins": [0, 10, 20],
+        "facets": {"0": 2, "1": 2},
+    }


### PR DESCRIPTION
For each of the models, this adds a new endpoint for faceting that looks like this:
```
POST /biosample/binned_facet attribute=depth num_bins=5
{
    "bins": [
        0, 
        400,
        800,
        1200,
        1600,
        2000
    ],
    "facets": [204, 0, 187, 0, 1]
}
```
This means, 204 results are contained in the range [0, 400), 187 in [800, 1200), and 1 in [1600, 2000].

You can provide a custom range:
```
POST /biosample/binned_facet attribute=depth num_bins=5 minimum=20 maximum=100
{
    "bins": [
        20.0,
        36.0,
        52.0,
        68.0,
        84.0,
        100.0
    ],
    "facets": [31, 0, 0, 0, 0]
}

```

This works for date types as well:
```
/biosample/binned_facet attribute=collection_date num_bins=5
{
    "bins": [
        "2011-06-15T00:00:00",
        "2012-10-12T09:36:00",
        "2014-02-09T19:12:00",
        "2015-06-10T04:48:00",
        "2016-10-07T14:24:00",
        "2018-02-05T00:00:00"
    ],
    "facets": [21, 138, 84, 157, 563]
}
```

Finally, the endpoint supports another mode of operation for date types where you can bin by "day", "week", "month", or "year".
```
/biosample/binned_facet attribute=collection_date resolution=year
{
    "bins": [
        "2011-01-01T00:00:00",
        "2012-01-01T00:00:00",
        "2013-01-01T00:00:00",
        "2014-01-01T00:00:00",
        "2015-01-01T00:00:00",
        "2016-01-01T00:00:00",
        "2017-01-01T00:00:00",
        "2018-01-01T00:00:00",
        "2019-01-01T00:00:00"
    ],
    "facets": [3, 18, 138, 47, 138, 56, 552, 11]
}
```

As with the normal faceting endpoints, you can also provide filtering conditions.