### PR TITLE
Bulk download API

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -402,6 +402,19 @@ async def download_data_object(
     return RedirectResponse(url=url)
 
 
+@router.post(
+    "/data_object/workflow_summary",
+    response_model=schemas.DataObjectAggregation,
+    tags=["data_object"],
+    name="Aggregate data objects by workflow",
+)
+def data_object_aggregation(
+    query: query.DataObjectQuerySchema = query.DataObjectQuerySchema(),
+    db: Session = Depends(get_db),
+):
+    return crud.aggregate_data_object_by_workflow(db, query.conditions)
+
+
 # reads_qc
 @router.post(
     "/reads_qc/search",

--- a/nmdc_server/bulk_download_schema.py
+++ b/nmdc_server/bulk_download_schema.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+from nmdc_server.data_object_filters import DataObjectFilter
+from nmdc_server.query import ConditionSchema
+from nmdc_server.schemas import FileDownloadMetadata
+
+
+class BulkDownloadBase(FileDownloadMetadata):
+    conditions: List[ConditionSchema] = []
+    filter: List[DataObjectFilter] = []
+
+
+class BulkDownload(BulkDownloadBase):
+    id: UUID
+    created: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class BulkDownloadCreate(BulkDownloadBase):
+    pass

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -205,8 +205,14 @@ def delete_biosample(db: Session, biosample: models.Biosample) -> None:
     db.commit()
 
 
-def search_biosample(db: Session, conditions: List[query.ConditionSchema]) -> Query:
-    return query.BiosampleQuerySchema(conditions=conditions).execute(db)
+def search_biosample(
+    db: Session,
+    conditions: List[query.ConditionSchema],
+    data_object_filter: List[query.DataObjectFilter],
+) -> Query:
+    return query.BiosampleQuerySchema(
+        conditions=conditions, data_object_filter=data_object_filter
+    ).execute(db)
 
 
 def facet_biosample(

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from sqlalchemy.orm import Query, Session
 
 from nmdc_server import aggregations, bulk_download_schema, models, query, schemas
+from nmdc_server.data_object_filters import get_local_data_url
 
 logger = getLogger(__name__)
 NumericValue = query.NumericValue
@@ -519,7 +520,10 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
                 logger.warning(f"Data object url is {data_object.url}")
             continue
 
-        url = data_object.url.replace("https://data.microbiomedata.org", "")
+        url = get_local_data_url(data_object.url)
+        if url is None:
+            logger.warning("Unknown host in data url")
+            continue
 
         # TODO: add crc checksums to support retries
         # TODO: add directory structure and metadata

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -252,6 +252,12 @@ def delete_data_object(db: Session, data_object: models.DataObject) -> None:
     db.commit()
 
 
+def aggregate_data_object_by_workflow(
+    db: Session, conditions: List[query.ConditionSchema]
+) -> schemas.DataObjectAggregation:
+    return aggregations.get_data_object_aggregation(db, conditions)
+
+
 # readsqc
 def get_reads_qc(db: Session, reads_qc_id: str) -> Optional[models.ReadsQC]:
     return db.query(models.ReadsQC).filter(models.ReadsQC.id == reads_qc_id).first()

--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from pydantic import BaseModel
 
+from nmdc_server import models
+
 
 class WorkflowActivityTypeEnum(Enum):
     reads_qc = "nmdc:ReadQCAnalysisActivity"
@@ -14,6 +16,41 @@ class WorkflowActivityTypeEnum(Enum):
     nom_analysis = "nmdc:NomAnalysisActivity"
     metabolomics_analysis = "nmdc:MetabolomicsAnalysisActivity"
     raw_data = "nmdc:RawData"
+
+    @property
+    def model(self):
+        return _workflow_enum_to_model[self]
+
+    @property
+    def output_association(self):
+        return _workflow_enum_to_output_association[self]
+
+
+_workflow_enum_to_model = {
+    WorkflowActivityTypeEnum.reads_qc: models.ReadsQC,
+    WorkflowActivityTypeEnum.metagenome_assembly: models.MetagenomeAssembly,
+    WorkflowActivityTypeEnum.metagenome_annotation: models.MetagenomeAnnotation,
+    WorkflowActivityTypeEnum.metaproteomic_analysis: models.MetaproteomicAnalysis,
+    WorkflowActivityTypeEnum.mags_analysis: models.MAGsAnalysis,
+    WorkflowActivityTypeEnum.read_based_analysis: models.ReadBasedAnalysis,
+    WorkflowActivityTypeEnum.nom_analysis: models.NOMAnalysis,
+    WorkflowActivityTypeEnum.metabolomics_analysis: models.MetabolomicsAnalysis,
+    WorkflowActivityTypeEnum.raw_data: models.OmicsProcessing,
+}
+
+_mpa = WorkflowActivityTypeEnum.metaproteomic_analysis
+
+_workflow_enum_to_output_association = {
+    WorkflowActivityTypeEnum.reads_qc: models.reads_qc_output_association,
+    WorkflowActivityTypeEnum.metagenome_assembly: models.metagenome_assembly_output_association,
+    WorkflowActivityTypeEnum.metagenome_annotation: models.metagenome_annotation_output_association,
+    _mpa: models.metaproteomic_analysis_output_association,
+    WorkflowActivityTypeEnum.mags_analysis: models.mags_analysis_output_association,
+    WorkflowActivityTypeEnum.read_based_analysis: models.read_based_analysis_output_association,
+    WorkflowActivityTypeEnum.nom_analysis: models.nom_analysis_output_association,
+    WorkflowActivityTypeEnum.metabolomics_analysis: models.metabolomics_analysis_output_association,
+    WorkflowActivityTypeEnum.raw_data: models.omics_processing_output_association,
+}
 
 
 class DataObjectFilter(BaseModel):

--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -6,6 +6,25 @@ from pydantic import BaseModel
 from nmdc_server import models
 
 
+# Nginx's mod_zip can only server local files.  To get arround this limitation,
+# we set up local proxies to all remote hosts.
+#   https://www.nginx.com/resources/wiki/modules/zip/#remote-upstreams
+# This means that we can only handle known prefixes.  This must be checked
+# on ingest and any additional hosts added to the nginx config.
+# TODO: There is probably a way to automate this using nginx pattern matching.
+data_url_hosts = {
+    "https://data.microbiomedata.org/data": "/data",
+    "https://nmdcdemo.emsl.pnnl.gov": "/nmdcdemo",
+}
+
+
+def get_local_data_url(url: str) -> Optional[str]:
+    for k, v in data_url_hosts.items():
+        if url.startswith(k):
+            return url.replace(k, v)
+    return None
+
+
 class WorkflowActivityTypeEnum(Enum):
     reads_qc = "nmdc:ReadQCAnalysisActivity"
     metagenome_assembly = "nmdc:MetagenomeAssembly"

--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -1,0 +1,21 @@
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class WorkflowActivityTypeEnum(Enum):
+    reads_qc = "nmdc:ReadQCAnalysisActivity"
+    metagenome_assembly = "nmdc:MetagenomeAssembly"
+    metagenome_annotation = "nmdc:MetagenomeAnnotation"
+    metaproteomic_analysis = "nmdc:MetaProteomicAnalysis"
+    mags_analysis = "nmdc:MAGsAnalysisActivity"
+    read_based_analysis = "nmdc:ReadbasedAnalysis"
+    nom_analysis = "nmdc:NomAnalysisActivity"
+    metabolomics_analysis = "nmdc:MetabolomicsAnalysisActivity"
+    raw_data = "nmdc:RawData"
+
+
+class DataObjectFilter(BaseModel):
+    workflow: Optional[WorkflowActivityTypeEnum]
+    file_type: Optional[str]

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from datetime import datetime
+from enum import Enum
 import json
 from typing import Any, Iterator, Optional
 
@@ -184,6 +185,8 @@ def json_serializer(data: Any) -> str:
     def default_(val: Any) -> str:
         if isinstance(val, datetime):
             return val.isoformat()
+        elif isinstance(val, Enum):
+            return val.value
         raise TypeError(f"Cannot serialize {val}")
 
     return json.dumps(data, default=default_)

--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
-from typing import Dict
+from typing import Dict, Optional
 from uuid import UUID, uuid4
 
 from factory import Factory, Faker, lazy_attribute, post_generation, SubFactory
@@ -223,6 +223,7 @@ class DataObjectFactory(SQLAlchemyModelFactory):
     file_size_bytes = Faker("pyint")
     md5_checksum = Faker("md5", raw_output=False)
     omics_processing = SubFactory(OmicsProcessingFactory)
+    workflow_type: Optional[str] = None
 
 
 class PipelineStepBase(SQLAlchemyModelFactory):

--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -219,6 +219,7 @@ class DataObjectFactory(SQLAlchemyModelFactory):
     id: str = Faker("pystr")
     name: str = Faker("word")
     description: str = Faker("sentence")
+    file_type: str = Faker("word")
     file_size_bytes = Faker("pyint")
     md5_checksum = Faker("md5", raw_output=False)
     omics_processing = SubFactory(OmicsProcessingFactory)

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -199,6 +199,9 @@ class BiosampleFilter(BaseFilter):
             return self.join_envo(self.table, query)
         return super().join_self(query, parent)
 
+    def join_data_object(self, query: Query) -> Query:
+        return self.join_omics_processing(query)
+
 
 class EnvBroadScaleFilter(BiosampleFilter):
     table = Table.env_broad_scale

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -73,6 +73,7 @@ def load(db: Session, function_limit=None):
         db,
         mongodb["metabolomics_analysis_activity_set"].find(),
         pipeline.load_metabolomics_analysis,
+        "nmdc:MetabolomicsAnalysisActivity",
     )
     db.commit()
 
@@ -81,6 +82,7 @@ def load(db: Session, function_limit=None):
         db,
         mongodb["read_based_analysis_activity_set"].find(),
         pipeline.load_read_based_analysis,
+        "nmdc:ReadbasedAnalysis",
     )
     db.commit()
 
@@ -89,6 +91,7 @@ def load(db: Session, function_limit=None):
         db,
         mongodb["nom_analysis_activity_set"].find(),
         pipeline.load_nom_analysis,
+        "nmdc:NomAnalysisActivity",
     )
     db.commit()
 
