### PR TITLE
Add omics_counts summary to study schema

### DIFF
--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -139,6 +139,7 @@ class Study(Base, AnnotatedModel):
     # TODO: Specify a default expression so that sample counts are present in
     #       non-search responses.
     sample_count = query_expression()
+    omics_counts = query_expression()
 
     principal_investigator_id = Column(
         UUID(as_uuid=True), ForeignKey("principal_investigator.id"), nullable=False

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -158,11 +158,17 @@ class StudyCreate(StudyBase):
     principal_investigator_id: UUID
 
 
+class OmicsCounts(BaseModel):
+    type: str
+    count: int
+
+
 class Study(StudyBase):
     open_in_gold: Optional[str]
     principal_investigator_name: str
     principal_investigator_image_url: str
     sample_count: Optional[int]
+    omics_counts: Optional[List[OmicsCounts]]
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
This implements the omics processing summary needed for #191.  As I suspected, doing the aggregation this way is noticeably slower due to the repeated subqueries.  A lateral join will likely remove most of the performance penalty.  I'll work on it after we get a proof of concept working.