### PR TITLE
Include definitions from schema

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
       -
         name: Checkout code
         uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
       -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
     - uses: actions/setup-node@v1
       with:
         node-version: '14.x'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "web/src/data/nmdc-schema"]
+	path = web/src/data/nmdc-schema
+	url = https://github.com/microbiomedata/nmdc-schema

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Getting started with Docker
 
-First, install [ldc](https://github.com/Kitware/ldc)
+* install [ldc](https://github.com/Kitware/ldc)
+* install submodules via `git submodule update --init --recursive`
 
 In order to populate the database, you must create a `.env` file in the top
 level directory containing mongo credentials.

--- a/web/package.json
+++ b/web/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "postinstall": "git submodule update --init --recursive",
     "serve": "rimraf -rf ./node_modules/.cache/vue-loader && vue-cli-service serve src/main.ts",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
     "@riophae/vue-treeselect": "^0.4.0",
-    "@sentry/tracing": "^6.2.1",
     "@sentry/vue": "^6.2.1",
     "@vue/composition-api": "^1.1.4",
     "axios": "^0.21.2",

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -1,6 +1,7 @@
 import { merge } from 'lodash';
 import axios from 'axios';
 import { setupCache } from 'axios-cache-adapter';
+import NmdcSchema from '@/data/nmdc-schema/jsonschema/nmdc.schema.json';
 
 const cache = setupCache({
   key: (req) => req.url + JSON.stringify(req.params) + JSON.stringify(req.data),
@@ -30,6 +31,13 @@ export type entityType = 'biosample'
   | 'metaproteomic_analysis'
   | 'data_object'
   | 'gene_function';
+
+/**
+ * By including this file in source with a git submodule,
+ * we get build-time typescript support for the dynamic types coming
+ * out of an entirely different repository.
+ */
+export type entitySchemaType = keyof typeof NmdcSchema.definitions;
 
 export interface BaseSearchResult {
   id: string;

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -1,5 +1,5 @@
 import colors from './colors';
-import { entityType } from './data/api';
+import { entityType, entitySchemaType } from './data/api';
 
 export interface EntityData {
   icon: string;
@@ -7,6 +7,7 @@ export interface EntityData {
   name: string;
   plural: string;
   visible: boolean;
+  schemaName?: entitySchemaType; // Match the table to the NMDC Schema definition
 }
 
 export interface FieldsData {
@@ -17,6 +18,7 @@ export interface FieldsData {
   description?: string;
   group?: string;
   hideAttr?: boolean;
+  schemaName?: string; // Match the field to the nmsc schema property
   encode?: (input: string) => string,
 }
 
@@ -27,6 +29,7 @@ const types: Record<entityType, EntityData> = {
     name: 'study',
     plural: 'studies',
     visible: true,
+    schemaName: 'Study',
   },
   omics_processing: {
     icon: 'mdi-file-table-box-multiple-outline',
@@ -34,6 +37,7 @@ const types: Record<entityType, EntityData> = {
     name: 'omics_processing',
     plural: 'Omics Processing',
     visible: true,
+    schemaName: 'OmicsProcessing',
   },
   biosample: {
     icon: 'mdi-test-tube',
@@ -41,6 +45,7 @@ const types: Record<entityType, EntityData> = {
     name: 'sample',
     plural: 'samples',
     visible: true,
+    schemaName: 'Biosample',
   },
   reads_qc: {
     icon: 'mdi-dna',
@@ -55,6 +60,7 @@ const types: Record<entityType, EntityData> = {
     name: 'metagenome_assembly',
     plural: 'Metagenome assembly',
     visible: true,
+    schemaName: 'MetagenomeAssembly',
   },
   metagenome_annotation: {
     icon: 'mdi-dna',
@@ -62,6 +68,7 @@ const types: Record<entityType, EntityData> = {
     name: 'metagenome_annotation',
     plural: 'Metagenome annotation',
     visible: true,
+    schemaName: 'MetagenomeAnnotationActivity',
   },
   metaproteomic_analysis: {
     icon: 'mdi-dna',
@@ -69,6 +76,7 @@ const types: Record<entityType, EntityData> = {
     name: 'metaproteomic_analysis',
     plural: 'Metaproteomic analysis',
     visible: true,
+    schemaName: 'MetaproteomicsAnalysisActivity',
   },
   data_object: {
     icon: 'mdi-database',
@@ -76,6 +84,7 @@ const types: Record<entityType, EntityData> = {
     name: 'data_object',
     plural: 'Data objects',
     visible: false,
+    schemaName: 'DataObject',
   },
   gene_function: {
     icon: 'mdi-dna',
@@ -172,6 +181,7 @@ const fields: Record<string, FieldsData> = {
   principal_investigator_name: {
     name: 'PI Name',
     icon: 'mdi-account',
+    schemaName: 'principal_investigator',
   },
   doi: {
     icon: 'mdi-file-document-outline',

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,7 +2,6 @@ import Vue from 'vue';
 import CompositionPlugin from '@vue/composition-api';
 import VueGtag from 'vue-gtag';
 import { init as SentryInit } from '@sentry/vue';
-import { Integrations } from '@sentry/tracing';
 import AsyncComputed from 'vue-async-computed';
 
 import router from '@/plugins/router';
@@ -27,7 +26,6 @@ if (process.env.NODE_ENV === 'production') {
   SentryInit({
     Vue,
     dsn: 'https://87132695029c4406afe033fb3b13b115@o267860.ingest.sentry.io/5658761',
-    integrations: [new Integrations.BrowserTracing()],
     tracesSampleRate: 1.0,
   });
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1042,17 +1042,6 @@
     "@sentry/types" "6.2.1"
     tslib "^1.9.3"
 
-"@sentry/tracing@^6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.1.tgz#61c18c43c5390c348b35dafe73947ab379252d8f"
-  integrity sha512-bvStY1SnL08wkSeVK3j9K5rivQQJdKFCPR2VYRFOCaUoleZ6ChPUnBvxQ/E2LXc0hk/y/wo1q4r5B0dfCCY+bQ==
-  dependencies:
-    "@sentry/hub" "6.2.1"
-    "@sentry/minimal" "6.2.1"
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    tslib "^1.9.3"
-
 "@sentry/types@6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.1.tgz#28c946230b2023f72307b65606d32052ad9e5353"


### PR DESCRIPTION
![Screenshot from 2021-09-14 14-11-27](https://user-images.githubusercontent.com/4214172/133311175-b9afd896-76b3-42f0-8006-5e37396b0f19.png)

# Notes for reviewer

I found this approach simpler than a backend ingest.

* Install https://github.com/microbiomedata/nmdc-schema as a git submodule
* use `postinstall` to install this submodule on `yarn install`
* Bundle the schema JSON file using webpack

This comes with the added benefit that typescript can enforce the mappings declared in `encoding.ts` because of `resolveJsonModule`.

See how, in the screenshot below, you can get a nice literal type by introspecting the values in the json object.  So if a name changes in a future version of the NMDC schema, it will actually break the build.
![Screenshot from 2021-09-14 13-44-05](https://user-images.githubusercontent.com/4214172/133311607-06741132-5207-4319-b59d-af775a0ecfe1.png)

This is probably less code than going the ingest route

fixes #505