### PR TITLE
Allow missing kegg description text

### DIFF
--- a/nmdc_server/ingest/kegg.py
+++ b/nmdc_server/ingest/kegg.py
@@ -26,8 +26,8 @@ def ingest_ko_text(db: Session) -> None:
 
     def ingest_tree(node: dict) -> None:
         if node["name"].startswith("K"):
-            term, text = node["name"].split("  ", maxsplit=1)
-            records[term] = text
+            term, *text = node["name"].split("  ", maxsplit=1)
+            records[term] = text[0] if text else ""
 
         for child in node.get("children", ()):
             ingest_tree(child)


### PR DESCRIPTION
## Expected

```
"name":"K00626  ACAT, atoB; acetyl-CoA C-acetyltransferase [EC:2.3.1.9]"
```

## Found

```
"name":"K00626"
```