### PR TITLE
Remove NMDC_MONGO_HOST from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ level directory containing mongo credentials.
 
 ```bash
 # .env
-NMDC_MONGO_HOST=changeme
 NMDC_MONGO_USER=changeme
 NMDC_MONGO_PASSWORD=changeme
 ```


### PR DESCRIPTION
The default value will be used in development.

@subdavis I think this is no longer needed, please correct me if that's wrong.