@@ -97,6 +100,7 @@ def load(db: Session, function_limit=None):
         db,
         mongodb["mags_activity_set"].find(),
         pipeline.load_mags,
+        "nmdc:MAGsAnalysisActivity",
     )
     db.commit()
 
@@ -113,6 +117,7 @@ def load(db: Session, function_limit=None):
                 db,
                 bar,
                 pipeline.load_mg_annotation,
+                "nmdc:MetagenomeAnnotation",
                 annotations=mongodb["raw.functional_annotation_set"],
                 function_limit=function_limit,
             )
@@ -126,6 +131,7 @@ def load(db: Session, function_limit=None):
         db,
         mongodb["read_QC_analysis_activity_set"].find(),
         pipeline.load_reads_qc,
+        "nmdc:ReadQCAnalysisActivity",
     )
     db.commit()
 
@@ -137,6 +143,7 @@ def load(db: Session, function_limit=None):
                 no_cursor_timeout=True,
             ),
             pipeline.load_mp_analysis,
+            "nmdc:MetaProteomicAnalysis",
         )
         db.commit()
     except Exception:
@@ -149,6 +156,7 @@ def load(db: Session, function_limit=None):
         db,
         mongodb["metagenome_assembly_set"].find(),
         pipeline.load_mg_assembly,
