### PR TITLE
Use CSS to prevent back-button on scroll

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -51,20 +51,6 @@ export default defineComponent({
         await harmonizerApi.init(r, templateChoice.value);
         await nextTick();
         harmonizerApi.loadData(sampleData.value.slice(2));
-
-        /*To avoid page navigation on horizontal scrolling (using trackpad)
-          reference- https://stackoverflow.com/questions/50616221/prevent-page-navigation-on-horizontal-scroll
-        */
-        r.addEventListener('mousewheel', (e) => {
-          e.stopPropagation();
-          const max = r.scrollWidth - r.offsetWidth;
-          // @ts-ignore
-          if (r.scrollLeft + e.deltaX < 0 || r.scrollLeft + e.deltaX > max) {
-            e.preventDefault();
-            // @ts-ignore
-            r.scrollLeft = Math.max(0, Math.min(max, r.scrollLeft + e.deltaX));
-          }
-        }, false);
       }
     });
 
@@ -511,6 +497,16 @@ export default defineComponent({
 </template>
 
 <style lang="scss">
+/*
+  https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior#examples
+  Prevent back button overscrolling
+  Chrome-only
+*/
+html {
+  margin: 0;
+  overscroll-behavior: none;
+}
+
 .harmonizer-container {
   height: calc(100vh - 260px) !important;
 }


### PR DESCRIPTION
Closes #752 

We previously used JavaScript to intercept the scrolling behavior and block over-scrolling (to prevent accidental back-button triggering). This is the more portable solution, but becomes difficult when the `div`'s size is dynamic. In those cases, the JavaScript blocking may "lock up" due to incorrect window size calculations.

This PR replaces the JavaScript with CSS to accomplish the same. It is ignored in [Safari (until new version 16)](https://caniuse.com/?search=overscroll-behavior), but is more performant and robust to dynamic `div`s.