### PR TITLE
Setting cookie headers

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -32,12 +32,14 @@ def create_app(env: typing.Mapping[str, str], secret_key: str = settings.secret_
     app.include_router(api.router, prefix="/api")
     app.include_router(auth.router, prefix="")
     same_site_value = "lax"
+    https_only = False
     if settings.environment == "production":
         same_site_value = "Strict"
+        https_only = True
     app.add_middleware(
         SessionMiddleware,
         secret_key=secret_key,
-        https_only=True,
+        https_only=https_only,
         same_site=same_site_value,
     )
 

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -21,7 +21,7 @@ def attach_sentry(app: FastAPI):
     app.add_middleware(SentryAsgiMiddleware)
 
 
-def create_app(env: typing.Mapping[str, str]) -> FastAPI:
+def create_app(env: typing.Mapping[str, str], secret_key: str = settings.secret_key) -> FastAPI:
     app = FastAPI(
         title="NMDC Dataset API",
         version=__version__,
@@ -31,6 +31,14 @@ def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     errors.attach_error_handlers(app)
     app.include_router(api.router, prefix="/api")
     app.include_router(auth.router, prefix="")
-    app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
+    same_site_value = "lax"
+    if settings.environment == "production":
+        same_site_value = "Strict"
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=secret_key,
+        https_only=True,
+        same_site=same_site_value,
+    )
 
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def db(connection):
 
 @pytest.fixture
 def app(db):
-    return create_app(env=os.environ.copy())
+    return create_app(env=os.environ.copy(), secret_key="test")
 
 
 @pytest.fixture

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,14 +1,13 @@
+import json
+from base64 import b64decode, b64encode
+from json import JSONEncoder
+
+import itsdangerous
 from starlette.testclient import TestClient
 
 from nmdc_server import fakes
 from nmdc_server.auth import Token
 from nmdc_server.config import settings
-from base64 import b64decode, b64encode
-
-import json
-import itsdangerous
-
-from json import JSONEncoder
 
 
 def test_login(client: TestClient):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -52,8 +52,8 @@ def test_cookie_headers(client: TestClient, token: Token):
     signer = itsdangerous.TimestampSigner("test")  # same as the secret_key set at application start
     encoded_token = b64encode(json.dumps(token, cls=TokenEncoder).encode("utf-8"))
     encoded_token = signer.sign(f"${str(encoded_token, 'utf-8')}")
-    data = signer.unsign(encoded_token, max_age=14 * 24 * 60 * 60)
-    cookies = {"session": json.loads(b64decode(data))}
+    # data = signer.unsign(encoded_token, max_age=14 * 24 * 60 * 60)
+    cookies = {"session": str(encoded_token)}
     resp = client.get("/api/me", cookies=cookies)
 
     assert resp.headers != None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,5 @@
 import json
-from base64 import b64decode, b64encode
+from base64 import b64encode
 from json import JSONEncoder
 
 import itsdangerous

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -50,9 +50,7 @@ def test_cookie_headers(client: TestClient, token: Token):
     # print(session)
     # cookies = {"session": f"${str(session, 'utf-8')}"}
     # todo-  figure out what is the value after ==
-    cookies = {
-        "session": "eyJ0b2tlbiI6IHsiYWNjZXNzX3Rva2VuIjogIjY5YTNmN2I2LTU2NzAtNDE4OC1hZDI1LWE4NmZjYzU5NWMwMyIsICJ0b2tlbl90eXBlIjogImJlYXJlciIsICJyZWZyZXNoX3Rva2VuIjogImQwYWQzMTlmLTk4YjgtNDdlNC05ODY0LWI4YTRkNTFlNzFhYSIsICJleHBpcmVzX2luIjogNjMxMTM4NTE4LCAic2NvcGUiOiAiL2F1dGhlbnRpY2F0ZSIsICJuYW1lIjogIkRlZXBpa2EgIiwgIm9yY2lkIjogIjAwMDAtMDAwMi0xNDM2LTg4NDgiLCAiZXhwaXJlc19hdCI6IDIyODc0MjY4MzJ9fQ==.YrkUEA.-kln8-0tTPgoSsTLsTWaQQ6JYo8="
-    }
+    cookies = {"session": ""}
     print(cookies)
     resp = client.get("/api/me", cookies=cookies)
     print(resp.headers)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,10 @@ from starlette.testclient import TestClient
 from nmdc_server import fakes
 from nmdc_server.auth import Token
 from nmdc_server.config import settings
+from base64 import b64encode
+import json
+
+from json import JSONEncoder
 
 
 def test_login(client: TestClient):
@@ -34,3 +38,23 @@ def test_login_required(db, client: TestClient):
 
     resp = client.get("/api/data_object/nmdc:id/download")
     assert resp.status_code == 401
+
+
+class TokenEncoder(JSONEncoder):
+    def default(self, o):
+        return str(o)
+
+
+def test_cookie_headers(client: TestClient, token: Token):
+    # session = b64encode(json.dumps(token, cls=TokenEncoder).encode("utf-8"))
+    # print(session)
+    # cookies = {"session": f"${str(session, 'utf-8')}"}
+    # todo-  figure out what is the value after ==
+    cookies = {
+        "session": "eyJ0b2tlbiI6IHsiYWNjZXNzX3Rva2VuIjogIjY5YTNmN2I2LTU2NzAtNDE4OC1hZDI1LWE4NmZjYzU5NWMwMyIsICJ0b2tlbl90eXBlIjogImJlYXJlciIsICJyZWZyZXNoX3Rva2VuIjogImQwYWQzMTlmLTk4YjgtNDdlNC05ODY0LWI4YTRkNTFlNzFhYSIsICJleHBpcmVzX2luIjogNjMxMTM4NTE4LCAic2NvcGUiOiAiL2F1dGhlbnRpY2F0ZSIsICJuYW1lIjogIkRlZXBpa2EgIiwgIm9yY2lkIjogIjAwMDAtMDAwMi0xNDM2LTg4NDgiLCAiZXhwaXJlc19hdCI6IDIyODc0MjY4MzJ9fQ==.YrkUEA.-kln8-0tTPgoSsTLsTWaQQ6JYo8="
+    }
+    print(cookies)
+    resp = client.get("/api/me", cookies=cookies)
+    print(resp.headers)
+    print(resp.headers["set-cookie"])
+    assert resp.headers != None


### PR DESCRIPTION
### Changes (#723 )

**Configuration Changes for Session Middleware**

- Setting the following cookie headers in production environment

    - HttpOnly (set by default) 
    - SameSite: Strict (default setting is lax)
    - Secure (set by setting https_only to true)

**Testing**

- Parameterized create_app() method to take secret_key as an input: to facilitate signature validation for a cookie during testing 
(This change can be reverted for now as the current test is not asserting set-cookie field in request headers)
- Added a new test that checks if the above mentioned headers are set in the cookie

The above mentioned test performs the following:
- encode the token object and sign it using the secret key provided in `configtest.py` => this gives the session cookie value (JWT token) (Ref: [Session Middleware](https://github.com/encode/starlette/blob/master/starlette/middleware/sessions.py#L62-L64))
- make a GET call with the above cookie set in request
- assert if `Set-Cookie` header is set in response

**TODO**
- [ ] Test the cookie headers in staging environment