### PR TITLE
Ingest data into a dedicated database to limit downtime

### DIFF
--- a/.docker-env
+++ b/.docker-env
@@ -1,8 +1,10 @@
 POSTGRES_PASSWORD=postgres
-PGHOST=db
+POSTGRES_DB=nmdc
+POSTGRES_USER=postgres
 PGUSER=postgres
 PGPASSWORD=postgres
 PGDATABASE=nmdc
-POSTGRES_URI="postgresql://postgres:postgres@postgres/nmdc"
+NMDC_DATABASE_URI="postgresql://postgres:postgres@db/nmdc"
 NMDC_CELERY_BACKEND="redis://redis:6379/0"
 NMDC_CELERY_BROKER="redis://redis:6379/0"
+NMDC_INGEST_DATABASE_URI="postgresql://postgres:postgres@db-ingest/nmdc"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
 
   data:
     image: nginx
+
   db:
     image: postgres:12
     volumes:
@@ -13,10 +14,23 @@ services:
       - .docker-env
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
+      - POSTGRES_DB=nmdc
+
+  db-ingest:
+    image: postgres:12
+    volumes:
+      - app-db-ingest:/var/lib/postgresql/data/pgdata
+    env_file:
+      - .docker-env
+    environment:
+      - PGDATA=/var/lib/postgresql/data/pgdata
+      - POSTGRES_DB=nmdc
 
   worker:
     depends_on:
       - redis
+      - db
+      - db-ingest
     env_file:
       - .docker-env
       - .env
@@ -34,6 +48,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    environment:
+      - PGHOST=db
     networks:
       - public
       - default
@@ -60,6 +76,7 @@ services:
 
 volumes:
   app-db-data:
+  app-db-ingest:
 
 networks:
   public:

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     environment: str = "production"
     database_uri: str = "postgresql:///nmdc"
     testing_database_uri: str = "postgresql:///nmdc_testing"
+    ingest_database_uri: str = "postgresql:///nmdc_testing"
     secret_key: str = "secret"
     client_id: str = "oauth client id"
     client_secret: str = "oauth secret key"

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -126,6 +126,7 @@ $$ LANGUAGE plpgsql;
 #  the configuration into fastapi dependencies more cleanly in a way that also
 #  supports factory-boy's scoped sessions.
 testing = False
+ingest = False
 
 
 def json_serializer(data: Any) -> str:
@@ -144,6 +145,8 @@ def create_engine() -> Engine:
         uri = settings.database_uri
         if testing:
             uri = settings.testing_database_uri
+        elif ingest:
+            uri = settings.ingest_database_uri
 
         _engine = _create_engine(uri, json_serializer=json_serializer)
 
@@ -151,8 +154,9 @@ def create_engine() -> Engine:
 
 
 @contextmanager
-def create_session() -> Iterator[Session]:
-    engine = create_engine()
+def create_session(engine=None) -> Iterator[Session]:
+    if engine is None:
+        engine = create_engine()
     SessionLocal.configure(bind=engine)
     metadata.bind = engine
 

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 def paginate_cursor(
     collection: Collection, page_size: int = 100, **kwargs
 ) -> Iterator[Dict[str, Any]]:
-    print("start iterator")
     skip = 0
     last_iteration_count = page_size
     while last_iteration_count == page_size:

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -1,8 +1,17 @@
-from nmdc_server import models
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from nmdc_server import database, models
 from nmdc_server.celery import celery_app
-from nmdc_server.database import create_session
+from nmdc_server.config import settings
+from nmdc_server.database import create_engine, create_session, metadata
 from nmdc_server.ingest.all import load
 from nmdc_server.ingest.lock import ingest_lock
+
+
+HERE = Path(__file__).parent
 
 
 @celery_app.task
@@ -10,22 +19,61 @@ def ping():
     return True
 
 
+def migrate(database_uri):
+    database._engine = None
+    with create_session() as db:
+        engine = db.bind
+        metadata.create_all(engine)
+        alembic_cfg = Config(str(HERE / "alembic.ini"))
+        alembic_cfg.set_main_option("script_location", str(HERE / "migrations"))
+        alembic_cfg.set_main_option("sqlalchemy.url", database_uri)
+        alembic_cfg.attributes["configure_logger"] = False
+        if command.current(alembic_cfg) is None:
+            command.stamp(alembic_cfg, "head")
+        else:
+            command.upgrade(alembic_cfg, "head")
+    database._engine = None
+
+
 @celery_app.task
 def ingest():
+    database._engine = None
+    database.ingest = False
+    prod_engine = create_engine()
+
+    database._engine = None
+    database.ingest = True
     with create_session() as db:
+        try:
+            for row in db.execute("select truncate_tables()"):
+                pass
+        except Exception:
+            db.rollback()
+
+    migrate(settings.ingest_database_uri)
+
+    with create_session() as db, create_session(prod_engine) as prod_db:
         with ingest_lock(db):
             try:
                 for row in db.execute("select truncate_tables()"):
                     pass
                 load(db)
+                for row in prod_db.query(models.FileDownload):
+                    db.merge(row)
                 db.commit()
             except Exception:
                 db.rollback()
                 raise
+    database._engine = None
+    database.ingest = False
+
+    populate_gene_functions()
 
 
 @celery_app.task
 def populate_gene_functions():
+    database._engine = None
+    database.ingest = True
     with create_session() as db:
         with ingest_lock(db):
             try:
@@ -35,3 +83,5 @@ def populate_gene_functions():
             except Exception:
                 db.rollback()
                 raise
+    database._engine = None
+    database.ingest = False

--- a/nmdc_server/migrations/env.py
+++ b/nmdc_server/migrations/env.py
@@ -5,7 +5,6 @@ from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from nmdc_server import models  # noqa
-from nmdc_server.config import Settings
 from nmdc_server.database import metadata
 
 
@@ -26,7 +25,8 @@ target_metadata = metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
-config.set_main_option("sqlalchemy.url", Settings().database_uri)
+
+# config.set_main_option("sqlalchemy.url", Settings().database_uri)
 
 
 def run_migrations_offline():
@@ -65,7 +65,6 @@ def run_migrations_online():
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
-
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
 

--- a/prestart.sh
+++ b/prestart.sh
@@ -13,5 +13,4 @@ echo 'Creating and migrating database'
 # in spin the database already exists
 PGDATABASE=postgres psql -c "create database nmdc;" || true
 
-nmdc-server migrate  # to create the database if necessary
-alembic -c nmdc_server/alembic.ini upgrade head
+nmdc-server migrate

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ commands = pytest {posargs} tests/
 commands =
     nmdc-server --testing truncate
     nmdc-server --testing migrate
-    alembic -c nmdc_server/alembic.ini upgrade head
     nmdc-server --testing ingest
     nmdc-server --testing truncate
 


### PR DESCRIPTION
This still needs some work on the spin infrastructure to perform replacement from the ingest to the production database.  I'm going to attempt it manually a couple of times before doing that.