+        "nmdc:MetagenomeAssembly",
     )
     db.commit()
 

--- a/nmdc_server/ingest/data_object.py
+++ b/nmdc_server/ingest/data_object.py
@@ -1,11 +1,14 @@
+from logging import getLogger
 from typing import Optional
 
 from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 
+from nmdc_server.data_object_filters import get_local_data_url
 from nmdc_server.models import DataObject
 from nmdc_server.schemas import DataObjectCreate
 
+logger = getLogger(__name__)
 file_type_map = {
     "fastq.gz": "Raw output file",
     "filterStats.txt": "Reads QC summary statistics",
@@ -35,6 +38,10 @@ def load(db: Session, cursor: Cursor):
 
         # TODO: Remove once the source data is fixed.
         url = obj.get("url", "")
+        if url and not get_local_data_url(url):
+            logger.warning(
+                f"Unknown url host '{url}', it need to be added to nginx config for bulk download"
+            )
         if url.startswith("https://data.microbiomedata.org") and not url.startswith(
             "https://data.microbiomedata.org/data"
         ):

--- a/nmdc_server/ingest/data_object.py
+++ b/nmdc_server/ingest/data_object.py
@@ -1,8 +1,31 @@
+from typing import Optional
+
 from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 
 from nmdc_server.models import DataObject
 from nmdc_server.schemas import DataObjectCreate
+
+file_type_map = {
+    "fastq.gz": "Raw output file",
+    "filterStats.txt": "Reads QC summary statistics",
+    "filtered.fastq.gz": "Reads QC result fastq (clean data)",
+    "mapping_stats.txt": "Assembled contigs coverage information",
+    "assembly_contigs.fna": "Final assembly contigs fasta",
+    "assembly_scaffolds.fna": "Final assembly scaffolds fasta",
+    "assembly.agp": "An AGP format file describes the assembly",
+    "pairedMapped_sorted.bam": "Sorted bam file of reads mapping back to the final assembly",
+    "KO TSV": "Tab delimited file for KO annotation.",
+    "EC TSV": "Tab delimited file for EC annotation.",
+    "Protein FAA": "FASTA amino acid file for annotated proteins.",
+}
+
+
+def derive_file_type(name: str) -> Optional[str]:
+    for pattern in sorted(file_type_map, key=lambda n: len(n), reverse=True):
+        if pattern in name:
+            return file_type_map[pattern]
+    return None
 
 
 def load(db: Session, cursor: Cursor):
@@ -18,5 +41,7 @@ def load(db: Session, cursor: Cursor):
             obj["url"] = url.replace(
                 "https://data.microbiomedata.org", "https://data.microbiomedata.org/data"
             )
+        if "file_type" not in obj:
+            obj["file_type"] = derive_file_type(obj["name"])
 
         db.add(DataObject(**obj))

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -52,6 +52,7 @@ def load_omics_processing(db: Session, obj: Dict[str, Any]):
             continue
 
         data_object.omics_processing = omics_processing
+        data_object.workflow_type = "nmdc:RawData"
         db.add(data_object)
         omics_processing.outputs.append(data_object)  # type: ignore
 

--- a/nmdc_server/ingest/pipeline.py
+++ b/nmdc_server/ingest/pipeline.py
@@ -135,7 +135,7 @@ load_metabolomics_analysis = generate_pipeline_loader(
 )
 
 
-def load(db: Session, cursor: Cursor, load_object: LoadObject, **kwargs):
+def load(db: Session, cursor: Cursor, load_object: LoadObject, workflow_type: str, **kwargs):
     remove_timezone_re = re.compile(r"Z\+\d+$", re.I)
 
     for obj in cursor:
@@ -179,6 +179,10 @@ def load(db: Session, cursor: Cursor, load_object: LoadObject, **kwargs):
 
         inputs = valid_inputs
         outputs = valid_outputs
+
+        for output in outputs:
+            output.workflow_type = workflow_type
+            db.add(output)
 
         db.flush()
         if inputs:

--- a/nmdc_server/migrations/versions/7f9314e44f22_bulk_download.py
+++ b/nmdc_server/migrations/versions/7f9314e44f22_bulk_download.py
@@ -1,0 +1,66 @@
+"""bulk download
+
+Revision ID: 7f9314e44f22
+Revises: 79a0b5695e7d
+Create Date: 2021-06-14 08:32:03.669322
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "7f9314e44f22"
+down_revision: Optional[str] = "79a0b5695e7d"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.create_table(
+        "bulk_download",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=False),
+        sa.Column("orcid", sa.String(), nullable=False),
+        sa.Column("ip", sa.String(), nullable=False),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column(
+            "conditions",
+            postgresql.JSONB(astext_type=sa.Text()),  # type: ignore
+            nullable=False,
+        ),
+        sa.Column(
+            "filter",
+            postgresql.JSONB(astext_type=sa.Text()),  # type: ignore
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_bulk_download")),
+    )
+    op.create_table(
+        "bulk_download_data_object",
+        sa.Column("bulk_download_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("data_object_id", sa.String(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["bulk_download_id"],
+            ["bulk_download.id"],
+            name=op.f("fk_bulk_download_data_object_bulk_download_id_bulk_download"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["data_object_id"],
+            ["data_object.id"],
+            name=op.f("fk_bulk_download_data_object_data_object_id_data_object"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "bulk_download_id", "data_object_id", name=op.f("pk_bulk_download_data_object")
+        ),
+    )
+    op.add_column("data_object", sa.Column("file_type", sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("data_object", "file_type")
+    op.drop_table("bulk_download_data_object")
+    op.drop_table("bulk_download")

--- a/nmdc_server/migrations/versions/c4d63f4206fb_add_file_type.py
+++ b/nmdc_server/migrations/versions/c4d63f4206fb_add_file_type.py
@@ -1,0 +1,35 @@
+"""add file type
+
+Revision ID: c4d63f4206fb
+Revises: 7f9314e44f22
+Create Date: 2021-06-17 09:11:53.621740
+
+"""
+from typing import Optional
+
+from alembic import op
+
+from nmdc_server.ingest.data_object import file_type_map
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d63f4206fb"
+down_revision: Optional[str] = "7f9314e44f22"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    for name in sorted(file_type_map, key=lambda n: len(n), reverse=True):
+        file_type = file_type_map[name]
+        op.execute(
+            f"""
+            update data_object
+            set file_type = '{file_type}'
+            where name like '%{name}%' and file_type is null
+        """
+        )
+
+
+def downgrade():
+    pass

--- a/nmdc_server/migrations/versions/da4a0d10abcf_add_workflow_type.py
+++ b/nmdc_server/migrations/versions/da4a0d10abcf_add_workflow_type.py
@@ -1,0 +1,52 @@
+"""add workflow type
+
+Revision ID: da4a0d10abcf
+Revises: c4d63f4206fb
+Create Date: 2021-06-17 09:58:59.127673
+
+"""
+from typing import Optional
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "da4a0d10abcf"
+down_revision: Optional[str] = "c4d63f4206fb"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+workflow_type_map = {
+    "reads_qc": "nmdc:ReadQCAnalysisActivity",
+    "metagenome_assembly": "nmdc:MetagenomeAssembly",
+    "metagenome_annotation": "nmdc:MetagenomeAnnotation",
+    "metaproteomic_analysis": "nmdc:MetaProteomicAnalysis",
+    "mags_analysis": "nmdc:MAGsAnalysisActivity",
+    "read_based_analysis": "nmdc:ReadbasedAnalysis",
+    "nom_analysis": "nmdc:NomAnalysisActivity",
+    "metabolomics_analysis": "nmdc:MetabolomicsAnalysisActivity",
+    "omics_processing": "nmdc:RawData",
+}
+
+
+def upgrade():
+    op.add_column("data_object", sa.Column("workflow_type", sa.String(), nullable=True))
+
+    for table, workflow in workflow_type_map.items():
+        op.execute(
+            f"""
+            update data_object
+            set workflow_type = '{workflow}'
+            from (
+                select d.id from
+                data_object d
+                join {table}_output_association a on d.id = a.data_object_id
+                join {table} t on t.id = a.{table}_id) as x
+            where data_object.id = x.id
+        """
+        )
+
+
+def downgrade():
+    op.drop_column("data_object", "workflow_type")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -274,7 +274,7 @@ class DataObject(Base):
     file_size_bytes = Column(BigInteger, nullable=False)
     md5_checksum = Column(String, nullable=True)
     url = Column(String, nullable=True)
-    # file_type = Column(String, nullable=True)
+    file_type = Column(String, nullable=True)
 
     # denormalized relationship representing the source omics_processing
     omics_processing_id = Column(String, ForeignKey("omics_processing.id"), nullable=True)
@@ -660,3 +660,40 @@ class MetaPGeneFunctionAggregation(Base):
             SET count = excluded.count, best_protein = excluded.best_protein;
         """
         )
