### PR TITLE
Add a redirection service for data objects

### DIFF
--- a/nmdc_server/alembic.ini
+++ b/nmdc_server/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migrations
+script_location = nmdc_server/migrations
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -411,3 +411,13 @@ def get_pi_image(db: Session, principal_investigator_id: UUID) -> Optional[bytes
     if pi is not None:
         return pi.image
     return None
+
+
+def create_file_download(
+    db: Session, file_download: schemas.FileDownloadCreate
+) -> models.FileDownload:
+    db_file_download = models.FileDownload(**file_download.dict())
+    db.add(db_file_download)
+    db.commit()
+    db.refresh(db_file_download)
+    return db_file_download

--- a/nmdc_server/migrations/versions/68a0445e19bf_add_file_downloads.py
+++ b/nmdc_server/migrations/versions/68a0445e19bf_add_file_downloads.py
@@ -1,0 +1,41 @@
+"""add file downloads
+
+Revision ID: 68a0445e19bf
+Revises: e66a8305a730
+Create Date: 2021-01-27 15:03:48.125215
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "68a0445e19bf"
+down_revision: Optional[str] = "e66a8305a730"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.create_table(
+        "file_download",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=False),
+        sa.Column("data_object_id", sa.String(), nullable=False),
+        sa.Column("ip", sa.String(), nullable=False),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column("orcid", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["data_object_id"],
+            ["data_object.id"],
+            name=op.f("fk_file_download_data_object_id_data_object"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_file_download")),
+    )
+
+
+def downgrade():
+    op.drop_constraint(op.f("uq_envo_ancestor_id"), "envo_ancestor", type_="unique")
+    op.drop_table("file_download")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Iterator, List, Optional, Type, Union
 from uuid import uuid4
 
@@ -412,3 +413,16 @@ class MGAGeneFunction(Base):  # metagenome annotation
     count = Column(Integer, default=1)
 
     function = relationship(GeneFunction)
+
+
+class FileDownload(Base):
+    __tablename__ = "file_download"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+    data_object_id = Column(String, ForeignKey("data_object.id"), nullable=False)
+    ip = Column(String, nullable=False)
+    user_agent = Column(String, nullable=True)
+    orcid = Column(String, nullable=False)
+
+    data_object = relationship(DataObject)

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -349,3 +349,19 @@ class MetaproteomicAnalysis(PipelineStep):
 
 OmicsTypes = Union[ReadsQC, MetagenomeAnnotation, MetagenomeAssembly, MetaproteomicAnalysis]
 Biosample.update_forward_refs()
+
+
+class FileDownloadBase(BaseModel):
+    ip: str
+    user_agent: str
+    orcid: str
+    data_object_id: str
+
+
+class FileDownload(FileDownloadBase):
+    id: str
+    created: datetime
+
+
+class FileDownloadCreate(FileDownloadBase):
+    pass

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -26,6 +26,9 @@ http {
             resolver $DNS_ADDRESS;
             set ${DOLLAR}backend ${BACKEND_URL};
             proxy_pass ${DOLLAR}backend;
+            proxy_set_header Host ${DOLLAR}host;
+            proxy_set_header X-Real-IP ${DOLLAR}remote_addr;
+            proxy_set_header X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
         }
 
         location /data/ {


### PR DESCRIPTION
This endpoint requires login and stores the following information from the request:
* orcid
* data object id
* user agent string
* ip address
* current time stamp

None of this information is exposed publicly.  It should allow us to derive any summary statistics we want by aggregations on this table.