### PR TITLE
Include unit information with summary endpoint

### DIFF
--- a/nmdc_server/attribute_units.py
+++ b/nmdc_server/attribute_units.py
@@ -1,0 +1,20 @@
+from typing import Dict, Optional
+
+from pint import Unit, UnitRegistry
+
+
+_registry = UnitRegistry()
+
+# TODO: This information should come from the upstream schema.  For now, we
+#       hard code relevant attributes here.
+
+
+_unit_info: Dict[str, Dict[str, Unit]] = {
+    "biosample": {
+        "depth": _registry("meters").units,
+    }
+}
+
+
+def get_attribute_units(table: str, attribute: str) -> Optional[Unit]:
+    return _unit_info.get(table, {}).get(attribute)

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 from uuid import UUID
 
+from pint import Unit
 from pydantic import BaseModel, Field, validator
 from sqlalchemy import BigInteger, Column, DateTime, Float, String
 
@@ -72,11 +73,44 @@ class AnnotatedBase(BaseModel):
 
 
 # aggregations
+class UnitDimensionality(BaseModel):
+    quantity: str
+    exponent: int
+
+
+class UnitInfo(BaseModel):
+    name: str
+    abbreviation: str
+    dimensionality: List[UnitDimensionality]
+
+    @classmethod
+    def from_unit(cls, unit: Optional[Unit]) -> Optional["UnitInfo"]:
+        if unit is None:
+            return None
+
+        dimensionality: List[UnitDimensionality] = []
+
+        for key, value in unit.dimensionality.items():
+            dimensionality.append(
+                UnitDimensionality(
+                    quantity=key,
+                    exponent=value,
+                )
+            )
+
+        return UnitInfo(
+            name=str(unit),
+            abbreviation=format(unit, "~"),
+            dimensionality=dimensionality,
+        )
+
+
 class AttributeSummary(BaseModel):
     count: int
     min: Optional[Union[float, datetime]]
     max: Optional[Union[float, datetime]]
     type: AttributeType
+    units: Optional[UnitInfo]
 
 
 class TableSummary(BaseModel):

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "factory-boy",
         "httpx",
         "itsdangerous",
+        "pint",
         "psycopg2-binary",
         "pymongo",
         "python-dateutil",


### PR DESCRIPTION
This adds a new optional property in the database summary for an attribute that contains normalized unit information.  The unit information is currently only available for `biosample.depth`, where the response looks like this:
```json
"depth": {
  "count": 49,
  "min": 0,
  "max": 2000,
  "type": "float",
  "units": {
    "name": "meter",
    "abbreviation": "m",
    "dimensionality": [
      {
        "quantity": "[length]",
        "exponent": 1
      }
    ]
  }
}
```
This is primarily to define a unit aware interface for the client to use.  We still need to define how to extract this information from the schema.

Ping @subdavis for using this information in the web client somehow.

Addresses #338