### PR TITLE
Client/bulk download

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: postgres:12
     volumes:
       - app-db-data:/var/lib/postgresql/data/pgdata
+      - ./nmdc.pgdump:/tmp/nmdc.pgdump
     env_file:
       - .docker-env
     environment:

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -2,13 +2,13 @@ import logging
 from typing import Any, Dict, Iterator
 
 import click
+from nmdc_server import models
+from nmdc_server.config import Settings
+from nmdc_server.ingest import (biosample, data_object, envo, omics_processing,
+                                pipeline, study)
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from sqlalchemy.orm import Session
-
-from nmdc_server import models
-from nmdc_server.config import Settings
-from nmdc_server.ingest import biosample, data_object, envo, omics_processing, pipeline, study
 
 logger = logging.getLogger(__name__)
 

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -2,13 +2,13 @@ import logging
 from typing import Any, Dict, Iterator
 
 import click
-from nmdc_server import models
-from nmdc_server.config import Settings
-from nmdc_server.ingest import (biosample, data_object, envo, omics_processing,
-                                pipeline, study)
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from sqlalchemy.orm import Session
+
+from nmdc_server import models
+from nmdc_server.config import Settings
+from nmdc_server.ingest import biosample, data_object, envo, omics_processing, pipeline, study
 
 logger = logging.getLogger(__name__)
 

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -30,9 +30,6 @@ http {
             proxy_set_header Host ${DOLLAR}host;
             proxy_set_header X-Real-IP ${DOLLAR}remote_addr;
             proxy_set_header X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
-
-            proxy_set_header Accept-Encoding "";
-            proxy_hide_header X-Archive-Files;
         }
 
         location /data/ {

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -52,6 +52,7 @@ export default Vue.extend({
       :length="Math.ceil(count / itemsPerPage)"
       :total-visible="7"
       class="pt-3"
+      depressed
       @input="$emit('set-page', $event)"
     />
     <v-list dense>

--- a/web/src/v2/components/BulkDownload.vue
+++ b/web/src/v2/components/BulkDownload.vue
@@ -1,0 +1,107 @@
+<script lang="ts">
+import { computed, defineComponent } from '@vue/composition-api';
+import { stateRefs, dataObjectFilter } from '@/v2/store';
+// @ts-ignore
+import Treeselect from '@riophae/vue-treeselect';
+import useBulkDownload from '@/v2/use/useBulkDownload';
+import { humanFileSize } from '@/data/utils';
+
+export default defineComponent({
+  components: { Treeselect },
+  setup() {
+    const {
+      downloadSummary,
+      downloadOptions,
+      download,
+    } = useBulkDownload(stateRefs.conditions, dataObjectFilter);
+
+    const options = computed(() => Object.entries(downloadOptions.value)
+      .map(([key, val]) => ({
+        id: key,
+        label: `${key} (${val.count})`,
+        children: Object.entries(val.file_types).map(([filetype, count]) => ({
+          id: `${key}::${filetype}`,
+          label: `${filetype} (${count})`,
+        })),
+      })));
+
+    async function createAndDownload() {
+      const val = await download();
+      window.location.assign(val.url);
+    }
+
+    return {
+      bulkDownloadSelected: stateRefs.bulkDownloadSelected,
+      options,
+      downloadSummary,
+      createAndDownload,
+      humanFileSize,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-card
+    outlined
+    class="pa-3 d-flex flex-column align-end"
+    color="primary"
+  >
+    <span
+      class="text-caption font-weight-bold white--text"
+    >
+      <template v-if="downloadSummary.count === 0">
+        No files selected
+      </template>
+      <template v-else>
+        Total {{ downloadSummary.count }} files
+        (Download archive size {{ humanFileSize(downloadSummary.size) }})
+      </template>
+    </span>
+    <div class="d-flex flex-row align-center">
+      <div class="white--text pr-2 text-caption grow font-weight-bold">
+        Bulk Download
+      </div>
+      <v-tooltip
+        left
+        nudge-bottom="20px"
+        min-width="300px"
+        max-width="300px"
+      >
+        <template #activator="{ on, attrs }">
+          <v-icon
+            small
+            color="white"
+            v-bind="attrs"
+            class="pr-2"
+            v-on="on"
+          >
+            mdi-help-circle
+          </v-icon>
+        </template>
+        <span>
+          Choose a group of files to download based on file type
+          from the currently filtered search results.
+        </span>
+      </v-tooltip>
+      <Treeselect
+        v-model="bulkDownloadSelected"
+        multiple
+        value-consists-of="LEAF_PRIORITY"
+        open-direction="below"
+        :options="options"
+      />
+      <v-btn
+        class="ml-3"
+        color="white"
+        depressed
+        @click="createAndDownload"
+      >
+        Download ZIP
+        <v-icon class="pl-3">
+          mdi-download
+        </v-icon>
+      </v-btn>
+    </div>
+  </v-card>
+</template>

--- a/web/src/v2/components/DataObjectTable.vue
+++ b/web/src/v2/components/DataObjectTable.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  defineComponent, PropType, reactive,
+  computed, defineComponent, PropType, reactive,
 } from '@vue/composition-api';
 import { flattenDeep } from 'lodash';
 
@@ -36,6 +36,10 @@ export default defineComponent({
       required: true,
     },
     loggedInUser: {
+      type: Boolean,
+      default: false,
+    },
+    showBulk: {
       type: Boolean,
       default: false,
     },
@@ -85,7 +89,7 @@ export default defineComponent({
       value: false,
     });
 
-    const items = flattenDeep(
+    const items = computed(() => flattenDeep(
       flattenDeep(props.omicsProcessing.map((p) => (
         /* Uncomment (and wrap with array) to enable raw data objects */
         /* {
@@ -111,7 +115,7 @@ export default defineComponent({
             object_description: descriptionMap[object_type] || '',
           };
         })),
-    );
+    ));
 
     function download(item: OmicsProcessingResult) {
       if (typeof item.url === 'string') {
@@ -169,7 +173,14 @@ export default defineComponent({
           </td>
         </tr>
         <tr>
-          <td />
+          <td>
+            <v-icon
+              v-if="showBulk"
+              :style="{ visibility: item.selected ? 'visible' : 'hidden'}"
+            >
+              mdi-checkbox-marked-circle-outline
+            </v-icon>
+          </td>
           <td>{{ item.object_type }}</td>
           <td>{{ item.object_description }}</td>
           <td>{{ humanFileSize(item.file_size_bytes ) }}</td>

--- a/web/src/v2/components/SampleListExpansion.vue
+++ b/web/src/v2/components/SampleListExpansion.vue
@@ -89,6 +89,7 @@ export default defineComponent({
         :omics-processing="projects"
         :omics-type="omicsType"
         :logged-in-user="loggedInUser"
+        :show-bulk="loggedInUser"
       />
     </template>
   </div>

--- a/web/src/v2/components/TooltipCard.vue
+++ b/web/src/v2/components/TooltipCard.vue
@@ -29,7 +29,7 @@ export default defineComponent({
       <template #activator="{ on, attrs }">
         <v-icon
           v-bind="attrs"
-          style="position: absolute; right: 6px; top: 6px; z-index: 20;"
+          style="position: absolute; right: 6px; top: 6px; z-index: 2;"
           v-on="on"
         >
           mdi-help-circle

--- a/web/src/v2/store/index.ts
+++ b/web/src/v2/store/index.ts
@@ -1,19 +1,31 @@
 import Vue from 'vue';
-import CompositionApi, { reactive, toRefs } from '@vue/composition-api';
+import CompositionApi, {
+  computed, ComputedRef, reactive, toRefs,
+} from '@vue/composition-api';
 import { uniqWith } from 'lodash';
 
 import { removeCondition as utilsRemoveCond } from '@/data/utils';
-import { api, Condition } from '@/data/api';
+import { api, Condition, DataObjectFilter } from '@/data/api';
 
 // TODO: Remove in version 3;
 Vue.use(CompositionApi);
 
 const state = reactive({
   conditions: [] as Condition[],
+  bulkDownloadSelected: [] as string[],
   user: null as string | null,
   hasAcceptedTerms: false,
 });
-const stateRefs = toRefs(state);
+
+/**
+ * An array of DataObjectFilter currently selected
+ */
+const dataObjectFilter: ComputedRef<DataObjectFilter[]> = computed(() => state
+  .bulkDownloadSelected.map((val) => {
+    /** See BulkDownload.vue for how this value is constructed */
+    const [workflow, file_type] = val.split('::');
+    return { workflow, file_type };
+  }));
 
 /**
  * load the current user on app start
@@ -95,8 +107,11 @@ function acceptTerms() {
   state.hasAcceptedTerms = true;
 }
 
+const stateRefs = toRefs(state);
+
 export {
   stateRefs,
+  dataObjectFilter,
   acceptTerms,
   loadCurrentUser,
   removeConditions,

--- a/web/src/v2/use/useBulkDownload.ts
+++ b/web/src/v2/use/useBulkDownload.ts
@@ -1,0 +1,55 @@
+import { Ref, ref, watch } from '@vue/composition-api';
+import {
+  api, BulkDownload, BulkDownloadAggregateSummary, BulkDownloadSummary, Condition, DataObjectFilter,
+} from '@/data/api';
+import useRequest from './useRequest';
+
+/**
+ * Encapsulates API and state for bulk download.
+ */
+export default function useBulkDownload(
+  conditions: Ref<Condition[]>,
+  dataObjectFilter: Ref<DataObjectFilter[]>,
+) {
+  const downloadOptions = ref({} as BulkDownloadSummary);
+  const bulkDownloads = ref([] as BulkDownload[]);
+  const { loading, error, request } = useRequest();
+  const downloadSummary = ref({
+    count: 0,
+    size: 0,
+  } as BulkDownloadAggregateSummary);
+
+  async function download() {
+    return request(async () => {
+      const val = await api.createBulkDownload(conditions.value, dataObjectFilter.value);
+      bulkDownloads.value.push(val);
+      return val;
+    });
+  }
+
+  async function getSummary() {
+    downloadSummary.value = await api.getBulkDownloadAggregateSummary(
+      conditions.value,
+      dataObjectFilter.value,
+    );
+  }
+
+  async function getDownloadOptions() {
+    downloadOptions.value = await api.getBulkDownloadSummary(conditions.value);
+  }
+
+  watch([conditions, dataObjectFilter], getSummary);
+  watch([conditions], getDownloadOptions);
+
+  getDownloadOptions();
+  getSummary();
+
+  return {
+    bulkDownloads,
+    downloadOptions,
+    downloadSummary,
+    error,
+    loading,
+    download,
+  };
+}

--- a/web/src/v2/use/useClockGate.ts
+++ b/web/src/v2/use/useClockGate.ts
@@ -1,6 +1,13 @@
 /**
- * useActiveConditions uses a boolean ref as a clock gate
- * for some other bit of reactive state.
+ * useClickGate uses a boolean ref as a clock gate
+ * for some other bit of reactive state.  This isn't
+ * actually realated to time, it's just the name for this
+ * kind of boolean logic.
+ *
+ * In other words, useClockGate reutrns a reactive var
+ * that only updates when the clock is true. The trick is to
+ * cache changes that happen while the clock is false so the
+ * state can change if clock changes.
  *
  * https://en.wikipedia.org/wiki/Clock_gating
  */

--- a/web/src/v2/use/useRequest.ts
+++ b/web/src/v2/use/useRequest.ts
@@ -1,0 +1,31 @@
+/**
+ * useRequest adds loading and error state to any sort of
+ * API request you might need.
+ */
+
+import { ref } from '@vue/composition-api';
+
+export default function useRequest() {
+  const loading = ref(false);
+  const error = ref(null);
+
+  async function request<T>(func: () => Promise<T>) {
+    try {
+      loading.value = true;
+      error.value = null;
+      const val = await func();
+      loading.value = false;
+      return val;
+    } catch (err) {
+      loading.value = false;
+      error.value = err;
+      throw err;
+    }
+  }
+
+  return {
+    loading,
+    error,
+    request,
+  };
+}


### PR DESCRIPTION
fixes #354 

I decided to try something a little more noticeable with the bulk download area.  This is an important feature, but it's also very separate from the controls in the rest of the page, so I wanted to make it stand out in a way that looks separarate.

I can switch it back to the [original mockup](https://www.figma.com/file/0asbM3ww4PyYv3G6iCS4MG/Bulk-Download?node-id=0%3A1) if people prefer that.

 - [ ] Not working locally, not sure if it will work once it's deployed
 - [ ] Need to invert default from all selected to none selected
 - [ ] Currently filled with dummy file types.

![Screenshot from 2021-06-23 15-35-19](https://user-images.githubusercontent.com/4214172/123157840-08281100-d439-11eb-8195-cd2476d5610f.png)
![Screenshot from 2021-06-23 15-37-16](https://user-images.githubusercontent.com/4214172/123157838-08281100-d439-11eb-9ea2-1717e4de0ab4.png)
![Screenshot from 2021-06-23 15-35-44](https://user-images.githubusercontent.com/4214172/123157839-08281100-d439-11eb-8e58-49893b9d8875.png)
