### PR TITLE
Prune Envo tree

### DIFF
--- a/tests/test_envo.py
+++ b/tests/test_envo.py
@@ -33,5 +33,5 @@ def test_envo_tree(envo_data, db: Session):
     trees = nested_envo_trees()
     assert set(trees.keys()) == {"env_broad_scale_id", "env_local_scale_id", "env_medium_id"}
     assert trees["env_broad_scale_id"].label == "ecosystem"
-    assert trees["env_local_scale_id"].label == "geographic feature"
+    assert trees["env_local_scale_id"].label == "astronomical body part"
     assert trees["env_medium_id"].label == "environmental material"


### PR DESCRIPTION
Remove all parts of the tree that are unreachable based on the set of terms present in the biosample table.

This is an improvement but not the final goal. In the current dataset, there are biosamples whose envo values do not fall under the three roots we've manually identified. So, this tree does not span the entire biosample set, but it does span most of it.

A more robust solution will involve more analysis of the dataset to comprehensively identify all roots and return an array of root nodes for each of the three facets.