### PR TITLE
Switch description and type

### DIFF
--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -57,6 +57,9 @@ export interface BiosampleSearchResult extends BaseSearchResult {
 export interface DataObjectSearchResult extends BaseSearchResult {
   file_size_bytes: number;
   md5_checksum: string;
+  file_type: string;
+  file_type_description: string;
+  url: string;
 
   // download count
   downloads: number;

--- a/web/src/v2/components/DataObjectTable.vue
+++ b/web/src/v2/components/DataObjectTable.vue
@@ -90,31 +90,14 @@ export default defineComponent({
     });
 
     const items = computed(() => flattenDeep(
-      flattenDeep(props.omicsProcessing.map((p) => (
-        /* Uncomment (and wrap with array) to enable raw data objects */
-        /* {
-          name: 'Raw',
-          project_id: p.project_id,
-          outputs: p.outputs,
-        }, */ p.omics_data)))
-        .map((omics_data) => omics_data.outputs.map((data_object, i) => {
-          const object_type = data_object.name
-            .replace(`${omics_data.omics_processing_id}_`, '')
-            .replace(/file/ig, '')
-            .replace(/([ACTG]+-?)+\./, '') /* Raw ACTG-ACTG.fastq.gz */
-            .replace('output: ', '')
-            .replace(/(\d+_?)+\.?/ig, '') /* dddd_dddd */
-            .replace(/(^\s+|\s+$)/g, ''); /* trim whitespace */
-          return {
-            ...data_object,
-            omics_data,
-            /* TODO Hack to replace metagenome with omics type name */
-            group_name: omics_data.name.replace('Metagenome', props.omicsType),
-            newgroup: i === 0,
-            object_type,
-            object_description: descriptionMap[object_type] || '',
-          };
-        })),
+      flattenDeep(props.omicsProcessing.map((p) => (p.omics_data)))
+        .map((omics_data) => omics_data.outputs.map((data_object, i) => ({
+          ...data_object,
+          omics_data,
+          /* TODO Hack to replace metagenome with omics type name */
+          group_name: omics_data.name.replace('Metagenome', props.omicsType),
+          newgroup: i === 0,
+        }))),
     ));
 
     function download(item: OmicsProcessingResult) {
@@ -190,8 +173,8 @@ export default defineComponent({
               <span>This file is included in the currently selected bulk download</span>
             </v-tooltip>
           </td>
-          <td>{{ item.object_type }}</td>
-          <td>{{ item.object_description }}</td>
+          <td>{{ item.file_type || item.name }}</td>
+          <td>{{ item.file_type_description || item.description }}</td>
           <td>{{ humanFileSize(item.file_size_bytes ) }}</td>
           <td>{{ item.downloads }}</td>
           <td>


### PR DESCRIPTION
I've noticed that some still don't have a `file_type` and `file_type_description`.  To prevent these from being blank, I fallback on `name` and `description`.

However, for these types, it is impossible to include these files in bulk download.  For example, these files in MAGs Analysis:

You can download `metagenome bins` and `checkm statistics` but the `bins.*` files have no `file_type` and `file_type_description` and cannot be selected.

![Screenshot from 2021-07-01 17-19-13](https://user-images.githubusercontent.com/4214172/124190618-95e6aa80-da90-11eb-81a6-4f48186c4e71.png)
![Screenshot from 2021-07-01 17-18-56](https://user-images.githubusercontent.com/4214172/124190619-95e6aa80-da90-11eb-9b57-44ab372b56ef.png)
