### PR TITLE
Add example UpSet plot

### DIFF
--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -1,0 +1,161 @@
+<script>
+import { defineComponent, watchEffect, ref } from '@vue/composition-api';
+import { select } from 'd3-selection';
+import { scaleBand, scaleLinear } from 'd3-scale';
+
+export default defineComponent({
+  props: {
+    data: {
+      type: Array,
+      required: true,
+    },
+    order: {
+      type: String,
+      required: true,
+    },
+    width: {
+      type: Number,
+      required: true,
+    },
+    height: {
+      type: Number,
+      required: true,
+    },
+  },
+
+  setup(props, { root }) {
+    const svgRoot = ref(undefined);
+
+    const margin = {
+      top: 20,
+      right: 30,
+      bottom: 30,
+      left: 30,
+    };
+
+    function makeUpSet(dataOrig, order, el) {
+      const width = props.width - margin.left - margin.right;
+      const height = props.height - margin.top - margin.bottom;
+
+      const data = [...dataOrig].sort((a, b) => b.counts[order] - a.counts[order]);
+
+      const uniqueSets = Array.from(
+        new Set([].concat(...data.map((d) => d.sets))),
+      ).sort();
+      const uniqueCounts = Array.from(
+        new Set([].concat(...data.map((d) => Object.keys(d.counts)))),
+      );
+      const setMembers = [].concat(
+        ...data.map((d, i) => d.sets.map((s) => ({ index: i, set: s }))),
+      );
+
+      const membershipWidth = 0.5 * width;
+
+      const membershipX = scaleBand()
+        .domain(uniqueSets)
+        .range([0, membershipWidth]);
+      const y = scaleBand()
+        .domain(data.map((d, i) => i))
+        .range([0, height])
+        .paddingInner(0.2);
+      const countsX = scaleBand()
+        .domain(uniqueCounts)
+        .range([membershipWidth, width])
+        .paddingInner(0.2);
+
+      select(el).selectAll('g').remove();
+
+      const svg = select(el)
+        .attr('width', width + margin.left + margin.right)
+        .attr('height', height + margin.top + margin.bottom)
+        .append('g')
+        .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+      svg.selectAll('line.set')
+        .data(uniqueSets)
+        .enter()
+        .append('line')
+        .attr('class', 'set')
+        .attr('x1', (s) => membershipX(s))
+        .attr('x2', (s) => membershipX(s))
+        .attr('y1', 0)
+        .attr('y2', height)
+        .attr('stroke', 'black');
+
+      svg.selectAll('text.set')
+        .data(uniqueSets)
+        .enter()
+        .append('text')
+        .attr('class', 'set')
+        .attr('x', (s) => membershipX(s))
+        .attr('y', -4)
+        .attr('text-anchor', 'middle')
+        .attr('font-size', margin.top - 8)
+        .text((d) => d)
+        .attr('fill', 'black');
+
+      svg.selectAll('line.membership')
+        .data(data)
+        .enter()
+        .append('line')
+        .attr('class', 'membership')
+        .attr('x1', (d) => Math.min(...d.sets.map((s) => membershipX(s))))
+        .attr('x2', (d) => Math.max(...d.sets.map((s) => membershipX(s))))
+        .attr('y1', (d, i) => y(i) + y.step() / 2)
+        .attr('y2', (d, i) => y(i) + y.step() / 2)
+        .attr('stroke-width', 3)
+        .attr('stroke', root.$vuetify.theme.currentTheme.blue);
+
+      svg.selectAll('circle')
+        .data(setMembers)
+        .enter().append('circle')
+        .attr('cx', (d) => membershipX(d.set))
+        .attr('cy', (d) => y(d.index) + y.step() / 2)
+        .attr('r', 5)
+        .attr('fill', root.$vuetify.theme.currentTheme.blue);
+
+      uniqueCounts.forEach((count) => {
+        const barX = scaleLinear()
+          .domain([0, Math.max(...data.map((d) => d.counts[count]))])
+          .range([0, countsX.bandwidth()]);
+        console.log(barX.domain());
+        console.log(barX.range());
+
+        svg.append('g')
+          .selectAll('rect')
+          .data(data)
+          .enter()
+          .append('rect')
+          .attr('x', countsX(count))
+          .attr('y', (d, i) => y(i))
+          .attr('width', (d) => barX(d.counts[count]))
+          .attr('height', y.bandwidth())
+          .attr('fill', root.$vuetify.theme.currentTheme.blue);
+      });
+
+      svg.selectAll('text.count')
+        .data(uniqueCounts)
+        .enter()
+        .append('text')
+        .attr('class', 'count')
+        .attr('x', (d) => countsX(d))
+        .attr('y', -4)
+        .attr('font-size', margin.top - 8)
+        .text((d) => d)
+        .attr('fill', 'black');
+    }
+
+    watchEffect(() => {
+      const { data, order } = props;
+      const el = svgRoot.value;
+      makeUpSet(data, order, el);
+    });
+
+    return { svgRoot };
+  },
+});
+</script>
+
+<template>
+  <svg ref="svgRoot" />
+</template>