+
+
+# Used to store a reference to a user requested zip download.  This is stored
+# in a table primarily to avoid a large query string in the zip download GET
+# endpoint.
+# TODO: consider expiring rows from this table
+class BulkDownload(Base):
+    __tablename__ = "bulk_download"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    # information about the requestor (as in the FileDownload table)
+    orcid = Column(String, nullable=False)
+    ip = Column(String, nullable=False)
+    user_agent = Column(String, nullable=True)
+
+    # the list of conditions on the biosample query `List[ConditionSchema]`
+    conditions = Column(JSONB, nullable=False)
+
+    # the filter on data objects `List[DataObjectFilter]`
+    filter = Column(JSONB, nullable=True)
+
+
+class BulkDownloadDataObject(Base):
+    __tablename__ = "bulk_download_data_object"
+
+    bulk_download_id = Column(UUID(as_uuid=True), ForeignKey(BulkDownload.id), primary_key=True)
+    data_object_id = Column(String, ForeignKey(DataObject.id), primary_key=True)
+
+    # the path inside the zip file
+    path = Column(String, nullable=False)
+
+    bulk_download = relationship(
+        BulkDownload, backref=backref("files", lazy="joined", cascade="all")
+    )
+    data_object = relationship(DataObject, lazy="joined", cascade="all")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -276,6 +276,9 @@ class DataObject(Base):
     url = Column(String, nullable=True)
     file_type = Column(String, nullable=True)
 
