### PR TITLE
Add doi info collected from doi.org

### DIFF
--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -49,6 +49,15 @@ class TokenFactory(Factory):
     expires_at: int = Faker("pyint", min_value=10000, max_value=99999)
 
 
+class DOIInfoFactory(SQLAlchemyModelFactory):
+    class Meta:
+        model = models.DOIInfo
+        sqlalchemy_session = db
+
+    id = Faker("doi")
+    info = Faker("pydict", value_types=["str"])
+
+
 class AnnotatedFactory(SQLAlchemyModelFactory):
     id: str = Faker("pystr")
     name: str = Faker("word")
@@ -71,7 +80,7 @@ class WebsiteFactory(SQLAlchemyModelFactory):
 
 class PublicationFactory(SQLAlchemyModelFactory):
     id = Faker("uuid")
-    doi = Faker("doi")
+    doi_object = SubFactory(DOIInfoFactory)
 
     class Meta:
         model = models.Publication
@@ -120,8 +129,8 @@ class StudyFactory(AnnotatedFactory):
     gold_name = Faker("word")
     gold_description = Faker("sentence")
     scientific_objective = Faker("sentence")
-    doi = Faker("doi")
     principal_investigator = SubFactory(PrincipalInvestigator)
+    doi_object = SubFactory(DOIInfoFactory)
 
     class Meta:
         model = models.Study

--- a/nmdc_server/ingest/doi.py
+++ b/nmdc_server/ingest/doi.py
@@ -1,0 +1,34 @@
+from logging import getLogger
+from typing import Any, Dict
+
+import requests
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from nmdc_server.models import DOIInfo
+
+logger = getLogger(__name__)
+
+
+def get_doi_info(doi: str) -> Dict[str, Any]:
+    url = f"https://doi.org/{doi}"
+    headers = {
+        "Accept": "application/vnd.citationstyles.csl+json",
+    }
+    return requests.get(url, headers=headers).json()
+
+
+def upsert_doi(db: Session, doi: str):
+    try:
+        info = get_doi_info(doi)
+    except Exception:
+        logger.exception(f"Failed to fetch {doi}")
+        # don't add an entry if it already exists
+        if db.query(DOIInfo).get(doi):
+            return
+        info = {}
+
+    statement = insert(DOIInfo.__table__).values(id=doi, info=info)
+    statement = statement.on_conflict_do_update(constraint="pk_doi_info", set_=dict(info=info))
+    db.execute(statement)
+    db.flush()

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from nmdc_server.crud import create_study
 from nmdc_server.ingest.common import extract_extras, extract_value
+from nmdc_server.ingest.doi import upsert_doi
 from nmdc_server.models import PrincipalInvestigator
 from nmdc_server.schemas import StudyCreate
 
@@ -58,5 +59,9 @@ def load(db: Session, cursor: Cursor):
             obj["scientific_objective"] = a["scientific_objective"]
         else:
             raise Exception(f"not found {obj['id']}")
+
+        upsert_doi(db, obj["doi"])
+        for doi in obj["publication_dois"]:
+            upsert_doi(db, obj["doi"])
 
         create_study(db, Study(**obj))

--- a/nmdc_server/migrations/versions/f1cd153d1a16_add_doi_table.py
+++ b/nmdc_server/migrations/versions/f1cd153d1a16_add_doi_table.py
@@ -1,0 +1,49 @@
+"""add doi table
+
+Revision ID: f1cd153d1a16
+Revises: 7057e7745ce6
+Create Date: 2021-02-17 15:40:31.316844
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Session
+
+from nmdc_server.ingest.doi import upsert_doi
+from nmdc_server.models import Publication, Study
+
+# revision identifiers, used by Alembic.
+revision: str = "f1cd153d1a16"
+down_revision: Optional[str] = "7057e7745ce6"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    db = Session(bind=op.get_bind())
+    op.create_table(
+        "doi_info",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("info", postgresql.JSONB(astext_type=sa.Text()), nullable=False),  # type: ignore
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_doi_info")),
+    )
+    for study in db.query(Study):
+        upsert_doi(db, study.doi)
+
+    for publication in db.query(Publication):
+        upsert_doi(db, publication.doi)
+
+    db.commit()
+    op.create_foreign_key(
+        op.f("fk_publication_doi_doi_info"), "publication", "doi_info", ["doi"], ["id"]
+    )
+    op.create_foreign_key(op.f("fk_study_doi_doi_info"), "study", "doi_info", ["doi"], ["id"])
+
+
+def downgrade():
+    op.drop_constraint(op.f("fk_study_doi_doi_info"), "study", type_="foreignkey")
+    op.drop_constraint(op.f("fk_publication_doi_doi_info"), "publication", type_="foreignkey")
+    op.drop_table("doi_info")

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -179,6 +179,7 @@ class Study(StudyBase):
     principal_investigator_image_url: str
     sample_count: Optional[int]
     omics_counts: Optional[List[OmicsCounts]]
+    publication_doi_info: Dict[str, Any]
 
     class Config:
         orm_mode = True

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "pymongo",
         "python-dateutil",
         "python-dotenv",
+        "requests",
         "sqlalchemy>=1.3.18",
         "starlette==0.13.6",
         "typing-extensions",


### PR DESCRIPTION
Adds to the study response a `publication_doi_info` object that contains the doi information returned by doi.org for each doi referenced by the study.

Alternatively, I could have created an endpoint that acts just like doi.org.  What I implemented minimizes the number of requests and queries made at the expense of a larger response size for the study endpoints.

Implements the server side of #286 
Fixes #136