### PR TITLE
Add gene functions from metagenome annotations

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from alembic import command
@@ -68,7 +69,19 @@ def truncate():
 
 
 @cli.command()
-def ingest():
+@click.option("-v", "--verbose", count=True)
+def ingest(verbose):
     """Ingest the latest data from mongo."""
+    level = logging.WARN
+    if verbose == 1:
+        level = logging.INFO
+    elif verbose > 1:
+        level = logging.DEBUG
+    logger = logging.getLogger()
+    logging.basicConfig(
+        level=level,
+        format="%(message)s",
+    )
+    logger.setLevel(logging.INFO)
     with create_session() as db:
         load(db)

--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -293,4 +293,4 @@ class MGAGeneFunction(SQLAlchemyModelFactory):
         sqlalchemy_session = db
 
     function = SubFactory(GeneFunction)
-    count = Faker("pyint")
+    subject = Faker("pystr")

--- a/nmdc_server/migrations/versions/18e52534911c_remove_gene_function_count.py
+++ b/nmdc_server/migrations/versions/18e52534911c_remove_gene_function_count.py
@@ -1,0 +1,44 @@
+"""remove gene function count
+
+Revision ID: 18e52534911c
+Revises: 68a0445e19bf
+Create Date: 2021-01-27 15:54:00.080993
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "18e52534911c"
+down_revision: Optional[str] = "68a0445e19bf"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.drop_table("mga_gene_function")
+    op.create_table(
+        "mga_gene_function",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("metagenome_annotation_id", sa.String(), nullable=False),
+        sa.Column("gene_function_id", sa.String(), nullable=False),
+        sa.Column("subject", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["gene_function_id"],
+            ["gene_function.id"],
+            name=op.f("fk_mga_gene_function_gene_function_id_gene_function"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["metagenome_annotation_id"],
+            ["metagenome_annotation.id"],
+            name=op.f("fk_mga_gene_function_metagenome_annotation_id_metagenome_annotation"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_mga_gene_function")),
+    )
+
+
+def downgrade():
+    op.drop_table("mga_gene_function")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
-    Integer,
     LargeBinary,
     String,
     Table,
@@ -406,11 +405,12 @@ class GeneFunction(Base):
 class MGAGeneFunction(Base):  # metagenome annotation
     __tablename__ = "mga_gene_function"
 
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     metagenome_annotation_id = Column(
-        String, ForeignKey("metagenome_annotation.id"), primary_key=True
+        String, ForeignKey("metagenome_annotation.id"), nullable=False
     )
-    gene_function_id = Column(String, ForeignKey("gene_function.id"), primary_key=True)
-    count = Column(Integer, default=1)
+    gene_function_id = Column(String, ForeignKey("gene_function.id"), nullable=False)
+    subject = Column(String, nullable=False)
 
     function = relationship(GeneFunction)
 

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -263,7 +263,7 @@ class MGAGeneFunction(BaseModel):
         orm_mode = True
 
     gene_function_id: str
-    count: int
+    subject: str
 
 
 class PipelineStepBase(BaseModel):


### PR DESCRIPTION
This add the gene function relations for metagenome annotations.  As I suspected, this makes running ETL on deploy (and testing it in github actions) unsustainable as it will take at least 15 minutes (probably more).  I'm going to have look into a new strategy for manually triggering the ETL.