### PR TITLE
Kegg search

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -201,12 +201,12 @@ def list_omics_processing_data_objects(db: Session, id: str) -> Query:
 
 
 def list_ko_terms_for_module(db: Session, module: str) -> List[str]:
-    q = db.query(models.KoTermToModule.term).filter(models.KoTermToModule.module == module)
+    q = db.query(models.KoTermToModule.term).filter(models.KoTermToModule.module.ilike(module))
     return [row[0] for row in q]
 
 
 def list_ko_terms_for_pathway(db: Session, pathway: str) -> List[str]:
-    q = db.query(models.KoTermToPathway.term).filter(models.KoTermToPathway.pathway == pathway)
+    q = db.query(models.KoTermToPathway.term).filter(models.KoTermToPathway.pathway.ilike(pathway))
     return [row[0] for row in q]
 
 

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -284,9 +284,7 @@ class BaseQuerySchema(BaseModel):
 
     def transformCondition(self, db, condition: BaseConditionSchema) -> List[BaseConditionSchema]:
         # Transform KEGG.(PATH|MODULE) queries into their respective ORTHOLOGY terms
-        if condition.key == "Table.gene_function:id" and not condition.value.startswith(
-            KEGG_Terms.ORTHOLOGY[0]
-        ):
+        if condition.key == "Table.gene_function:id":
             if condition.value.startswith(KEGG_Terms.PATHWAY[0]):
                 searchable_name = condition.value.replace(
                     KEGG_Terms.PATHWAY[0], KEGG_Terms.PATHWAY[1]
@@ -302,7 +300,8 @@ class BaseQuerySchema(BaseModel):
                     models.KoTermToModule.module.ilike(searchable_name)
                 )
             else:
-                raise ValueError(f"Unexpected function type {condition}")
+                # This is not a condition we know how to transform.
+                return [condition]
             return [
                 SimpleConditionSchema(
                     op="==",

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -284,7 +284,6 @@ class BaseQuerySchema(BaseModel):
 
     def transformCondition(self, db, condition: BaseConditionSchema) -> List[BaseConditionSchema]:
         # Transform KEGG.(PATH|MODULE) queries into their respective ORTHOLOGY terms
-        print(condition.key)
         if condition.key == "Table.gene_function:id" and not condition.value.startswith(
             KEGG_Terms.ORTHOLOGY[0]
         ):
@@ -326,7 +325,6 @@ class BaseQuerySchema(BaseModel):
             conditions = [
                 c for condition in _conditions for c in self.transformCondition(db, condition)
             ]
-            print(conditions)
             # If transformation eliminated the condition group, report no filters
             has_filters = len(conditions) > 0
             match = table_re.match(key)

--- a/nmdc_server/table.py
+++ b/nmdc_server/table.py
@@ -19,6 +19,12 @@ EnvMediumTerm = aliased(models.EnvoTerm)
 MetaPGeneFunction = aliased(models.GeneFunction)
 
 
+class KEGG_Terms:
+    ORTHOLOGY = ("KEGG.ORTHOLOGY:K", "K")
+    PATHWAY = ("KEGG.PATHWAY:MAP", "MAP")
+    MODULE = ("KEGG.MODULE:M", "M")
+
+
 class Table(Enum):
     biosample = "biosample"
     study = "study"

--- a/nmdc_server/table.py
+++ b/nmdc_server/table.py
@@ -19,7 +19,7 @@ EnvMediumTerm = aliased(models.EnvoTerm)
 MetaPGeneFunction = aliased(models.GeneFunction)
 
 
-class KEGG_Terms:
+class KeggTerms:
     ORTHOLOGY = ("KEGG.ORTHOLOGY:K", "K")
     PATHWAY = ("KEGG.PATHWAY:MAP", "MAP")
     MODULE = ("KEGG.MODULE:M", "M")

--- a/web/src/components/MenuContent.vue
+++ b/web/src/components/MenuContent.vue
@@ -90,13 +90,22 @@ export default defineComponent({
         <v-icon>mdi-close</v-icon>
       </v-btn>
     </v-card-title>
-    <v-card-text>
+    <v-card-text
+      v-if="description"
+      class="py-1"
+    >
       {{ description }}
     </v-card-text>
     <v-card-text
       v-if="getField(field, table).description"
+      class="py-1"
     >
-      {{ getField(field, table).description }}
+      <p
+        v-for="d, i in getField(field, table).description"
+        :key="i"
+      >
+        {{ d }}
+      </p>
     </v-card-text>
     <template v-if="isOpen">
       <filter-list


### PR DESCRIPTION
@zachmullen I really quite disliked the client-side transformation of KEGG terms, so I did it on the server side.

This implementation isn't perfect, and it should probably be some kind of join, but it's relatively well isolated in the `transformCondition` function IMO.

It also makes the search functions case-insensitive.

This is a basic version where you can paste in the new terms and they'll be transformed on the server.