### PR TITLE
Expose postgres to host in development configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,3 +4,7 @@ services:
     volumes:
       - "./nmdc_server:/app/nmdc_server"
     command: /start-reload.sh
+
+  db:
+    ports:
+      - 5432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - "8000:8000"
 
   web:
-    depends_on: 
+    depends_on:
       - backend
       - data
     env_file:


### PR DESCRIPTION
This allows the use of alembic command line from the host, and the postgres shell.