### PR TITLE
Add Token Authentication

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -7,6 +7,7 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from starlette.middleware.sessions import SessionMiddleware
 
 from nmdc_server import __version__, api, auth, errors
+from nmdc_server.auth_middleware import AuthMiddleware
 from nmdc_server.config import settings
 
 
@@ -31,6 +32,6 @@ def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     errors.attach_error_handlers(app)
     app.include_router(api.router, prefix="/api")
     app.include_router(auth.router, prefix="")
+    app.add_middleware(AuthMiddleware, secret_key=settings.secret_key)
     app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
-
     return app

--- a/nmdc_server/auth_middleware.py
+++ b/nmdc_server/auth_middleware.py
@@ -1,0 +1,39 @@
+import json
+import typing
+from base64 import b64decode
+
+import itsdangerous
+from itsdangerous.exc import BadSignature
+from starlette.datastructures import Secret
+from starlette.requests import HTTPConnection
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class AuthMiddleware:
+    def __init__(
+        self,
+        app: ASGIApp,
+        secret_key: typing.Union[str, Secret],
+        auth_header: str = "authorization",
+        max_age: typing.Optional[int] = 14 * 24 * 60 * 60,  # 14 days, in seconds
+    ) -> None:
+        self.app = app
+        self.signer = itsdangerous.TimestampSigner(str(secret_key))
+        self.auth_header = auth_header
+        self.max_age = max_age
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+
+        connection = HTTPConnection(scope)
+
+        if self.auth_header in connection.headers:
+            data = connection.headers[self.auth_header].encode("utf-8")
+            try:
+                data = self.signer.unsign(data, max_age=self.max_age)
+                scope["session"] = json.loads(b64decode(data))
+            except BadSignature:
+                scope["session"] = {}
+        else:
+            pass
+
+        await self.app(scope, receive, send)

--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -1,11 +1,19 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, ref } from '@vue/composition-api';
 import { stateRefs } from '@/store';
 
 export default defineComponent({
   setup() {
+    const showToast = ref(false);
+    async function copyToClipboard(token : string) {
+      await navigator.clipboard.writeText(token);
+      showToast.value = true;
+    }
     return {
       me: stateRefs.user,
+      showToast,
+      token: '123', // todo- get the actual token
+      copyToClipboard,
     };
   },
 });
@@ -14,15 +22,46 @@ export default defineComponent({
 <template>
   <div>
     <template v-if="me">
-      <v-btn
-        text
-        color="grey darken-2"
+      <v-menu
+        :close-on-content-click="false"
+        :nudge-width="100"
+        left
+        offset-x
       >
-        <v-icon left>
-          mdi-account-circle
-        </v-icon>
-        {{ me }}
-      </v-btn>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            text
+            color="grey darken-2"
+            v-bind="attrs"
+            v-on="on"
+          >
+            <v-icon left>
+              mdi-account-circle
+            </v-icon>
+            {{ me }}
+          </v-btn>
+        </template>
+
+        <v-card>
+          <v-list>
+            <v-list-item>
+              <v-list-item-content>
+                <v-list-item-title>NMDC API Token</v-list-item-title>
+                <v-list-item-subtitle><a href="https://github.com/microbiomedata/nmdc-server/wiki/Search-API-Docs">Know more</a></v-list-item-subtitle>
+              </v-list-item-content>
+
+              <v-list-item-action>
+                <v-btn
+                  icon
+                  @click="copyToClipboard(token)"
+                >
+                  <v-icon>mdi-clipboard-text-multiple-outline</v-icon>
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-menu>
       <v-btn
         icon
         color="grey darken-2"
@@ -30,6 +69,16 @@ export default defineComponent({
       >
         <v-icon>mdi-logout</v-icon>
       </v-btn>
+      <v-snackbar
+        v-model="showToast"
+        :timeout="1000"
+        :value="true"
+        absolute
+        bottom
+        color="primary"
+      >
+        Copied!
+      </v-snackbar>
     </template>
     <template v-else>
       <v-btn


### PR DESCRIPTION
### Changes

- A new middleware to authenticate incoming requests. Every request that requires authorization must have an **authorization** header (new) or set-cookie (already exists)
- Authorization token can be copied from the NMDC home page by clicking on the username (todo- attach screenshot)

**TODO** 

- [ ] Get the actual JWT token or an expirable token to be sent in the auth header - to be accessible from the UI
- [ ] Update middleware accordingly