--- a/web/src/views/Search/Search.vue
+++ b/web/src/views/Search/Search.vue
@@ -5,6 +5,7 @@ import { mapActions, mapState, mapGetters } from 'vuex';
 import { types } from '@/encoding';
 import removeCondition from '@/data/utils';
 
+import ChartContainer from '@/components/Presentation/ChartContainer.vue';
 import EcosystemSankey from '@/components/Presentation/EcosystemSankey.vue';
 import FacetBarChart from '@/components/Presentation/FacetBarChart.vue';
 import FacetHistogramChart from '@/components/Presentation/FacetHistogramChart.vue';
@@ -14,24 +15,47 @@ import BinnedSummaryWrapper from '@/components/BinnedSummaryWrapper.vue';
 import DateHistogram from '@/components/Presentation/DateHistogram.vue';
 import LocationMap from '@/components/Presentation/LocationMap.vue';
 import SearchResults from '@/components/Presentation/SearchResults.vue';
+import UpSet from '@/components/Presentation/UpSet.vue';
 
 import Sidebar from './Sidebar.vue';
 
 export default Vue.extend({
   components: {
     BinnedSummaryWrapper,
+    ChartContainer,
     FacetBarChart,
     FacetHistogramChart,
     FacetSummaryWrapper,
     // DateHistogram,
     DateHistogram,
     SearchResults,
+    UpSet,
     LocationMap,
     EcosystemSankey,
     Sidebar,
   },
 
-  data: () => ({ types }),
+  data: () => ({
+    types,
+    upSetData: [
+      {
+        sets: ['MG', 'MP'],
+        counts: { Samples: 33, Studies: 1 },
+      },
+      {
+        sets: ['MG', 'MP', 'MT', 'OM'],
+        counts: { Samples: 45, Studies: 1 },
+      },
+      {
+        sets: ['MG'],
+        counts: { Samples: 143, Studies: 3 },
+      },
+      {
+        sets: ['MB'],
+        counts: { Samples: 87, Studies: 3 },
+      },
+    ],
+  }),
 
   computed: {
     ...mapState(['results', 'page', 'pageSize']),
@@ -89,6 +113,15 @@ export default Vue.extend({
     <sidebar />
     <v-main v-if="typeResults">
       <v-container fluid>
+        <v-row>
+          <v-col :cols="12">
+            <ChartContainer>
+              <template #default="{ width, height }">
+                <UpSet v-bind="{ width, height, data: upSetData, order: 'Samples' }" />
+              </template>
+            </ChartContainer>
+          </v-col>
+        </v-row>
         <!-- BIOSAMPLE CHARTS -->
         <template v-if="type === 'biosample'">
           <v-row>


### PR DESCRIPTION
Adding a draft of the UpSet plot to the search results view. It currently uses dummy data.

![image](https://user-images.githubusercontent.com/81305/105873715-c601bd00-5fc9-11eb-8c39-57c0935f5049.png)
