### PR TITLE
Add docs for tunneling mongodb in development

### DIFF
--- a/.docker-env
+++ b/.docker-env
@@ -8,3 +8,6 @@ NMDC_DATABASE_URI="postgresql://postgres:postgres@db/nmdc_a"
 NMDC_CELERY_BACKEND="redis://redis:6379/0"
 NMDC_CELERY_BROKER="redis://redis:6379/0"
 NMDC_INGEST_DATABASE_URI="postgresql://postgres:postgres@db/nmdc_a"
+# See docs/mongo_ssh_tunnel.md for how to access Mongo in development
+NMDC_MONGO_HOST=host.docker.internal
+NMDC_MONGO_PORT=27027

--- a/.github/docs/mongo_ssh_tunnel.md
+++ b/.github/docs/mongo_ssh_tunnel.md
@@ -1,0 +1,7 @@
+1. If you haven't already, [set up MFA on your NERSC account](https://docs.nersc.gov/connect/mfa/)
+   (it's required for SSHing in).
+1. Run the following SSH tunneling command, substituting your actual NERSC username:
+
+   ```ssh -L 127.0.0.1:27027:mongo-loadbalancer.nmdc-runtime-dev.development.svc.spin.nersc.org:27017 <YOUR_NERSC_USERNAME>@dtn01.nersc.gov '/bin/bash -c "while [[ 1 ]]; do echo heartbeat; sleep 300; done"'```
+
+1. When prompted, provide your NERSC password concatenated with your MFA OTP code.

--- a/README.md
+++ b/README.md
@@ -10,23 +10,25 @@ level directory containing mongo credentials.
 
 ```bash
 # .env
-NMDC_MONGO_HOST=changeme
 NMDC_MONGO_USER=changeme
 NMDC_MONGO_PASSWORD=changeme
 ```
 
-With that file in place, populate the docker volume by running,
+In order to do an ingest, you'll need to setup SSH tunneling to the Mongo DB running at NERSC.
+How to do so is documented [here](./docs/mongo_ssh_tunnel.md).
+
+Once your `.env` file has the Mongo credentials, and your SSH tunnel is open, you can run:
 
 ```bash
-ldc run backend nmdc-server truncate # if necessary
-ldc run backend nmdc-server migrate
-ldc run backend nmdc-server ingest
+ldc dev run backend nmdc-server truncate # if necessary
+ldc dev run backend nmdc-server migrate
+ldc dev run backend nmdc-server ingest
 ```
 
 Then you can start up the services.
 
 ```bash
-ldc up
+ldc dev up
 ```
 
 View main application at `http://localhost:8080/` and the swagger page at `http://localhost:8080/docs`.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,10 @@ services:
       - "./nmdc_server:/app/nmdc_server"
     command: /start-reload.sh
 
+  db:
+    environment:
+      - POSTGRES_DB=nmdc_a
+
   worker:
     volumes:
       - "./nmdc_server:/app/nmdc_server"


### PR DESCRIPTION
@subdavis would you mind testing this out for me? Based on [this](https://stackoverflow.com/questions/31324981/how-to-access-host-port-from-docker-container), we may need to add 

```yaml
extra_hosts:
  - "host.docker.internal:host-gateway"
```

to docker-compose config, but only on Linux. It works without it on MacOS.