### PR TITLE
Switch from Alpine to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM tiangolo/uvicorn-gunicorn:python3.8-alpine3.10
+FROM tiangolo/uvicorn-gunicorn:python3.8
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
-RUN apk update && \
-    apk add --virtual build-deps gcc python-dev musl-dev libressl-dev libffi-dev g++ && \
-    apk add postgresql-dev postgresql-client && \
-    apk add py-cryptography
+RUN apt-get update && apt-get install -y postgresql-client
 
-RUN pip install -U pip
+RUN pip install -U pip setuptools wheel
 COPY setup.py setup.cfg /app/
 RUN pip install -e /app
 

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,12 +1,9 @@
-FROM python:3.8-alpine3.10
+FROM python:3.8
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
-RUN apk update && \
-    apk add --virtual build-deps gcc python-dev musl-dev libressl-dev libffi-dev g++ && \
-    apk add postgresql-dev postgresql-client && \
-    apk add py-cryptography
+RUN apt-get update && apt-get install -y postgresql-client
 
-RUN pip install -U pip
+RUN pip install -U pip setuptools wheel
 COPY setup.py setup.cfg /app/
 RUN pip install -e /app
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
         "requests",
         "sentry-sdk[celery,sqlalchemy]",
         "sqlalchemy>=1.4",
-        "starlette",
-        "typing-extensions",
+        "starlette==0.17.1",
+        "typing-extensions==4.0.1",
     ],
     include_package_data=True,
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ setup(
         "requests",
         "sentry-sdk[celery,sqlalchemy]",
         "sqlalchemy>=1.4",
-        "starlette==0.17.1",
-        "typing-extensions==4.0.1",
+        "starlette",
+        "typing-extensions",
     ],
     include_package_data=True,
     entry_points="""


### PR DESCRIPTION
Alpine and python don't mix well [1] [2]

[1] https://github.com/tiangolo/uvicorn-gunicorn-docker#-alpine-python-warning
[2] https://www.notion.so/A-Comprehensive-Guide-for-Switching-to-Poetry-b452ad4d816a4cdda3726847c74fc21f#f3405cef8fc043508dfcdd2115b14cd4

Because there are no wheels for alpine, builds are taking forever.  Switch to debian base images.  Drop all the manual installation of build requirements and just use wheels.