### PR TITLE
Show geographic location (city/state) in sample detail page

### DIFF
--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -40,11 +40,34 @@ export default defineComponent({
       return undefined;
     }
 
+    function dottedValueDisplayName(dottedFieldName: string) {
+      const fields = dottedFieldName.split('.');
+      const field = fields[fields.length - 1];
+      let intermediateValue: any = props.item;
+      while (fields.length && intermediateValue !== undefined) {
+        const intermediateField = fields.shift()!;
+        intermediateValue = intermediateValue[intermediateField];
+      }
+      return valueDisplayName(field, intermediateValue);
+    }
+
+    function dottedFieldDisplayName(dottedFieldName: string) {
+      const fields = dottedFieldName.split('.');
+      const field = fields.pop()!;
+      return fieldDisplayName(field);
+    }
+
+    function getDottedField(dottedFieldName: string) {
+      const fields = dottedFieldName.split('.');
+      const field = fields.pop()!;
+      return getField(field);
+    }
+
     return {
       href,
-      getField,
-      fieldDisplayName,
-      valueDisplayName,
+      getDottedField,
+      dottedFieldDisplayName,
+      dottedValueDisplayName,
     };
   },
 });
@@ -92,19 +115,19 @@ export default defineComponent({
       class="pr-2"
       alt="Logo"
     >
-    <v-list-item-avatar v-else-if="getField(field)">
+    <v-list-item-avatar v-else-if="getDottedField(field)">
       <v-icon>
-        {{ getField(field).icon || 'mdi-text' }}
+        {{ getDottedField(field).icon || 'mdi-text' }}
       </v-icon>
     </v-list-item-avatar>
     <v-list-item-content>
       <v-list-item-title>
-        {{ fieldDisplayName(field) }}
+        {{ dottedFieldDisplayName(field) }}
       </v-list-item-title>
       <v-list-item-subtitle
         style="white-space: initial;"
       >
-        {{ valueDisplayName(field, item[field]) }}
+        {{ dottedValueDisplayName(field, item[field]) }}
       </v-list-item-subtitle>
     </v-list-item-content>
   </v-list-item>

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -29,6 +29,13 @@ export default defineComponent({
         }
         return !isObject(value) && value && (!getField(field) || !getField(field).hideAttr);
       });
+
+      // add geo_loc_name to after lat/lon
+      if (props.item?.annotations?.geo_loc_name !== undefined) {
+        const geoLocIndex = ret.includes('latitude') ? ret.indexOf('latitude') + 1 : ret.length;
+        ret.splice(geoLocIndex, 0, 'annotations.geo_loc_name');
+      }
+
       return ret;
     });
 


### PR DESCRIPTION
Closes part of #740 

This adds the geographic location name to the sample detail page.

<img width="1297" alt="Screen Shot 2022-07-13 at 11 41 16 AM" src="https://user-images.githubusercontent.com/13244041/178775928-1b6d6e72-5ad0-4a4c-aa1f-fb60768a2408.png">
