### PR TITLE
Add the ability to query by the existence of multiple omics types

### DIFF
--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -157,3 +157,6 @@ def load(db: Session, function_limit=None):
 
     models.MetaPGeneFunctionAggregation.populate(db)
     db.commit()
+
+    models.Biosample.populate_multiomics(db)
+    db.commit()

--- a/nmdc_server/migrations/versions/04137e962f0f_add_multiomics.py
+++ b/nmdc_server/migrations/versions/04137e962f0f_add_multiomics.py
@@ -1,0 +1,31 @@
+"""add multiomics
+
+Revision ID: 04137e962f0f
+Revises: ef834f950de9
+Create Date: 2021-05-16 00:22:03.125760
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+
+from nmdc_server.database import update_multiomics_sql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "04137e962f0f"
+down_revision: Optional[str] = "ef834f950de9"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.add_column(
+        "biosample", sa.Column("multiomics", sa.Integer(), nullable=False, server_default="0")
+    )
+    op.execute(update_multiomics_sql)
+
+
+def downgrade():
+    op.drop_column("biosample", "multiomics")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Integer,
     LargeBinary,
     String,
     Table,
@@ -21,7 +22,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import backref, query_expression, relationship, Session
 from sqlalchemy.orm.relationships import RelationshipProperty
 
-from nmdc_server.database import Base
+from nmdc_server.database import Base, update_multiomics_sql
 
 
 def gold_url(base: str, id: str) -> Optional[str]:
@@ -198,6 +199,7 @@ class Biosample(Base, AnnotatedModel):
     latitude = Column(Float, nullable=False)
     longitude = Column(Float, nullable=False)
     study_id = Column(String, ForeignKey("study.id"), nullable=False)
+    multiomics = Column(Integer, nullable=False, default=0)
 
     # gold terms
     ecosystem = Column(String, nullable=True)
@@ -226,6 +228,11 @@ class Biosample(Base, AnnotatedModel):
     @property
     def open_in_gold(self) -> Optional[str]:
         return gold_url("https://gold.jgi.doe.gov/biosample?id=", self.id)
+
+    @classmethod
+    def populate_multiomics(cls, db: Session):
+        db.execute(update_multiomics_sql)
+        db.commit()
 
 
 omics_processing_output_association = output_association("omics_processing")

--- a/nmdc_server/multiomics.py
+++ b/nmdc_server/multiomics.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class MultiomicsValue(Enum):
+    mb = 0b10000
+    mg = 0b01000
+    mp = 0b00100
+    mt = 0b00010
+    om = 0b00001

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from pint import Unit
 from pydantic import BaseModel, Field, validator
-from sqlalchemy import BigInteger, Column, DateTime, Float, String
+from sqlalchemy import BigInteger, Column, DateTime, Float, Integer, String
 
 from nmdc_server import models
 
@@ -47,7 +47,7 @@ class AttributeType(Enum):
             return AttributeType.date
         elif isinstance(column.type, Float):
             return AttributeType.float_
-        elif isinstance(column.type, BigInteger):
+        elif isinstance(column.type, (BigInteger, Integer)):
             return AttributeType.integer
         elif isinstance(column.type, String):
             return AttributeType.string
@@ -255,6 +255,7 @@ class Biosample(BiosampleBase):
     env_medium_terms: List[str] = []
 
     omics_processing: List["OmicsProcessing"]
+    multiomics: int
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
This adds a new denormalized column called `multiomics` to the biosample table.  This is an integer representing a bit mask of omics processing types available for the sample.  Bit values are encoded in an enum:

```python
class MultiomicsValue(Enum):
    mb = 0b10000
    mg = 0b01000
    mp = 0b00100
    mt = 0b00010
    om = 0b00001
```

A new schema for querying this information is also implemented:

```python
{
  "table": "biosample",
  "field": "multiomics",
  "op": "has",
  "value": 6
}
```
This will query for biosamples that have **both** metatranscriptome and metaproteomic omics_processing.  (They might have others as well.)

Implements the server side of #367.