### PR TITLE
Add omics_data information to biosample search results

### DIFF
--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -188,7 +188,6 @@ class ProjectCreate(ProjectBase):
 class Project(ProjectBase):
     study_id: str
     open_in_gold: Optional[str]
-    # has_outputs: List[str] = []
 
     class Config:
         orm_mode = True
@@ -226,6 +225,8 @@ class Biosample(BiosampleBase):
     ecosystem_type: str
     ecosystem_subtype: str
     specific_ecosystem: str
+
+    omics_data: List["OmicsTypes"]
 
     class Config:
         orm_mode = True
@@ -273,6 +274,8 @@ class PipelineStepBase(BaseModel):
     ended_at_time: datetime
     execution_resource: str
     project_id: str
+
+    outputs: List[DataObject]
 
 
 class PipelineStep(PipelineStepBase):
@@ -342,3 +345,7 @@ class MetaproteomicAnalysisBase(PipelineStepBase):
 
 class MetaproteomicAnalysis(PipelineStep):
     pass
+
+
+OmicsTypes = Union[ReadsQC, MetagenomeAnnotation, MetagenomeAssembly, MetaproteomicAnalysis]
+Biosample.update_forward_refs()


### PR DESCRIPTION
This implements the `omics_data` attribute of #191.  The only difference is that there is an extra object (the workflow execution object) between the sample and data_object.  For example:
```json
[
  {
    "id": "nmdc:23ed2430a9b1e9d120c4c97a2a7b8a5b",
    "name": "ReadQC activiity 1778_72754",
    "type": "nmdc:ReadQCAnalysisActivity",
    "git_url": "https://github.com/microbiomedata/ReadsQC/releases/tag/1.0.0",
    "started_at_time": "2020-03-20T00:00:00",
    "ended_at_time": "2020-03-20T00:00:00",
    "execution_resource": "NERSC - Cori",
    "project_id": "gold:Gp0108335",
    "outputs": [
      {
        "id": "nmdc:bf13805c9b0af6fec35734378f5f5fb0",
        "name": "filterStats.txt",
        "description": "Filtered read data stats for gold:Gp0108335",
        "file_size_bytes": 288,
        "md5_checksum": null
      },
      {
        "id": "nmdc:88b3d02641c1974a7e6d3f677172939e",
        "name": "1778_72754.filtered.fastq.gz",
        "description": "Filtered read data for gold:Gp0108335",
        "file_size_bytes": 7435842133,
        "md5_checksum": null
      }
    ]
  },
  ...
]
```

I will add in the additional information on the data object once I do the migration with the latest source data.

One caveat to this is that the omics_data list will not be filtered by the query conditions.  For example if the condition `metagenome_assembly.contigs > 800` is in the query, this list will still contain all metagenome assemblies even if they don't fulfill this condition.  It is still true however, that the list of biosamples returned will have at least one metagenome assembly that fulfills the condition.  I don't think that this is a major issue, but I can come back to it if needed.