+    # denormalized relationship with a workflow activity output
+    workflow_type = Column(String, nullable=True)
+
     # denormalized relationship representing the source omics_processing
     omics_processing_id = Column(String, ForeignKey("omics_processing.id"), nullable=True)
     omics_processing = relationship(OmicsProcessing)

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -274,6 +274,7 @@ class DataObject(Base):
     file_size_bytes = Column(BigInteger, nullable=False)
     md5_checksum = Column(String, nullable=True)
     url = Column(String, nullable=True)
+    # file_type = Column(String, nullable=True)
 
     # denormalized relationship representing the source omics_processing
     omics_processing_id = Column(String, ForeignKey("omics_processing.id"), nullable=True)

--- a/nmdc_server/pagination.py
+++ b/nmdc_server/pagination.py
@@ -55,10 +55,10 @@ class Pagination:
             "Resource-Count": str(count),
         }
 
-    def response(self, query: orm.Query) -> PaginatedResponse:
+    def response(self, query: orm.Query, processor=lambda x: x) -> PaginatedResponse:
         count = query.count()
         self._response.headers.update(self.headers(query, count))
         return {
-            "results": list(self.paginate(query, count)),
+            "results": [processor(x) for x in self.paginate(query, count)],
             "count": count,
         }

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -8,12 +8,13 @@ from pydantic import BaseModel, PositiveInt
 from sqlalchemy import and_, ARRAY, cast, Column, func, inspect, or_
 from sqlalchemy.orm import Query, Session, with_expression
 from sqlalchemy.orm.util import AliasedClass
-from sqlalchemy.sql.expression import ClauseElement, intersect
+from sqlalchemy.sql.expression import ClauseElement, intersect, union
+from sqlalchemy.sql.selectable import CTE
 from typing_extensions import Literal
 
 from nmdc_server import binning, models, schemas
 from nmdc_server.binning import DateBinResolution
-from nmdc_server.data_object_filters import DataObjectFilter
+from nmdc_server.data_object_filters import DataObjectFilter, WorkflowActivityTypeEnum
 from nmdc_server.filters import create_filter_class
 from nmdc_server.multiomics import MultiomicsValue
 from nmdc_server.table import (
@@ -614,6 +615,77 @@ class MetabolomicsAnalysisQuerySchema(BaseQuerySchema):
     @property
     def table(self) -> Table:
         return Table.metabolomics_analysis
+
+
+class DataObjectAggregation(BaseModel):
+    count: int
+    size: int
+
+
+class DataObjectQuerySchema(BaseQuerySchema):
+    data_object_filter: List[DataObjectFilter] = []
+
+    def query(self, db: Session) -> Query:
+        omics_processing_qs = OmicsProcessingQuerySchema(conditions=self.conditions)
+        op_cte = omics_processing_qs.query(db).cte()
+
+        if not self.data_object_filter:
+            # shortcut to send back *all* files associated with the omics processing
+            # this uses the denormalized omics_processing_id on the data object table
+            return db.query(models.DataObject).join(
+                op_cte, models.DataObject.omics_processing_id == op_cte.c.id
+            )
+
+        subqueries = [
+            self._data_object_filter_subquery(db, f, op_cte) for f in self.data_object_filter
+        ]
+        union_query = union(*subqueries)  # type: ignore
+        return db.query(models.DataObject).join(
+            union_query, models.DataObject.id == union_query.c.id
+        )
+
+    def execute(self, db: Session) -> Query:
+        return self.query(db)
+
+    def _data_object_filter_subquery(
+        self, db: Session, filter: DataObjectFilter, op_cte: CTE
+    ) -> Query:
+        if filter.workflow is None:
+            query = db.query(models.DataObject.id.label("id")).join(
+                op_cte,
+                models.DataObject.omics_processing_id == op_cte.c.id,
+            )
+        elif filter.workflow == WorkflowActivityTypeEnum.raw_data:
+            query = (
+                db.query(models.DataObject.id.label("id"))
+                .join(
+                    models.omics_processing_output_association,
+                    models.omics_processing_output_association.c.data_object_id
+                    == models.DataObject.id,
+                )
+                .join(
+                    op_cte,
+                    models.omics_processing_output_association.c.omics_processing_id == op_cte.c.id,
+                )
+            )
+        else:
+            query = db.query(models.DataObject.id.label("id")).join(
+                filter.workflow.output_association,
+                filter.workflow.output_association.c.data_object_id == models.DataObject.id,
+            )
+
+        return query
+
+    def aggregate(self, db: Session) -> DataObjectAggregation:
+        subquery = self.query(db).subquery()
+        row = db.query(func.count(subquery.c.id), func.sum(subquery.c.file_size_bytes)).first()
+        if not row:
+            return DataObjectAggregation(count=0, size=0)
+        return DataObjectAggregation(count=row[0], size=row[1])
+
+    @property
+    def table(self) -> Table:
+        return Table.data_object
 
 
 class BaseSearchResponse(BaseModel):

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -681,7 +681,7 @@ class DataObjectQuerySchema(BaseQuerySchema):
         row = db.query(func.count(subquery.c.id), func.sum(subquery.c.file_size_bytes)).first()
         if not row:
             return DataObjectAggregation(count=0, size=0)
-        return DataObjectAggregation(count=row[0], size=row[1])
+        return DataObjectAggregation(count=row[0] or 0, size=row[1] or 0)
 
     @property
     def table(self) -> Table:

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -173,6 +173,14 @@ class EnvironmentGeospatialAggregation(BaseModel):
         orm_mode = True
 
 
+class DataObjectAggregationElement(BaseModel):
+    count: int = 0
+    file_types: Dict[str, int] = {}
+
+
+DataObjectAggregation = Dict[str, DataObjectAggregationElement]
+
+
 # study
 class StudyBase(AnnotatedBase):
     principal_investigator_websites: List[str] = []

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
@@ -534,7 +536,13 @@ MAGCreate.update_forward_refs()
 MetaprotemoicPeptide.update_forward_refs()
 
 
-class FileDownloadBase(BaseModel):
+class FileDownloadMetadata(BaseModel):
+    ip: str
+    user_agent: str
+    orcid: str
+
+
+class FileDownloadBase(FileDownloadMetadata):
     ip: str
     user_agent: str
     orcid: str

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -328,6 +328,10 @@ class DataObject(DataObjectBase):
         data_object: "DataObject",
         filters: List[DataObjectFilter],
     ) -> bool:
