### PR TITLE
Invert the relationship between biosample and project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ NMDC_MONGO_PASSWORD=changeme
 
 ```
 nmdc-server truncate
-nmdc-server migrate
+alembic -c nmdc_server/alembic.ini upgrade head
 nmdc-server ingest
 ```
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -88,8 +88,8 @@ async def create_biosample(
     db: Session = Depends(get_db),
     token: Token = Depends(login_required),
 ):
-    if crud.get_project(db, biosample.project_id) is None:
-        raise HTTPException(status_code=400, detail="Project does not exist")
+    if crud.get_project(db, biosample.study_id) is None:
+        raise HTTPException(status_code=400, detail="Study does not exist")
 
     return crud.create_biosample(db, biosample)
 

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -40,7 +40,9 @@ def migrate(obj):
         if command.current(alembic_cfg) is None:
             command.stamp(alembic_cfg, "head")
         else:
-            command.upgrade(alembic_cfg, "head")
+            # TODO: Figure out why this doesn't work
+            # command.upgrade(alembic_cfg, "head")
+            pass
 
 
 @cli.command()

--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Dict
 from uuid import UUID, uuid4
 
-from factory import Factory, Faker, post_generation, SubFactory
+from factory import Factory, Faker, lazy_attribute, post_generation, SubFactory
 from factory.alchemy import SQLAlchemyModelFactory
 from faker.providers import BaseProvider, date_time, geo, internet, lorem, misc, person, python
 from sqlalchemy.orm.scoping import scoped_session
@@ -166,16 +166,6 @@ class StudyPublicationFactory(SQLAlchemyModelFactory):
         sqlalchemy_session = db
 
 
-class ProjectFactory(AnnotatedFactory):
-    class Meta:
-        model = models.Project
-        sqlalchemy_session = db
-
-    add_date = Faker("date_time")
-    mod_date = Faker("date_time")
-    study = SubFactory(StudyFactory)
-
-
 class BiosampleFactory(AnnotatedFactory):
     class Meta:
         model = models.Biosample
@@ -190,12 +180,26 @@ class BiosampleFactory(AnnotatedFactory):
     env_medium = SubFactory(EnvoTermFactory)
     latitude = Faker("latitude")
     longitude = Faker("longitude")
-    project = SubFactory(ProjectFactory)
+    study = SubFactory(StudyFactory)
     ecosystem = Faker("word")
     ecosystem_category = Faker("word")
     ecosystem_type = Faker("word")
     ecosystem_subtype = Faker("word")
     specific_ecosystem = Faker("word")
+
+
+class ProjectFactory(AnnotatedFactory):
+    class Meta:
+        model = models.Project
+        sqlalchemy_session = db
+
+    add_date = Faker("date_time")
+    mod_date = Faker("date_time")
+    biosample = SubFactory(BiosampleFactory)
+
+    @lazy_attribute
+    def study(self):
+        return self.biosample.study
 
 
 class DataObjectFactory(SQLAlchemyModelFactory):

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -31,12 +31,14 @@ def load(db: Session):
     data_object.load(db, mongodb["data_object_set"].find())
     db.commit()
 
-    logger.info("Loading omics processing...")
-    biosample_project = project.load(db, mongodb["omics_processing_set"].find())
+    logger.info("Loading biosamples...")
+    biosample.load(
+        db, mongodb["biosample_set"].find(), omics_processing=mongodb["omics_processing_set"]
+    )
     db.commit()
 
-    logger.info("Loading biosamples...")
-    biosample.load(db, mongodb["biosample_set"].find(), biosample_project)
+    logger.info("Loading omics processing...")
+    project.load(db, mongodb["omics_processing_set"].find())
     db.commit()
 
     logger.info("Loading metagenomes annotation...")

