### PR TITLE
Basic ipython shell helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 First, install [ldc](https://github.com/Kitware/ldc)
 
 In order to populate the database, you must create a `.env` file in the top
-level directory containing mongo credentials.  
+level directory containing mongo credentials.
 
 ```bash
 # .env
@@ -114,3 +114,14 @@ commands as usual, e.g.
 ```bash
 alembic -c nmdc_server/alembic.ini revision --autogenerate
 ```
+
+### Developing with the shell
+
+A handy IPython shell is provided with some commonly used symbols automatically
+imported, and `autoreload 2` enabled. To run it:
+
+```bash
+ldc dev run --rm backend nmdc-server shell
+```
+
+You can also pass `--print-sql` to output all SQL queries.

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -76,3 +76,33 @@ def ingest(verbose, function_limit):
         click.echo(f"errors {m}:")
         for id in s:
             click.echo(id)
+
+
+@cli.command()
+@click.option("--print-sql", is_flag=True, default=False)
+def shell(print_sql: bool):
+    from IPython import start_ipython
+    from traitlets.config import Config
+
+    imports = [
+        "from nmdc_server.database import create_session",
+        "from nmdc_server.config import settings",
+        "from nmdc_server.models import "
+        "Biosample, EnvoAncestor, EnvoTerm, EnvoTree, OmicsProcessing, Study",
+    ]
+
+    print("The following are auto-imported:")
+    for line in imports:
+        print(f"\033[1;32m{line}\033[0;0m")
+
+    exec_lines = ["%autoreload 2"] + imports
+
+    if print_sql:
+        exec_lines.append("settings.print_sql = True")
+        print("SQL debugging is ON")
+
+    c = Config()
+    c.InteractiveShellApp.exec_lines = exec_lines
+    c.InteractiveShellApp.extensions = ["autoreload"]
+
+    start_ipython(argv=[], config=c)

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -1,4 +1,6 @@
 import logging
+from pathlib import Path
+from typing import Optional
 
 import click
 
@@ -80,13 +82,14 @@ def ingest(verbose, function_limit):
 
 @cli.command()
 @click.option("--print-sql", is_flag=True, default=False)
-def shell(print_sql: bool):
+@click.argument("script", required=False, type=click.Path(exists=True, dir_okay=False))
+def shell(print_sql: bool, script: Optional[Path]):
     from IPython import start_ipython
     from traitlets.config import Config
 
     imports = [
-        "from nmdc_server.database import create_session",
         "from nmdc_server.config import settings",
+        "from nmdc_server.database import create_session",
         "from nmdc_server.models import "
         "Biosample, EnvoAncestor, EnvoTerm, EnvoTree, OmicsProcessing, Study",
     ]
@@ -104,5 +107,8 @@ def shell(print_sql: bool):
     c = Config()
     c.InteractiveShellApp.exec_lines = exec_lines
     c.InteractiveShellApp.extensions = ["autoreload"]
+
+    if script:
+        c.InteractiveShellApp.file_to_run = script
 
     start_ipython(argv=[], config=c)

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
 
     sentry_dsn: Optional[str] = None
 
+    print_sql: bool = False
+
     @property
     def current_db_uri(self) -> str:
         if self.environment == "testing":

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -195,7 +195,7 @@ def json_serializer(data: Any) -> str:
 
 @functools.lru_cache(maxsize=None)
 def create_engine(uri: str) -> Engine:
-    return _create_engine(uri, json_serializer=json_serializer)
+    return _create_engine(uri, json_serializer=json_serializer, echo=settings.print_sql)
 
 
 @contextmanager

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "fastapi",
         "factory-boy",
         "httpx<0.18.2",
+        "ipython",
         "itsdangerous",
         "pint",
         "psycopg2-binary",


### PR DESCRIPTION
Here's my cheap attempt at a poor man's version of Django's `shell_plus` in this stack. It gives us some free imports, and a SQL debugging option. Next step would be to add a way to pass it a script, or to make all the ipython options generally more configurable via pass-through.