+        # we can't download files without urls
+        if not data_object.url:
+            return False
+
         # when no filters are provided, that means all data objects are selected
         if not filters:
             return True

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -338,9 +338,9 @@ class DataObject(DataObjectBase):
             return False
 
         def file_type_match(f, file_type) -> bool:
-            if f.file_type is None:
+            if f.file_type is None or f.file_type == file_type:
                 return True
-            return True
+            return False
 
         for f in filters:
             if workflow_match(f, workflow) and file_type_match(f, None):

--- a/nmdc_server/table.py
+++ b/nmdc_server/table.py
@@ -30,6 +30,7 @@ class Table(Enum):
     metabolomics_analysis = "metabolomics_analysis"
     gene_function = "gene_function"
     metap_gene_function = "metap_gene_function"
+    data_object = "data_object"
 
     env_broad_scale = "env_broad_scale"
     env_local_scale = "env_local_scale"
@@ -42,6 +43,16 @@ class Table(Enum):
         if self not in _table_model_map:
             raise Exception("Unknown table")
         return _table_model_map[self]
+
+
+DataObjectRaw = aliased(models.DataObject)
+DataObjectReadsQC = aliased(models.DataObject)
+DataObjectMetagenomeAssembly = aliased(models.DataObject)
+DataObjectMetagenomeAnnotation = aliased(models.DataObject)
+DataObjectMetaproteomicAnalysis = aliased(models.DataObject)
+DataObjectMagsAnalysis = aliased(models.DataObject)
+DataObjectReadBasedAnalysis = aliased(models.DataObject)
+DataObjectMetabolomicsAnalysis = aliased(models.DataObject)
 
 
 _table_model_map: Dict[Table, Union[models.ModelType, AliasedClass]] = {
@@ -62,6 +73,7 @@ _table_model_map: Dict[Table, Union[models.ModelType, AliasedClass]] = {
     Table.env_local_scale: EnvLocalScaleTerm,
     Table.env_medium: EnvMediumTerm,
     Table.principal_investigator: models.PrincipalInvestigator,
+    Table.data_object: models.DataObject,
 }
 
 workflow_execution_tables = {

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm.session import Session
 
 from nmdc_server import fakes, query
+from nmdc_server.data_object_filters import WorkflowActivityTypeEnum
 
 
 def test_bulk_download_query(db: Session):
@@ -9,11 +10,19 @@ def test_bulk_download_query(db: Session):
     op1 = fakes.OmicsProcessingFactory(biosample=sample)
     fakes.OmicsProcessingFactory(biosample=sample)
 
-    raw1 = fakes.DataObjectFactory(omics_processing=op1)
+    raw1 = fakes.DataObjectFactory(
+        url="https://data.microbiomedata.org/data/raw",
+        omics_processing=op1,
+        workflow_type=WorkflowActivityTypeEnum.raw_data.value,
+    )
     op1.outputs.append(raw1)
 
     metag = fakes.MetagenomeAnnotationFactory(omics_processing=op1)
-    metag_output = fakes.DataObjectFactory(omics_processing=op1)
+    metag_output = fakes.DataObjectFactory(
+        url="https://data.microbiomedata.org/data/metag",
+        omics_processing=op1,
+        workflow_type=WorkflowActivityTypeEnum.metagenome_annotation.value,
+    )
     metag.outputs.append(metag_output)
 
     db.commit()
@@ -38,13 +47,17 @@ def test_generate_bulk_download(db: Session, client: TestClient, token):
     fakes.OmicsProcessingFactory(biosample=sample)
 
     raw1 = fakes.DataObjectFactory(
-        omics_processing=op1, url="https://data.microbiomedata.org/data/raw"
+        url="https://data.microbiomedata.org/data/raw",
+        omics_processing=op1,
+        workflow_type=WorkflowActivityTypeEnum.raw_data.value,
     )
     op1.outputs.append(raw1)
 
     metag = fakes.MetagenomeAnnotationFactory(omics_processing=op1)
     metag_output = fakes.DataObjectFactory(
-        omics_processing=op1, url="https://data.microbiomedata.org/data/metag"
+        url="https://data.microbiomedata.org/data/metag",
+        omics_processing=op1,
+        workflow_type=WorkflowActivityTypeEnum.metagenome_annotation.value,
     )
     metag.outputs.append(metag_output)
 
@@ -71,13 +84,17 @@ def test_generate_bulk_download_filtered(db: Session, client: TestClient, token)
     fakes.OmicsProcessingFactory(biosample=sample)
 
     raw1 = fakes.DataObjectFactory(
-        omics_processing=op1, url="https://data.microbiomedata.org/data/raw"
+        url="https://data.microbiomedata.org/data/raw",
+        omics_processing=op1,
+        workflow_type=WorkflowActivityTypeEnum.raw_data.value,
     )
     op1.outputs.append(raw1)
 
     metag = fakes.MetagenomeAnnotationFactory(omics_processing=op1)
     metag_output = fakes.DataObjectFactory(
-        omics_processing=op1, url="https://data.microbiomedata.org/data/metag"
+        url="https://data.microbiomedata.org/data/metag",
+        omics_processing=op1,
+        workflow_type=WorkflowActivityTypeEnum.metagenome_annotation.value,
     )
     metag.outputs.append(metag_output)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -14,6 +14,7 @@ def test_bulk_download_query(db: Session):
         url="https://data.microbiomedata.org/data/raw",
         omics_processing=op1,
         workflow_type=WorkflowActivityTypeEnum.raw_data.value,
+        file_type="ftype1",
     )
     op1.outputs.append(raw1)
 
@@ -22,6 +23,7 @@ def test_bulk_download_query(db: Session):
         url="https://data.microbiomedata.org/data/metag",
         omics_processing=op1,
         workflow_type=WorkflowActivityTypeEnum.metagenome_annotation.value,
+        file_type="ftype2",
     )
     metag.outputs.append(metag_output)
 
