### PR TITLE
Bugfix support bulk emsl

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -386,20 +386,9 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
 
     for file in bulk_download.files:  # type: ignore
         data_object = file.data_object
-
-        # TODO: Support arbitrary urls
-        if data_object.url is None or not data_object.url.startswith(
-            "https://data.microbiomedata.org/data"
-        ):
-            if data_object and data_object.url is None:
-                logger.warning("Data object url is empty")
-            if data_object and data_object.url is not None:
-                logger.warning(f"Data object url is {data_object.url}")
-            continue
-
         url = get_local_data_url(data_object.url)
         if url is None:
-            logger.warning("Unknown host in data url")
+            logger.warning(f"Data object url for {file.path} was {data_object.url}")
             continue
 
         # TODO: add crc checksums to support retries

--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -18,7 +18,9 @@ data_url_hosts = [
 ]
 
 
-def get_local_data_url(url: str) -> Optional[str]:
+def get_local_data_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
     for r, v in data_url_hosts:
         if r.match(url):
             return r.sub(v, url)


### PR DESCRIPTION
Bug excluded emsl from bulk download.  Null check was redundant, passed responsibility on to get_local_data_url which will either generate a valid path or return None.

Tested working locally.