### PR TITLE
Bump max WAL size from 1GB (default) to 2GB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_DB=nmdc
+    command:
+      - postgres
+      - "-c"
+      # Our MGA ingest makes some *very* large transactions
+      - "max_wal_size=2GB"
 
   worker:
     image: ghcr.io/microbiomedata/nmdc-server/worker:latest


### PR DESCRIPTION
The postgres logs during MGA ingest were emitting these warnings:

```
2021-09-27 19:06:20.211 UTC [26] LOG:  checkpoints are occurring too frequently (26 seconds apart)
2021-09-27 19:06:20.211 UTC [26] HINT:  Consider increasing the configuration parameter "max_wal_size".
```

This is just some light tuning, it may or may not have a substantial impact on ingest performance.