### PR TITLE
Remove `SentryAsgiMiddleware`

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -2,7 +2,6 @@ import typing
 
 import sentry_sdk
 from fastapi import FastAPI
-from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -18,7 +17,6 @@ def attach_sentry(app: FastAPI):
         dsn=settings.sentry_dsn,
         integrations=[SqlalchemyIntegration()],
     )
-    app.add_middleware(SentryAsgiMiddleware)
 
 
 def create_app(env: typing.Mapping[str, str]) -> FastAPI:


### PR DESCRIPTION
App startup failed with:
```
RuntimeError: The Sentry Python SDK can now automatically support ASGI frameworks like Starlette and FastAPI. Please remove 'SentryAsgiMiddleware' from your project. See https://docs.sentry.io/platforms/python/guides/asgi/ for more information.
```

This PR removes `SentryAsgiMiddleware` from our project as the error suggests.