### PR TITLE
Upset click

### DIFF
--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -2,6 +2,7 @@
 import { defineComponent, watchEffect, ref } from '@vue/composition-api';
 import { select } from 'd3-selection';
 import { scaleBand, scaleLinear } from 'd3-scale';
+import { MultiomicsValue } from '@/encoding';
 
 export default defineComponent({
   props: {
@@ -10,10 +11,6 @@ export default defineComponent({
       required: true,
     },
     tooltips: {
-      type: Object,
-      required: true,
-    },
-    valueMap: {
       type: Object,
       required: true,
     },
@@ -157,12 +154,16 @@ export default defineComponent({
               .attr('fill', root.$vuetify.theme.currentTheme.blue)
               .classed('upset-bar-clickable', true)
               .on('click', (event, values) => {
-                const conditions = values.sets.map((v) => ({
-                  table: 'omics_processing',
-                  field: 'omics_type',
-                  value: props.valueMap[v],
-                  op: '==',
-                }));
+                const value = values.sets.reduce((prev, cur) => {
+                  const next = prev | MultiomicsValue[cur]; //eslint-disable-line no-bitwise
+                  return next;
+                }, 0);
+                const conditions = [{
+                  field: 'multiomics',
+                  table: 'biosample',
+                  op: 'has',
+                  value,
+                }];
                 emit('select', { conditions });
               });
             parent.append('text')

--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -13,6 +13,10 @@ export default defineComponent({
       type: Object,
       required: true,
     },
+    valueMap: {
+      type: Object,
+      required: true,
+    },
     order: {
       type: String,
       required: true,
@@ -27,7 +31,7 @@ export default defineComponent({
     },
   },
 
-  setup(props, { root }) {
+  setup(props, { root, emit }) {
     const svgRoot = ref(undefined);
 
     const margin = {
@@ -150,7 +154,17 @@ export default defineComponent({
               .attr('y', (d, i) => y(i))
               .attr('width', (d) => barX(d.counts[count]))
               .attr('height', y.bandwidth())
-              .attr('fill', root.$vuetify.theme.currentTheme.blue);
+              .attr('fill', root.$vuetify.theme.currentTheme.blue)
+              .classed('upset-bar-clickable', true)
+              .on('click', (event, values) => {
+                const conditions = values.sets.map((v) => ({
+                  table: 'omics_processing',
+                  field: 'omics_type',
+                  value: props.valueMap[v],
+                  op: '==',
+                }));
+                emit('select', { conditions });
+              });
             parent.append('text')
               .attr('class', 'count')
               .attr('x', (d) => countsX(count) + barX(d.counts[count]) + 3)
@@ -172,6 +186,15 @@ export default defineComponent({
   },
 });
 </script>
+
+<style>
+.upset-bar-clickable {
+  cursor: pointer;
+}
+.upset-bar-clickable:hover {
+  fill: rgba(0, 0, 0, .5) !important;
+}
+</style>
 
 <template>
   <svg ref="svgRoot" />

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -208,9 +208,10 @@ export interface EnvironmentSankeyResponse {
   [index: number]: EnvironmentSankeyEntity;
 }
 
-export type opType = 'between' | '<' | '<=' | '>' | '>=' | '==' | '!=';
+export type opType = 'between' | '<' | '<=' | '>' | '>=' | '==' | '!=' | 'has';
 export const opMap: Record<opType, string> = {
   between: 'between',
+  has: 'has',
   '<': 'less',
   '<=': 'lte',
   '>': 'greater',

--- a/web/src/data/protobuf-descriptor.json
+++ b/web/src/data/protobuf-descriptor.json
@@ -39,7 +39,8 @@
                 "<=": 3,
                 ">": 4,
                 ">=": 5,
-                "!=": 6
+                "!=": 6,
+                "has": 7
               }
             },
             "Table": {
@@ -73,7 +74,8 @@
                 "specific_ecosystem": 17,
                 "env_broad_scale": 18,
                 "env_local_scale": 19,
-                "env_medium": 20
+                "env_medium": 20,
+                "multiomics": 21
               }
             }
           }

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -338,8 +338,17 @@ function getField(name: string, table?: entityType): FieldsData {
   return {};
 }
 
+const MultiomicsValue = {
+  MB: 0b10000,
+  MG: 0b01000,
+  MP: 0b00100,
+  MT: 0b00010,
+  NOM: 0b00001,
+};
+
 export {
   types,
   ecosystems,
+  MultiomicsValue,
   getField,
 };

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -32,6 +32,13 @@ const staticUpsetTooltips = {
   MT: 'Metatranscriptomics',
   NOM: 'Natural Organic Matter',
 };
+const staticUpsetValueMap = {
+  MG: 'Metagenome',
+  MP: 'Proteomics',
+  MB: 'Metabolomics',
+  MT: 'Metatranscriptome',
+  NOM: 'Organic Matter Characterization',
+};
 
 function makeSetsFromBitmask(mask_str: string) {
   const mask = parseInt(mask_str, 10); // the bitmask comes in as a string
@@ -143,6 +150,7 @@ export default defineComponent({
       removeConditions,
       setBoundsFromMap,
       staticUpsetTooltips,
+      staticUpsetValueMap,
       upsetData,
     };
   },
@@ -221,8 +229,11 @@ export default defineComponent({
                   height,
                   data: upsetData,
                   tooltips: staticUpsetTooltips,
+                  valueMap: staticUpsetValueMap,
                   order: 'Samples',
                 }"
+                @select="setUniqueCondition(
+                  ['omics_type'], ['omics_processing'], $event.conditions)"
               />
             </template>
           </ChartContainer>

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -32,13 +32,6 @@ const staticUpsetTooltips = {
   MT: 'Metatranscriptomics',
   NOM: 'Natural Organic Matter',
 };
-const staticUpsetValueMap = {
-  MG: 'Metagenome',
-  MP: 'Proteomics',
-  MB: 'Metabolomics',
-  MT: 'Metatranscriptome',
-  NOM: 'Organic Matter Characterization',
-};
 
 function makeSetsFromBitmask(mask_str: string) {
   const mask = parseInt(mask_str, 10); // the bitmask comes in as a string
@@ -150,7 +143,6 @@ export default defineComponent({
       removeConditions,
       setBoundsFromMap,
       staticUpsetTooltips,
-      staticUpsetValueMap,
       upsetData,
     };
   },
@@ -229,7 +221,6 @@ export default defineComponent({
                   height,
                   data: upsetData,
                   tooltips: staticUpsetTooltips,
-                  valueMap: staticUpsetValueMap,
                   order: 'Samples',
                 }"
                 @select="setUniqueCondition(


### PR DESCRIPTION
fixes #390

This doesn't exactly address that issue because the backend doesn't support `AND` operations for terms for the same field/table.  The convention is `AND` across facets, `OR` within facets.  In order for clicking one of these bars to behave expectedly, we would need `AND` across and within the `omics_processing.omics_type` facet.

UPDATE: see #390 for explanation of how to resolve this with multiomics.