### PR TITLE
Fix httpx dependency issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "cryptography<3.4",  # https://github.com/pyca/cryptography/issues/5771
         "fastapi",
         "factory-boy",
-        "httpx<0.18.2",
+        "httpx<=0.18.2",
         "ipython",
         "itsdangerous",
         "pint",


### PR DESCRIPTION
No idea what happened.  Seems like an exported symbol disappeared 

https://github.com/encode/httpx/blob/master/CHANGELOG.md

```ImportError: cannot import name 'USE_CLIENT_DEFAULT' from 'httpx' (/usr/local/lib/python3.8/site-packages/httpx/__init__.py)```