### PR TITLE
Node forge 1.3.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -75,6 +75,7 @@
     "last 2 versions"
   ],
   "resolutions": {
+    "node-forge": "^1.3.0",
     "serialize-javascript": "^3.1",
     "http-proxy": "1.18.1"
   }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7194,10 +7194,10 @@ node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+node-forge@^0.10.0, node-forge@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.0.tgz#37a874ea723855f37db091e6c186e5b67a01d4b2"
+  integrity sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA==
 
 node-ipc@^9.1.1:
   version "9.2.1"


### PR DESCRIPTION
Required by webpack dev server in HTTPS mode, which we don't use.

This pin may break that feature, but it doesn't matter.