### PR TITLE
Add gene function to query conditions

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -27,6 +27,16 @@ def get_or_create(
 
 # summaries
 def get_database_summary(db: Session) -> schemas.DatabaseSummary:
+    gene_function_count = db.query(models.GeneFunction).count()
+    gene_function = schemas.TableSummary(
+        total=gene_function_count,
+        attributes={
+            "id": schemas.AttributeSummary(
+                count=gene_function_count,
+                type="string",
+            )
+        },
+    )
     return schemas.DatabaseSummary(
         study=aggregations.get_table_summary(db, models.Study),
         project=aggregations.get_table_summary(db, models.Project),
@@ -36,6 +46,7 @@ def get_database_summary(db: Session) -> schemas.DatabaseSummary:
         metagenome_assembly=aggregations.get_table_summary(db, models.MetagenomeAssembly),
         metagenome_annotation=aggregations.get_table_summary(db, models.MetagenomeAnnotation),
         metaproteomic_analysis=aggregations.get_table_summary(db, models.MetaproteomicAnalysis),
+        gene_function=gene_function,
     )
 
 

--- a/nmdc_server/ingest/data_object.py
+++ b/nmdc_server/ingest/data_object.py
@@ -2,11 +2,13 @@ from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 
 from nmdc_server.models import DataObject
+from nmdc_server.schemas import DataObjectCreate
 
 
 def load(db: Session, cursor: Cursor):
-    for obj in cursor:
-        obj.pop("_id")
+    fields = set(DataObjectCreate.__fields__.keys())
+    for obj_ in cursor:
+        obj = {key: obj_[key] for key in obj_.keys() & fields}
 
         # TODO: Remove once the source data is fixed.
         url = obj.get("url", "")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -353,18 +353,6 @@ class MetaproteomicAnalysis(Base, PipelineStep):
     outputs = output_relationship(metaproteomic_analysis_output_association)
 
 
-ModelType = Union[
-    Type[Study],
-    Type[Project],
-    Type[DataObject],
-    Type[Biosample],
-    Type[ReadsQC],
-    Type[MetagenomeAssembly],
-    Type[MetagenomeAnnotation],
-    Type[MetaproteomicAnalysis],
-]
-
-
 class Website(Base):
     __tablename__ = "website"
 
@@ -427,3 +415,16 @@ class FileDownload(Base):
     orcid = Column(String, nullable=False)
 
     data_object = relationship(DataObject)
+
+
+ModelType = Union[
+    Type[Study],
+    Type[Project],
+    Type[DataObject],
+    Type[Biosample],
+    Type[ReadsQC],
+    Type[MetagenomeAssembly],
+    Type[MetagenomeAnnotation],
+    Type[MetaproteomicAnalysis],
+    Type[GeneFunction],
+]

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -92,6 +92,7 @@ class DatabaseSummary(BaseModel):
     metagenome_assembly: TableSummary
     metagenome_annotation: TableSummary
     metaproteomic_analysis: TableSummary
+    gene_function: TableSummary
 
 
 class AggregationSummary(BaseModel):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -483,3 +483,32 @@ def test_query_data_object(db: Session):
         ]
     )
     assert {"file2"} == {r.id for r in q.execute(db)}
+
+
+def test_query_gene_function(db: Session):
+    sample1 = fakes.BiosampleFactory(id="sample1")
+    fakes.BiosampleFactory(id="sample2")
+    gene_functions = [fakes.MGAGeneFunction(function__id=f"function{i}") for i in range(10)]
+    fakes.MetagenomeAnnotationFactory(gene_functions=gene_functions, project__biosample=sample1)
+    db.commit()
+
+    q = query.BiosampleQuerySchema(
+        conditions=[
+            {
+                "table": "gene_function",
+                "field": "id",
+                "value": "function1",
+            }
+        ],
+    )
+    assert {r.id for r in q.execute(db)} == {"sample1"}
+    q = query.BiosampleQuerySchema(
+        conditions=[
+            {
+                "table": "gene_function",
+                "field": "id",
+                "value": "invalid",
+            }
+        ],
+    )
+    assert {r.id for r in q.execute(db)} == set()


### PR DESCRIPTION
This is fairly simple because gene functions aren't queryable on their own.  It adds support to all of the search and faceting endpoints the following condition:
```
{
  "table": "gene_function",
  "field": "id",
  "value": "KEGG.ORTHOLOGY:K06207"
}
```

Note the value has to contain the `KEGG.ORTHOLOGY:` prefix.  The client should add that, I could have the server add the prefix, but my understanding is we may add id's from different databases.  This could help disambiguate them.