### PR TITLE
Return raw data associated with an omics_processing

### DIFF
--- a/nmdc_server/ingest/project.py
+++ b/nmdc_server/ingest/project.py
@@ -42,6 +42,8 @@ def load_project(db: Session, obj: Dict[str, Any]):
 
         data_object.project = project
         db.add(data_object)
+        project.outputs.append(data_object)  # type: ignore
+
     db.add(project)
 
 

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -236,6 +236,7 @@ class Project(ProjectBase):
     open_in_gold: Optional[str]
 
     omics_data: List["OmicsTypes"]
+    outputs: List["DataObject"]
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
Adds server side support for #230 

The raw data is returned with the project object as the property "outputs", e.g.
```json
{
  "id": "gold:Gp0115663",
  "name": "Groundwater microbial communities from the Columbia River, Washington, USA, for microbe roles in carbon and contaminant biogeochemistry - GW-RW metaG T2_23-Sept-14",
  "description": "Coupling Microbial Communities to Carbon and Contaminant Biogeochemistry in the Groundwater-Surface Water Interaction Zone",
  ...,
  "outputs": [
    {
      "id": "jgi:55d740280d8785342fcf7e39",
      "name": "9422.8.132674.GTTTCG.fastq.gz",
      "description": "Raw sequencer read data",
      "file_size_bytes": 2861414297,
      "md5_checksum": null,
      "url": null
    }
  ]
}
```