### PR TITLE
Add a celery worker for performing async tasks

### DIFF
--- a/.docker-env
+++ b/.docker-env
@@ -4,3 +4,5 @@ PGUSER=postgres
 PGPASSWORD=postgres
 PGDATABASE=nmdc
 POSTGRES_URI="postgresql://postgres:postgres@postgres/nmdc"
+NMDC_CELERY_BACKEND="redis://redis:6379/0"
+NMDC_CELERY_BROKER="redis://redis:6379/0"

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 #   postgresql://user:password@host:port/database
 export NMDC_DATABASE_URI="postgresql:///nmdc"
 export NMDC_TESTING_DATABASE_URI="postgresql:///nmdc_testing"
+export NMDC_ENVIRONMENT="development"

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,0 +1,15 @@
+FROM python:3.8-alpine3.10
+
+RUN apk update && \
+    apk add --virtual build-deps gcc python-dev musl-dev libressl-dev libffi-dev && \
+    apk add postgresql-dev postgresql-client && \
+    apk add py-cryptography
+
+COPY setup.py setup.cfg /app/
+RUN pip install -e /app
+
+COPY nmdc_server /app/nmdc_server
+COPY .env.production /app/.env
+
+WORKDIR /app/
+CMD ["celery", "-b", "redis://redis:6379/0", "--result-backend", "redis://redis:6379/0", "-A", "nmdc_server.celery.celery_app", "worker", "-E", "-l", "INFO"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.3"
 services:
+  redis:
+    image: redis
+
   data:
     image: nginx
   db:
@@ -11,9 +14,20 @@ services:
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
 
+  worker:
+    depends_on:
+      - redis
+    env_file:
+      - .docker-env
+      - .env
+    build:
+      context: .
+      dockerfile: Dockerfile.worker
+
   backend:
     depends_on:
       - db
+      - redis
     env_file:
       - .docker-env
       - .env

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -78,7 +78,7 @@ async def login_required(token: Optional[Token] = Depends(get_token)) -> Token:
     return token
 
 
-async def admin_required(token: Token = Depends(get_token)) -> Token:
+async def admin_required(token: Token = Depends(login_required)) -> Token:
     if settings.environment in {"development", "testing"}:
         return token
     if token.orcid in _admin_users:

--- a/nmdc_server/celery.py
+++ b/nmdc_server/celery.py
@@ -1,0 +1,7 @@
+from celery import Celery
+
+from nmdc_server.config import settings
+
+
+celery_app = Celery("nmdc", backend=settings.celery_backend, broker=settings.celery_broker)
+celery_app.conf.imports += ("nmdc_server.jobs",)

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -6,6 +6,7 @@ from starlette.config import Config
 
 
 class Settings(BaseSettings):
+    environment: str = "production"
     database_uri: str = "postgresql:///nmdc"
     testing_database_uri: str = "postgresql:///nmdc_testing"
     secret_key: str = "secret"
@@ -21,6 +22,9 @@ class Settings(BaseSettings):
     mongo_database: str = "dwinston_share"
     mongo_user: str = ""
     mongo_password: str = ""
+
+    celery_backend: str = "redis://redis:6379/0"
+    celery_broker: str = "redis://redis:6379/0"
 
     class Config:
         env_prefix = "nmdc_"

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -1,0 +1,6 @@
+from nmdc_server.celery import celery_app
+
+
+@celery_app.task
+def ping():
+    return True

--- a/prestart.sh
+++ b/prestart.sh
@@ -9,12 +9,9 @@ done
 #       point we should decide how to do migrations correctly.
 # PGDATABASE=postgres psql -c "drop database if exists nmdc;"
 
-echo 'Ingesting data'
+echo 'Creating and migrating database'
 # in spin the database already exists
 PGDATABASE=postgres psql -c "create database nmdc;" || true
 
-echo 'Upgrading schema and ingesting data'
-nmdc-server truncate
 nmdc-server migrate  # to create the database if necessary
 alembic -c nmdc_server/alembic.ini upgrade head
-nmdc-server ingest

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     install_requires=[
         "alembic",
         "authlib",
+        "celery[redis,librabbitmq]",
         "click",
         "cryptography<3.4",  # https://github.com/pyca/cryptography/issues/5771
         "fastapi==0.61.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from starlette.testclient import TestClient
 
 from nmdc_server import auth, database
 from nmdc_server.app import create_app
+from nmdc_server.config import settings
 from nmdc_server.database import create_engine
 from nmdc_server.fakes import db as _db, TokenFactory
 
@@ -19,6 +20,12 @@ async def create_test_session(request: Request) -> auth.Token:
     data["refresh_token"] = str(data["refresh_token"])
     request.session["token"] = data
     return token
+
+
+@pytest.fixture(autouse=True)
+def testing_environment():
+    settings.environment = "testing"
+    return settings
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 from starlette.testclient import TestClient
 
+from nmdc_server import fakes
 from nmdc_server.auth import Token
 from nmdc_server.config import settings
 
@@ -22,6 +23,14 @@ def test_logout(client: TestClient, token: Token):
     assert resp.json() == None
 
 
-def test_login_required(client: TestClient):
+def test_admin_required(client: TestClient):
     resp = client.post("/api/study", json={"doi": "abc"})
+    assert resp.status_code == 401
+
+
+def test_login_required(db, client: TestClient):
+    fakes.DataObjectFactory(id="nmdc:id")
+    db.commit()
+
+    resp = client.get("/api/data_object/nmdc:id/download")
     assert resp.status_code == 401

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
-  3.7: py37, ingest
-  3.8: py38, ingest, lint, typecheck, black
+  3.7: py37
+  3.8: py38, lint, typecheck, black
 
 [testenv]
 deps =


### PR DESCRIPTION
This removes data ingest from the server start.  I added a task to ping the worker that I will use to get the production stack working.  Once that is done, I will migrate the ingestion code into a celery task that can be manually triggered via an endpoint.

I have also added the concept of an admin user that is allowed to make data changes.  Because we don't have a user table, it is just a hard coded set of orcids (currently only me).  We can add additional admins via PR's until we find the need to generate a user table.