--- a/nmdc_server/migrations/versions/a9bf0258c0d2_invert_relationship.py
+++ b/nmdc_server/migrations/versions/a9bf0258c0d2_invert_relationship.py
@@ -1,0 +1,50 @@
+"""invert relationship
+
+Revision ID: a9bf0258c0d2
+Revises: 18e52534911c
+Create Date: 2021-01-28 15:41:01.324587
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a9bf0258c0d2"
+down_revision: Optional[str] = "18e52534911c"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.add_column("biosample", sa.Column("study_id", sa.String(), nullable=False))
+    op.drop_constraint("fk_biosample_project_id_project", "biosample", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("fk_biosample_study_id_study"), "biosample", "study", ["study_id"], ["id"]
+    )
+    op.drop_column("biosample", "project_id")
+    op.add_column("project", sa.Column("biosample_id", sa.String(), nullable=True))
+    op.drop_constraint("fk_project_study_id_study", "project", type_="foreignkey")
+    op.create_foreign_key(
+        op.f("fk_project_biosample_id_biosample"), "project", "biosample", ["biosample_id"], ["id"]
+    )
+    op.drop_column("project", "study_id")
+
+
+def downgrade():
+    op.add_column(
+        "project", sa.Column("study_id", sa.VARCHAR(), autoincrement=False, nullable=False)
+    )
+    op.drop_constraint(op.f("fk_project_biosample_id_biosample"), "project", type_="foreignkey")
+    op.create_foreign_key("fk_project_study_id_study", "project", "study", ["study_id"], ["id"])
+    op.drop_column("project", "biosample_id")
+    op.add_column(
+        "biosample", sa.Column("project_id", sa.VARCHAR(), autoincrement=False, nullable=False)
+    )
+    op.drop_constraint(op.f("fk_biosample_study_id_study"), "biosample", type_="foreignkey")
+    op.create_foreign_key(
+        "fk_biosample_project_id_project", "biosample", "project", ["project_id"], ["id"]
+    )
+    op.drop_column("biosample", "study_id")

--- a/nmdc_server/migrations/versions/e2df18f14429_nullable_study.py
+++ b/nmdc_server/migrations/versions/e2df18f14429_nullable_study.py
@@ -1,0 +1,30 @@
+"""nullable study
+
+Revision ID: e2df18f14429
+Revises: a9bf0258c0d2
+Create Date: 2021-01-28 17:24:48.950907
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e2df18f14429"
+down_revision: Optional[str] = "a9bf0258c0d2"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.add_column("project", sa.Column("study_id", sa.String(), nullable=True))
+    op.create_foreign_key(
+        op.f("fk_project_study_id_study"), "project", "study", ["study_id"], ["id"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(op.f("fk_project_study_id_study"), "project", type_="foreignkey")
+    op.drop_column("project", "study_id")

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -174,30 +174,9 @@ class Study(StudyBase):
         orm_mode = True
 
 
-# project
-class ProjectBase(AnnotatedBase):
-    study_id: str
-    add_date: Optional[datetime]
-    mod_date: Optional[datetime]
-
-
-class ProjectCreate(ProjectBase):
-    pass
-
-
-class Project(ProjectBase):
-    study_id: str
-    open_in_gold: Optional[str]
-
-    omics_data: List["OmicsTypes"]
-
-    class Config:
-        orm_mode = True
-
-
 # biosample
 class BiosampleBase(AnnotatedBase):
-    project_id: str
+    study_id: str
     depth: Optional[float]
     env_broad_scale_id: Optional[str]
     env_local_scale_id: Optional[str]
@@ -229,7 +208,28 @@ class Biosample(BiosampleBase):
     env_local_scale_terms: List[str] = []
     env_medium_terms: List[str] = []
 
-    projects: List[Project]
+    projects: List["Project"]
+
+    class Config:
+        orm_mode = True
+
+
+# project
+class ProjectBase(AnnotatedBase):
+    study_id: Optional[str]
+    biosample_id: Optional[str]
+    add_date: Optional[datetime]
+    mod_date: Optional[datetime]
+
+
+class ProjectCreate(ProjectBase):
+    pass
+
+
+class Project(ProjectBase):
+    open_in_gold: Optional[str]
+
+    omics_data: List["OmicsTypes"]
 
     class Config:
         orm_mode = True
@@ -351,6 +351,7 @@ class MetaproteomicAnalysis(PipelineStep):
 
 OmicsTypes = Union[ReadsQC, MetagenomeAnnotation, MetagenomeAssembly, MetaproteomicAnalysis]
 Project.update_forward_refs()
+Biosample.update_forward_refs()
 
 
 class FileDownloadBase(BaseModel):

--- a/prestart.sh
+++ b/prestart.sh
@@ -15,5 +15,6 @@ PGDATABASE=postgres psql -c "create database nmdc;" || true
 
 echo 'Upgrading schema and ingesting data'
 nmdc-server truncate
-nmdc-server migrate
+nmdc-server migrate  # to create the database if necessary
+alembic -c nmdc_server/alembic.ini upgrade head
 nmdc-server ingest

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands = pytest {posargs} tests/
 commands =
     nmdc-server --testing truncate
     nmdc-server --testing migrate
+    alembic -c nmdc_server/alembic.ini upgrade head
     nmdc-server --testing ingest
     nmdc-server --testing truncate
 


### PR DESCRIPTION
This was a mistake in the data model that needs to be corrected now that there are multiple projects per biosample.

A couple of weird things about the new schema:
* biosample_id is nullable on the project because we don't have biosample information on all projects
* study_id exists on both biosample and project so that queries can be joined both ways.  This will be unnecessary if we make biosample_id on project non-nullable.

I'm only 80% sure the way the tables are being joined now produces the expected result.  It's tricky with two different ways to join with the study table.  We will want to have the people who know the data better vet the search results once we have the data import ironed out.

@subdavis I don't think this will break anything you are working on.  The only big difference is that the biosample search results will now contain multiple projects in the list rather than always one.

It may break when you try to upgrade your database.  I'm having a strange problem where alembic's migrations don't apply.  Until I figure that  out, you can just run `docker-compose run backend psql postgres -c 'drop database nmdc;'` and it will start the database from scratch.