@@ -36,6 +38,11 @@ def test_bulk_download_query(db: Session):
     }
 
     qs = query.DataObjectQuerySchema(data_object_filter=[{"workflow": "nmdc:RawData"}])
+    rows = qs.execute(db).all()
+    assert [raw1.id] == [d.id for d in rows]
+    assert qs.aggregate(db) == {"size": raw1.file_size_bytes, "count": 1}
+
+    qs = query.DataObjectQuerySchema(data_object_filter=[{"file_type": "ftype1"}])
     rows = qs.execute(db).all()
     assert [raw1.id] == [d.id for d in rows]
     assert qs.aggregate(db) == {"size": raw1.file_size_bytes, "count": 1}

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,102 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm.session import Session
+
+from nmdc_server import fakes, query
+
+
+def test_bulk_download_query(db: Session):
+    sample = fakes.BiosampleFactory()
+    op1 = fakes.OmicsProcessingFactory(biosample=sample)
+    fakes.OmicsProcessingFactory(biosample=sample)
+
+    raw1 = fakes.DataObjectFactory(omics_processing=op1)
+    op1.outputs.append(raw1)
+
+    metag = fakes.MetagenomeAnnotationFactory(omics_processing=op1)
+    metag_output = fakes.DataObjectFactory(omics_processing=op1)
+    metag.outputs.append(metag_output)
+
+    db.commit()
+
+    qs = query.DataObjectQuerySchema()
+    rows = qs.execute(db).all()
+    assert len(rows) == 2
+    assert qs.aggregate(db) == {
+        "size": raw1.file_size_bytes + metag_output.file_size_bytes,
+        "count": 2,
+    }
+
+    qs = query.DataObjectQuerySchema(data_object_filter=[{"workflow": "nmdc:RawData"}])
+    rows = qs.execute(db).all()
+    assert [raw1.id] == [d.id for d in rows]
+    assert qs.aggregate(db) == {"size": raw1.file_size_bytes, "count": 1}
+
+
+def test_generate_bulk_download(db: Session, client: TestClient, token):
+    sample = fakes.BiosampleFactory()
+    op1 = fakes.OmicsProcessingFactory(biosample=sample)
+    fakes.OmicsProcessingFactory(biosample=sample)
+
+    raw1 = fakes.DataObjectFactory(
+        omics_processing=op1, url="https://data.microbiomedata.org/data/raw"
+    )
+    op1.outputs.append(raw1)
+
+    metag = fakes.MetagenomeAnnotationFactory(omics_processing=op1)
+    metag_output = fakes.DataObjectFactory(
+        omics_processing=op1, url="https://data.microbiomedata.org/data/metag"
+    )
+    metag.outputs.append(metag_output)
+
+    db.commit()
+
+    resp = client.post("/api/bulk_download")
+    print(resp.content)
+    assert resp.status_code == 201
+    assert resp.json()["id"]
+    id_ = resp.json()["id"]
+
+    resp = client.post("/api/bulk_download/summary")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 2
+
+    resp = client.get(f"/api/bulk_download/{id_}")
+    assert resp.status_code == 200
+    assert b"/raw" in resp.content and b"/metag" in resp.content
+
+
+def test_generate_bulk_download_filtered(db: Session, client: TestClient, token):
+    sample = fakes.BiosampleFactory()
+    op1 = fakes.OmicsProcessingFactory(biosample=sample)
+    fakes.OmicsProcessingFactory(biosample=sample)
+
+    raw1 = fakes.DataObjectFactory(
+        omics_processing=op1, url="https://data.microbiomedata.org/data/raw"
+    )
+    op1.outputs.append(raw1)
+
+    metag = fakes.MetagenomeAnnotationFactory(omics_processing=op1)
+    metag_output = fakes.DataObjectFactory(
+        omics_processing=op1, url="https://data.microbiomedata.org/data/metag"
+    )
+    metag.outputs.append(metag_output)
+
+    db.commit()
+
+    filter = [
+        {
+            "workflow": "nmdc:MetagenomeAnnotation",
+        }
+    ]
+    resp = client.post("/api/bulk_download", json={"data_object_filter": filter})
+    assert resp.status_code == 201
+    assert resp.json()["id"]
+    id_ = resp.json()["id"]
+
+    resp = client.post("/api/bulk_download/summary", json={"data_object_filter": filter})
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+    resp = client.get(f"/api/bulk_download/{id_}")
+    assert resp.status_code == 200
+    assert b"/raw" not in resp.content and b"/metag" in resp.content

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -38,5 +38,9 @@ http {
         location /data/ {
             proxy_pass http://data:8080/;
         }
+
+        location /nmdcdemo/ {
+            proxy_pass https://nmdcdemo.emsl.pnnl.gov/;
+        }
     }
 }


