### PR TITLE
Prevent zooming too far when map data changes

### DIFF
--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -133,7 +133,11 @@ export default defineComponent({
 
     watchEffect(() => {
       if (mapRef.value && mapCenter.value) {
-        mapRef.value.fitBounds(mapCenter.value, { padding: [20, 20] });
+        const fitBoundsOptions = {
+          padding: [20, 20],
+          maxZoom: 5,
+        };
+        mapRef.value.fitBounds(mapCenter.value, fitBoundsOptions);
         mapRef.value.mapObject.invalidateSize(false);
       }
     });


### PR DESCRIPTION
Resolves #783 

Previously, when filtering through data using the sidebar would cause the map bounds to change, the map would zoom in too far if the results of the query were small. Now, when the map bounds change due to updated search queries, there is a maximum zoom level. This allows users to maintain context for where the data is without needing to zoom back out. Users can still zoom in towards the data.

Without max zoom:
![without_max_zoom](https://user-images.githubusercontent.com/7085625/190016963-82badfa8-c185-4892-bc04-1741fd0f6b24.png)

With max zoom = 5:
![with_max_zoom](https://user-images.githubusercontent.com/7085625/190016986-f95dcf1c-78ad-4358-9b03-5c40743b34ed.png)
