### PR TITLE
Implement sample_count summary in study search results

### DIFF
--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -17,7 +17,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import query_expression, relationship
 from sqlalchemy.orm.relationships import RelationshipProperty
 
 from nmdc_server.database import Base
@@ -135,6 +135,10 @@ class Study(Base, AnnotatedModel):
     gold_description = Column(String, nullable=False, default="")
     scientific_objective = Column(String, nullable=False, default="")
     doi = Column(String, nullable=False)
+
+    # TODO: Specify a default expression so that sample counts are present in
+    #       non-search responses.
+    sample_count = query_expression()
 
     principal_investigator_id = Column(
         UUID(as_uuid=True), ForeignKey("principal_investigator.id"), nullable=False

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -162,6 +162,7 @@ class Study(StudyBase):
     open_in_gold: Optional[str]
     principal_investigator_name: str
     principal_investigator_image_url: str
+    sample_count: Optional[int]
 
     class Config:
         orm_mode = True

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "psycopg2-binary",
         "python-dateutil",
         "python-dotenv",
-        "sqlalchemy",
+        "sqlalchemy>=1.3.18",
         "starlette==0.13.6",
         "typing-extensions",
     ],


### PR DESCRIPTION
This is fairly simple to accomplish via [query time expressions](https://docs.sqlalchemy.org/en/14/orm/mapped_sql_expr.html#query-time-sql-expressions-as-mapped-attributes), but it is something of a brute force solution because it repeats subqueries twice.  This may be a performance issue when I get to implementing workflow execution summaries.  The solution will be to implement these subqueries as lateral joins, but that will take a more significant refactor.

One caveat of the current implementation is that `sample_count` will be `null` when fetching from `/study/{id}`.  I don't think this is a problem for the current use case.  I would likely use a stored, denormalized value in this case if the need arises.