### PR TITLE
Migration fixes

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -67,7 +67,7 @@ def ingest(verbose, function_limit, skip_annotation):
     logger = get_logger(__name__)
     logging.basicConfig(level=level, format="%(message)s")
     logger.setLevel(logging.INFO)
-
+    jobs.migrate(ingest_db=True)
     with SessionLocalIngest() as ingest_db:
         load(ingest_db, function_limit=function_limit, skip_annotation=skip_annotation)
         if settings.current_db_uri != settings.ingest_database_uri:

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
-from alembic.migration import MigrationContext
 
 from nmdc_server import database, models
 from nmdc_server.celery_config import celery_app
@@ -28,11 +27,9 @@ def migrate(ingest_db: bool = False):
     """
     if ingest_db:
         database_uri = settings.ingest_database_uri
-        engine = database.engine_ingest
         session_maker = database.SessionLocalIngest
     else:
         database_uri = settings.current_db_uri
-        engine = database.engine
         session_maker = database.SessionLocal
 
     with session_maker() as db:
@@ -40,15 +37,7 @@ def migrate(ingest_db: bool = False):
         alembic_cfg.set_main_option("script_location", str(HERE / "migrations"))
         alembic_cfg.set_main_option("sqlalchemy.url", database_uri)
         alembic_cfg.attributes["configure_logger"] = True
-
-        with db.connection() as conn:
-            context = MigrationContext.configure(conn)
-            head = context.get_current_revision()
-            if head is None:
-                database.metadata.create_all(bind=engine)
-                command.stamp(alembic_cfg, "head")
-            else:
-                command.upgrade(alembic_cfg, "head")
+        command.upgrade(alembic_cfg, "head")
 
 
 @celery_app.task

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -32,7 +32,7 @@ def migrate(ingest_db: bool = False):
         database_uri = settings.current_db_uri
         session_maker = database.SessionLocal
 
-    with session_maker() as db:
+    with session_maker():
         alembic_cfg = Config(str(HERE / "alembic.ini"))
         alembic_cfg.set_main_option("script_location", str(HERE / "migrations"))
         alembic_cfg.set_main_option("sqlalchemy.url", database_uri)

--- a/prestart.sh
+++ b/prestart.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 export PGUSER PGPASSWORD PGDATABASE PGHOST POSTGRES_URI
 
 while ! PGDATABASE=postgres psql --quiet -c "select * from user" ; do
@@ -7,7 +9,23 @@ done
 
 echo 'Creating and migrating database'
 # in spin the database already exists
-PGDATABASE=postgres psql -c "create database nmdc_a;" || true
-PGDATABASE=postgres psql -c "create database nmdc_b;" || true
+PGDATABASE=postgres psql -c "create database nmdc_a;" \
+|| pg_dump \
+    --table "user_logins" \
+    --table "submission_metadata" \
+    --table "file_download" \
+    --file "nmdc_a-$(date +%s)-$(openssl rand -hex 32).sql" \
+    --data-only \
+    nmdc_a
+
+
+PGDATABASE=postgres psql -c "create database nmdc_b;" \
+|| pg_dump \
+    --table "user_logins" \
+    --table "submission_metadata" \
+    --table "file_download" \
+    --file "nmdc_b-$(date +%s)-$(openssl rand -hex 32).sql" \
+    --data-only \
+    nmdc_b
 
 nmdc-server migrate

--- a/prestart.sh
+++ b/prestart.sh
@@ -9,23 +9,9 @@ done
 
 echo 'Creating and migrating database'
 # in spin the database already exists
-PGDATABASE=postgres psql -c "create database nmdc_a;" \
-|| pg_dump \
-    --table "user_logins" \
-    --table "submission_metadata" \
-    --table "file_download" \
-    --file "nmdc_a-$(date +%s)-$(openssl rand -hex 32).sql" \
-    --data-only \
-    nmdc_a
+PGDATABASE=postgres psql -c "create database nmdc_a;" || true
 
 
-PGDATABASE=postgres psql -c "create database nmdc_b;" \
-|| pg_dump \
-    --table "user_logins" \
-    --table "submission_metadata" \
-    --table "file_download" \
-    --file "nmdc_b-$(date +%s)-$(openssl rand -hex 32).sql" \
-    --data-only \
-    nmdc_b
+PGDATABASE=postgres psql -c "create database nmdc_b;" || true
 
 nmdc-server migrate


### PR DESCRIPTION
Resolves part of #765:

- Put ingest and migration in Postgres transactions. This will ensure consistency of the data, so the final state of the data is guaranteed.
- Move migration step from separate process to part of the entrypoint script, which first runs backup, then migration, then start server