### PR DESCRIPTION
fixes #354

I still want to do a little more refinement of this before merging.  Hopefully, @subdavis can look it over before then and see if it matches his expectations of the UI.  

Biosample search
================

This changes the biosample search endpoint to include a new data_object_filter attribute, e.g.:
```json
{
  "conditions": [],
  "data_object_filter": [{"workflow": "nmdc:ReadQCAnalysisActivity", "file_type": "fastqc"}]
}
```
Each filter object contains an optional workflow enum and file type (currently ignored until we get data for it).  A workflow is one of the following:
```
nmdc:ReadQCAnalysisActivity
nmdc:MetagenomeAssembly
nmdc:MetagenomeAnnotation
nmdc:MetaProteomicAnalysis
nmdc:MAGsAnalysisActivity
nmdc:ReadbasedAnalysis
nmdc:NomAnalysisActivity
nmdc:MetabolomicsAnalysisActivity
nmdc:RawData
```
It specifies which workflow the file was generated from (`nmdc:RawData` indicates it is an output of the omics_processing).  Further, if the object contains no workflow attribute, then it will match any workflow.  This could be useful to get a file type from any workflow.  If the file type is missing, then it will match all files.

Multiple filters are joined together as an `or` condition.  No filter object will match *all* files associated with the query.

Data objects in the biosample search result will now have an additional attribute `selected` indicating if the data object was selected by the filter.

File type aggregation
=====================

One new endpoint is added to aggregate matching data objects by workflow and file type to populate the data filter UI.
```
POST /data_object/workflow_summary {"conditions": [...]}
=> {
  "nmdc:ReadQCAnalysisActivity": {
    "count": 2,
    "file_types": {
      "Reads QC result fastq (clean data)": 1,
      "Reads QC summary statistics": 1
    }
  },
  "nmdc:MetagenomeAssembly": {
    "count": 5,
    "file_types": {
      "An AGP format file describes the assembly": 1,
      "Assembled contigs coverage information": 1,
      "Final assembly contigs fasta": 1,
      "Final assembly scaffolds fasta": 1,
      "Sorted bam file of reads mapping back to the final assembly": 1
    }
  },
  "nmdc:MetagenomeAnnotation": {
    "count": 5,
    "file_types": {
      "FASTA amino acid file for annotated proteins.": 1,
      "Tab delimited file for EC annotation.": 1,
      "Tab delimited file for KO annotation.": 1
    }
  },
  "nmdc:MetaProteomicAnalysis": {
    "count": 4,
    "file_types": {}
  },
  "nmdc:MAGsAnalysisActivity": {
    "count": 5,
    "file_types": {}
  },
  "nmdc:ReadbasedAnalysis": {
    "count": 9,
    "file_types": {}
  },
  "nmdc:NomAnalysisActivity": {
    "count": 0,
    "file_types": {}
  },
  "nmdc:MetabolomicsAnalysisActivity": {
    "count": 1,
    "file_types": {}
  },
  "nmdc:RawData": {
    "count": 5,
    "file_types": {
      "Raw output file": 1
    }
  }
}
```
Note: The file types are just place holders based on descriptions and many are missing.  Once this information is populated from the source data, the file_types dict should be complete.

Bulk download endpoints
=======================

Three new endpoints were added to support bulk downloads.  They use the same schemas as the biosample search endpoint.

Summarize the matching files:
```
POST /bulk_download/summary {"conditions": [...], "data_object_filter": [...]}
=> {"count": 26, "size": 2354243523}
```

Create a bulk download entity:
```
POST /bulk_download {"conditions": [...], "data_object_filter": [...]}
=> {"id": "19ad618e-453a-4bd8-a59b-89dee46a1aff", ...}
```

Download the data:
```
GET /bulk_download/:id
```

I expect the client side workflow here to be:
1. Generate a list of conditions in the usual way
2. Populate the data filter dialog using the workflow summary endpoint
3. Add additional data_object filters from the new ui
4. Get summary information and display it in the ui
5. Have a button somewhere to generate a download link (this will call the post endpoint)
6. Show the download link

I made the download a two step process for two reasons.  One, the actual download needs to be a GET request and packing too much into query strings is ugly.  Two, so I can store the actual list of files in a table.  With an explicit table, I can more easily track download statistics and the results of the GET request can't change with a new data ingest (perhaps important for retrying long running downloads).
