### PR TITLE
Add omics_processing counts to study search response

### DIFF
--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -148,6 +148,7 @@ class Study(Base, AnnotatedModel):
     #       non-search responses.
     sample_count = query_expression()
     omics_counts = query_expression()
+    omics_processing_counts = query_expression()
 
     principal_investigator_id = Column(
         UUID(as_uuid=True), ForeignKey("principal_investigator.id"), nullable=False

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -179,6 +179,7 @@ class Study(StudyBase):
     principal_investigator_image_url: str
     sample_count: Optional[int]
     omics_counts: Optional[List[OmicsCounts]]
+    omics_processing_counts: Optional[List[OmicsCounts]]
     publication_doi_info: Dict[str, Any]
 
     class Config:


### PR DESCRIPTION
Adds `omics_processing_counts` to the study search response which contains aggregated counts of the omics processings (projects) grouped by type.

Implements the server part of #298