### PR TITLE
Show friendly environmental terms in sample detail page

### DIFF
--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -2,12 +2,12 @@
 import { defineComponent, PropType } from '@vue/composition-api';
 import { getField } from '@/encoding';
 import { fieldDisplayName, valueDisplayName } from '@/util';
-import { BaseSearchResult } from '@/data/api';
+import { BaseSearchResult, BiosampleSearchResult } from '@/data/api';
 
 export default defineComponent({
   props: {
     item: {
-      type: Object as PropType<BaseSearchResult>,
+      type: Object as PropType<BaseSearchResult | BiosampleSearchResult>,
       required: true,
     },
     field: {

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -29,6 +29,13 @@ export default defineComponent({
   },
 
   setup(props) {
+    function getValue(field: string) {
+      if (field === 'geo_loc_name') {
+        return props.item.annotations.geo_loc_name;
+      }
+      return valueDisplayName(field, props.item[field]);
+    }
+
     function href(field: string) {
       if (field.startsWith('open_in_')) {
         return props.item[field];
@@ -40,34 +47,11 @@ export default defineComponent({
       return undefined;
     }
 
-    function dottedValueDisplayName(dottedFieldName: string) {
-      const fields = dottedFieldName.split('.');
-      const field = fields[fields.length - 1];
-      let intermediateValue: any = props.item;
-      while (fields.length && intermediateValue !== undefined) {
-        const intermediateField = fields.shift()!;
-        intermediateValue = intermediateValue[intermediateField];
-      }
-      return valueDisplayName(field, intermediateValue);
-    }
-
-    function dottedFieldDisplayName(dottedFieldName: string) {
-      const fields = dottedFieldName.split('.');
-      const field = fields.pop()!;
-      return fieldDisplayName(field);
-    }
-
-    function getDottedField(dottedFieldName: string) {
-      const fields = dottedFieldName.split('.');
-      const field = fields.pop()!;
-      return getField(field);
-    }
-
     return {
+      getField,
+      fieldDisplayName,
+      getValue,
       href,
-      getDottedField,
-      dottedFieldDisplayName,
-      dottedValueDisplayName,
     };
   },
 });
@@ -115,19 +99,19 @@ export default defineComponent({
       class="pr-2"
       alt="Logo"
     >
-    <v-list-item-avatar v-else-if="getDottedField(field)">
+    <v-list-item-avatar v-else-if="getField(field)">
       <v-icon>
-        {{ getDottedField(field).icon || 'mdi-text' }}
+        {{ getField(field).icon || 'mdi-text' }}
       </v-icon>
     </v-list-item-avatar>
     <v-list-item-content>
       <v-list-item-title>
-        {{ dottedFieldDisplayName(field) }}
+        {{ fieldDisplayName(field) }}
       </v-list-item-title>
       <v-list-item-subtitle
         style="white-space: initial;"
       >
-        {{ dottedValueDisplayName(field, item[field]) }}
+        {{ getValue(field) }}
       </v-list-item-subtitle>
     </v-list-item-content>
   </v-list-item>

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -33,6 +33,15 @@ export default defineComponent({
       if (field === 'geo_loc_name') {
         return props.item.annotations.geo_loc_name;
       }
+      if (
+        field === 'env_broad_scale'
+          || field === 'env_local_scale'
+          || field === 'env_medium'
+      ) {
+        const item = props.item as BiosampleSearchResult;
+        const env = item[field];
+        return `${env.label} (${env.id})`;
+      }
       return valueDisplayName(field, props.item[field]);
     }
 

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -29,9 +29,17 @@ export default defineComponent({
         'env_local_scale_id',
         'env_medium_id',
       ]);
+      const includeFields = new Set([
+        'env_broad_scale',
+        'env_local_scale',
+        'env_medium',
+      ]);
       const ret = Object.keys(props.item).filter((field) => {
         if (skipFields.has(field)) {
           return false;
+        }
+        if (includeFields.has(field)) {
+          return true;
         }
         const value = props.item[field];
         return !isObject(value) && value && (!getField(field) || !getField(field).hideAttr);

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -25,6 +25,9 @@ export default defineComponent({
       const skipFields = new Set([
         'name',
         'description',
+        'env_broad_scale_id',
+        'env_local_scale_id',
+        'env_medium_id',
       ]);
       const ret = Object.keys(props.item).filter((field) => {
         if (skipFields.has(field)) {

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       // add geo_loc_name to after lat/lon
       if (props.item?.annotations?.geo_loc_name !== undefined) {
         const geoLocIndex = ret.includes('latitude') ? ret.indexOf('latitude') + 1 : ret.length;
-        ret.splice(geoLocIndex, 0, 'annotations.geo_loc_name');
+        ret.splice(geoLocIndex, 0, 'geo_loc_name');
       }
 
       return ret;

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -22,11 +22,15 @@ export default defineComponent({
 
   setup(props) {
     const displayFields = computed(() => {
+      const skipFields = new Set([
+        'name',
+        'description',
+      ]);
       const ret = Object.keys(props.item).filter((field) => {
-        const value = props.item[field];
-        if (['name', 'description'].includes(field)) {
+        if (skipFields.has(field)) {
           return false;
         }
+        const value = props.item[field];
         return !isObject(value) && value && (!getField(field) || !getField(field).hideAttr);
       });
 

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -2,7 +2,7 @@
 import { computed, defineComponent, PropType } from '@vue/composition-api';
 import { isObject } from 'lodash';
 
-import { BaseSearchResult } from '@/data/api';
+import { BaseSearchResult, BiosampleSearchResult } from '@/data/api';
 import { getField } from '@/encoding';
 import AttributeItem from './AttributeItem.vue';
 
@@ -15,7 +15,7 @@ export default defineComponent({
       default: '',
     },
     item: {
-      type: Object as PropType<BaseSearchResult>,
+      type: Object as PropType<BaseSearchResult | BiosampleSearchResult>,
       required: true,
     },
   },


### PR DESCRIPTION
Closes part of https://github.com/microbiomedata/nmdc-server/issues/740

This remove the "Env ___ Id" attributes in favor of more descriptive attributes in the sample detail page.
<img width="1472" alt="Screen Shot 2022-07-13 at 1 33 49 PM" src="https://user-images.githubusercontent.com/13244041/178797128-6f9e377a-b916-426f-ad87-3a29ab89fc03.png">