### PR TITLE
Re-export before download

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -105,8 +105,9 @@ export default defineComponent({
       await submit();
     });
 
-    function downloadSamples() {
-      const worksheet = utils.aoa_to_sheet(sampleData.value);
+    async function downloadSamples() {
+      const data = await harmonizerApi.exportJson();
+      const worksheet = utils.aoa_to_sheet(data);
       const workbook = utils.book_new();
       utils.book_append_sheet(workbook, worksheet, 'Sheet1');
       // @ts-ignore


### PR DESCRIPTION
Re-run export routine instead of using last known copy from validation.

Note that this sorta eliminates the relationship between validation and download.  You can enter valid data, validate it, break it again, not validate it again, and download it.

fixes #609 