### PR TITLE
Incorporate UX Design Feedback Round 2

### DIFF
--- a/web/src/colors.js
+++ b/web/src/colors.js
@@ -12,6 +12,7 @@ export default {
   green,
   blue,
   purple,
+  grey: colors.grey,
   primary: purple,
   secondary: red,
   accent: orange,

--- a/web/src/components/Presentation/ConditionChips.vue
+++ b/web/src/components/Presentation/ConditionChips.vue
@@ -124,6 +124,7 @@ export default Vue.extend({
                 field: group.field,
                 table: group.table,
                 isOpen: menuState[group.key],
+                toggleMenu: (val) => toggleMenu(group.key, val),
               }"
             />
           </v-card>

--- a/web/src/v2/components/DataObjectTable.vue
+++ b/web/src/v2/components/DataObjectTable.vue
@@ -46,7 +46,7 @@ export default defineComponent({
   setup(props) {
     const headers: DataTableHeader[] = [
       {
-        text: 'Workflow Activity',
+        text: '',
         value: 'group_name',
         sortable: false,
       },
@@ -99,8 +99,8 @@ export default defineComponent({
             ...data_object,
             omics_data,
             /* TODO Hack to replace metagenome with omics type name */
-            group_name: i === 0 ? omics_data.name
-              .replace('Metagenome', props.omicsType) : '',
+            group_name: omics_data.name.replace('Metagenome', props.omicsType),
+            newgroup: i === 0,
             object_type,
             object_description: descriptionMap[object_type] || '',
           };
@@ -153,43 +153,57 @@ export default defineComponent({
       :items="items"
       dense
     >
-      <template #[`item.file_size_bytes`]="{ item }">
-        {{ humanFileSize(item.file_size_bytes ) }}
-      </template>
-      <template #[`item.action`]="{ item }">
-        <v-tooltip
-          :disabled="!!(loggedInUser && item.url)"
-          bottom
+      <template #item="{ item, index }">
+        <tr
+          v-if="(item.newgroup || index == 0) && item.group_name"
+          :style="{ 'background-color': '#e0e0e0' }"
         >
-          <template #activator="{ on, attrs }">
-            <span v-on="on">
-              <v-btn
-                v-if="item.url"
-                icon
-                :disabled="!loggedInUser"
-                v-bind="attrs"
-                @click="download(item)"
-              >
-                <v-icon>mdi-download</v-icon>
-              </v-btn>
-              <v-btn
-                v-else
-                icon
-                disabled
-              >
-                <v-icon>
-                  mdi-file-hidden
-                </v-icon>
-              </v-btn>
-            </span>
-          </template>
-          <span v-if="item.url">
-            You must be logged in
-          </span>
-          <span v-else>
-            File unavailable
-          </span>
-        </v-tooltip>
+          <td colspan="5">
+            <b>Workflow Activity:</b> {{ item.group_name }}
+          </td>
+        </tr>
+        <tr>
+          <td />
+          <td>{{ item.object_type }}</td>
+          <td>{{ item.object_description }}</td>
+          <td>{{ humanFileSize(item.file_size_bytes ) }}</td>
+          <td>
+            <v-tooltip
+              :disabled="!!(loggedInUser && item.url)"
+              bottom
+            >
+              <template #activator="{ on, attrs }">
+                <span v-on="on">
+                  <v-btn
+                    v-if="item.url"
+                    icon
+                    :disabled="!loggedInUser"
+                    v-bind="attrs"
+                    color="primary"
+                    @click="download(item)"
+                  >
+                    <v-icon>mdi-download</v-icon>
+                  </v-btn>
+                  <v-btn
+                    v-else
+                    icon
+                    disabled
+                  >
+                    <v-icon>
+                      mdi-file-hidden
+                    </v-icon>
+                  </v-btn>
+                </span>
+              </template>
+              <span v-if="item.url">
+                You must be logged in
+              </span>
+              <span v-else>
+                File unavailable
+              </span>
+            </v-tooltip>
+          </td>
+        </tr>
       </template>
     </v-data-table>
   </v-card>

--- a/web/src/v2/components/FacetedSearch.vue
+++ b/web/src/v2/components/FacetedSearch.vue
@@ -110,6 +110,7 @@ export default Vue.extend({
         <template v-for="sf in filteredFields">
           <v-menu
             :key="sf.key"
+            :value="menuState[sf.key]"
             offset-x
             :close-on-content-click="false"
             @input="toggleMenu(sf.key, $event)"
@@ -138,6 +139,7 @@ export default Vue.extend({
                   field: sf.field,
                   table: sf.table,
                   isOpen: menuState[sf.key],
+                  toggleMenu: (val) => toggleMenu(sf.key, val),
                 }"
               />
             </v-card>

--- a/web/src/v2/components/MenuContent.vue
+++ b/web/src/v2/components/MenuContent.vue
@@ -50,6 +50,13 @@ export default Vue.extend({
   <div>
     <v-card-title class="pb-0">
       {{ fieldDisplayName(field, table) }} {{ getField(field, table).units }}
+      <v-spacer />
+      <v-btn
+        icon
+        @click="$emit('close')"
+      >
+        <v-icon>mdi-close</v-icon>
+      </v-btn>
     </v-card-title>
     <filter-list
       v-if="summary.type === 'string' && isOpen"

--- a/web/src/v2/components/TooltipCard.vue
+++ b/web/src/v2/components/TooltipCard.vue
@@ -1,0 +1,42 @@
+<script>
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+  },
+  setup() {
+    return { id: `tooltipCard-${Math.random().toString().slice(2, 10)}` };
+  },
+});
+</script>
+
+<template>
+  <v-card
+    :id="id"
+    outlined
+  >
+    <v-tooltip
+      :attach="`#${id}`"
+      left
+      nudge-bottom="20px"
+      min-width="300px"
+      max-width="300px"
+    >
+      <template #activator="{ on, attrs }">
+        <v-icon
+          v-bind="attrs"
+          style="position: absolute; right: 6px; top: 6px; z-index: 20;"
+          v-on="on"
+        >
+          mdi-help-circle
+        </v-icon>
+      </template>
+      <span>{{ text }}</span>
+    </v-tooltip>
+    <slot />
+  </v-card>
+</template>

--- a/web/src/v2/views/IndividualResults/IndividualTitle.vue
+++ b/web/src/v2/views/IndividualResults/IndividualTitle.vue
@@ -30,7 +30,7 @@ export default defineComponent({
           x-large
           @click="$router.go(-1)"
         >
-          <v-icon>mdi-arrow-left-circle</v-icon>
+          <v-icon>mdi-chevron-left-box</v-icon>
         </v-btn>
       </v-col>
       <v-col class="grow">

--- a/web/src/v2/views/Search/BiosampleVisGroup.vue
+++ b/web/src/v2/views/Search/BiosampleVisGroup.vue
@@ -152,8 +152,7 @@ export default defineComponent({
       <v-col cols="4">
         <TooltipCard
           :text="lipsum"
-          height="100%"
-          class="py-0 d-flex flex-column justify-center"
+          class="py-0 d-flex flex-column justify-center fill-height"
         >
           <ChartContainer :height="160">
             <template #default="{ width, height }">

--- a/web/src/v2/views/Search/BiosampleVisGroup.vue
+++ b/web/src/v2/views/Search/BiosampleVisGroup.vue
@@ -10,11 +10,14 @@ import ChartContainer from '@/components/Presentation/ChartContainer.vue';
 import FacetSummaryWrapper from '@/components/FacetSummaryWrapper.vue';
 import BinnedSummaryWrapper from '@/components/BinnedSummaryWrapper.vue';
 // ENDTODO
+import TooltipCard from '@/v2/components/TooltipCard.vue';
 
 import {
   toggleConditions, removeConditions, setUniqueCondition,
 } from '@/v2/store';
 import { Condition } from '@/data/api';
+
+const lipsum = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ';
 
 const staticUpsetData = [
   {
@@ -68,6 +71,7 @@ export default defineComponent({
     FacetBarChart,
     LocationMap,
     EcosystemSankey,
+    TooltipCard,
     // TODO replace with composition functions
     FacetSummaryWrapper,
     BinnedSummaryWrapper,
@@ -75,6 +79,7 @@ export default defineComponent({
   },
   setup() {
     return {
+      lipsum,
       toggleConditions,
       setUniqueCondition,
       removeConditions,
@@ -89,10 +94,7 @@ export default defineComponent({
   <div>
     <v-row>
       <v-col :cols="4">
-        <v-card
-          outlined
-          class="pa-1"
-        >
+        <TooltipCard :text="lipsum">
           <FacetSummaryWrapper
             table="omics_processing"
             field="omics_type"
@@ -111,11 +113,11 @@ export default defineComponent({
               />
             </template>
           </FacetSummaryWrapper>
-        </v-card>
+        </TooltipCard>
       </v-col>
       <v-col :cols="8">
-        <v-card
-          outlined
+        <TooltipCard
+          :text="lipsum"
           class="pa-1"
         >
           <LocationMap
@@ -123,13 +125,13 @@ export default defineComponent({
             :conditions="conditions"
             @selected="toggleConditions($event.conditions)"
           />
-        </v-card>
+        </TooltipCard>
       </v-col>
     </v-row>
     <v-row>
       <v-col cols="8">
-        <v-card
-          outlined
+        <TooltipCard
+          :text="lipsum"
           class="py-2"
         >
           <BinnedSummaryWrapper
@@ -145,11 +147,11 @@ export default defineComponent({
               />
             </template>
           </BinnedSummaryWrapper>
-        </v-card>
+        </TooltipCard>
       </v-col>
       <v-col cols="4">
-        <v-card
-          outlined
+        <TooltipCard
+          :text="lipsum"
           height="100%"
           class="py-0 d-flex flex-column justify-center"
         >
@@ -166,7 +168,7 @@ export default defineComponent({
               />
             </template>
           </ChartContainer>
-        </v-card>
+        </TooltipCard>
       </v-col>
     </v-row>
   </div>

--- a/web/src/v2/views/Search/Layout.vue
+++ b/web/src/v2/views/Search/Layout.vue
@@ -176,11 +176,11 @@ export default defineComponent({
                   <v-list-item-action>
                     <v-btn
                       icon
-                      plain
+                      large
                       :to="{ name: 'V2Study', params: { id: result.id } }"
                     >
-                      <v-icon color="grey">
-                        mdi-chevron-right
+                      <v-icon>
+                        mdi-chevron-right-box
                       </v-icon>
                     </v-btn>
                   </v-list-item-action>
@@ -239,11 +239,11 @@ export default defineComponent({
                   <v-list-item-action>
                     <v-btn
                       icon
-                      plain
+                      large
                       :to="{ name: 'V2Sample', params: { id: result.id } }"
                     >
-                      <v-icon color="grey">
-                        mdi-chevron-right
+                      <v-icon>
+                        mdi-chevron-right-box
                       </v-icon>
                     </v-btn>
                   </v-list-item-action>

--- a/web/src/v2/views/Search/Sidebar.vue
+++ b/web/src/v2/views/Search/Sidebar.vue
@@ -182,7 +182,7 @@ export default defineComponent({
       class="ma-3"
       @remove="removeConditions([$event])"
     >
-      <template #menu="{ field, table, isOpen }">
+      <template #menu="{ field, table, isOpen, toggleMenu }">
         <MenuContent
           v-bind="{
             field,
@@ -192,6 +192,7 @@ export default defineComponent({
             summary: dbSummaryForTable(table, field),
           }"
           @select="setConditions($event.conditions)"
+          @close="toggleMenu(false)"
         />
       </template>
     </ConditionChips>
@@ -206,7 +207,7 @@ export default defineComponent({
       :conditions="conditions"
       :fields="FunctionSearchFacets"
     >
-      <template #menu="{ field, table, isOpen }">
+      <template #menu="{ field, table, isOpen, toggleMenu }">
         <MenuContent
           v-bind="{
             field,
@@ -216,6 +217,7 @@ export default defineComponent({
             conditions,
           }"
           @select="setConditions($event.conditions)"
+          @close="toggleMenu(false)"
         />
       </template>
     </FacetedSearch>


### PR DESCRIPTION
![Screenshot from 2021-04-26 12-21-59](https://user-images.githubusercontent.com/4214172/116117292-0f75ad00-a68a-11eb-8781-09cfedbf7633.png)
![Screenshot from 2021-04-26 11-55-36](https://user-images.githubusercontent.com/4214172/116117294-100e4380-a68a-11eb-9ec9-5c76b92ed9e4.png)
![Screenshot from 2021-04-26 11-55-12](https://user-images.githubusercontent.com/4214172/116117296-100e4380-a68a-11eb-8cde-138874acb39e.png)
![Screenshot from 2021-04-26 11-54-50](https://user-images.githubusercontent.com/4214172/116117297-100e4380-a68a-11eb-8977-4bfb536b6497.png)

I think this takes care of all the feedback we decided to move on from https://www.figma.com/file/h3v0xOrdZSYWSCRZhxQcXw/Improvements-based-on-'Mockup-Report-SGCI-NMDC-Usability-Consulting.pdf'?node-id=0%3A1

* Still using lorem ipsum for hover text.  I can switch these to full dialogs with a dismiss button if you think they need more than just a sentence or two.
* I went with sort of a hybrid for the download table change.  I liked the dedicated workflow header more than just the darkened background.  I also added a duplicate workflow header on the top of the N > 1th page of results so you don't have to remember what workflow section you're in page-to-page.
  * I didn't make it collapsible because there's already a lot going on in here and it seemed premature.  Also, only some omics types have this workflow header now (the column is removed) so it'd be kinda awkward to have to expand some tables and others just be normal tables.  Feedback welcome.
 

fixes #341 