### PR TITLE
Add brush to time histogram

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
         "sqlalchemy>=1.4",
         "starlette==0.17.1",
         "typing-extensions==4.0.1",
+        # pinned 3rd party dependencies
+        "importlib-metadata==4.12.0",
     ],
     include_package_data=True,
     entry_points="""

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
   },
 
   watch: {
-    facetSummaryUnconditional() {
+    facetSummary() {
       // Derive min/max from full range
       const setMinMax = () => {
         const min = Date.parse(this.facetSummaryUnconditional.bins[0]);
@@ -107,8 +107,7 @@ export default Vue.extend({
       }
     },
     onBrushEnd(brushRange) {
-      console.log('In event handler onBrushEnd', brushRange);
-      if (brushRange || brushRange[0] !== this.min || brushRange[1] !== this.max) {
+      if (brushRange && (brushRange[0] !== this.min || brushRange[1] !== this.max)) {
         this.$emit('select', {
           type: this.table,
           conditions: [
@@ -139,28 +138,17 @@ export default Vue.extend({
       <template #default="{ width, height }">
         <TimeHistogram
           ref="histogram"
-          v-bind="{ width, height, data: facetSummaryUnconditional }"
+          v-bind="{ width, height, data: facetSummaryUnconditional, range: range || [] }"
           @onBrushEnd="onBrushEnd"
         />
       </template>
-      <!--<template #below>
-        <div class="mx-4">
-          <v-range-slider
-            v-model="range"
-            :min="min"
-            :max="max"
-            hide-details
-            color="primary"
-            thumb-color="accent"
-            @change="afterDrag"
-          />
-          <div class="d-flex">
-            <span>{{ moment(range[0]).format('MM/DD/YYYY') }}</span>
-            <v-spacer />
-            <span>{{ moment(range[1]).format('MM/DD/YYYY') }}</span>
-          </div>
+      <template #below>
+        <div class="mx-4 d-flex">
+          <v-spacer />
+          <h4>Collection Date</h4>
+          <v-spacer />
         </div>
-      </template>-->
+      </template>
     </ChartContainer>
   </div>
 </template>

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -106,6 +106,28 @@ export default Vue.extend({
         });
       }
     },
+    onBrushEnd(brushRange) {
+      console.log('In event handler onBrushEnd', brushRange);
+      if (brushRange || brushRange[0] !== this.min || brushRange[1] !== this.max) {
+        this.$emit('select', {
+          type: this.table,
+          conditions: [
+            ...this.otherConditions,
+            {
+              field: this.field,
+              op: 'between',
+              value: brushRange.map((d) => moment(d).format('YYYY-MM-DDT00:00:00.000')),
+              table: this.table,
+            },
+          ],
+        });
+      } else if (this.myConditions.length) {
+        this.$emit('select', {
+          type: this.table,
+          conditions: this.otherConditions,
+        });
+      }
+    },
   },
 });
 </script>
@@ -117,6 +139,7 @@ export default Vue.extend({
         <TimeHistogram
           ref="histogram"
           v-bind="{ width, height, data: facetSummary, range }"
+          @onBrushEnd="onBrushEnd"
         />
       </template>
       <template #below>

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -134,7 +134,6 @@ export default Vue.extend({
 <template>
   <div class="histogram">
     <ChartContainer>
-      <!-- v-if="facetSummaryUnconditional && range !== null">-->
       <template #default="{ width, height }">
         <TimeHistogram
           ref="histogram"

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -134,15 +134,16 @@ export default Vue.extend({
 
 <template>
   <div class="histogram">
-    <ChartContainer v-if="facetSummary && range !== null">
+    <ChartContainer>
+      <!-- v-if="facetSummaryUnconditional && range !== null">-->
       <template #default="{ width, height }">
         <TimeHistogram
           ref="histogram"
-          v-bind="{ width, height, data: facetSummary, range }"
+          v-bind="{ width, height, data: facetSummaryUnconditional }"
           @onBrushEnd="onBrushEnd"
         />
       </template>
-      <template #below>
+      <!--<template #below>
         <div class="mx-4">
           <v-range-slider
             v-model="range"
@@ -159,7 +160,7 @@ export default Vue.extend({
             <span>{{ moment(range[1]).format('MM/DD/YYYY') }}</span>
           </div>
         </div>
-      </template>
+      </template>-->
     </ChartContainer>
   </div>
 </template>

--- a/web/src/components/Presentation/TimeHistogram.vue
+++ b/web/src/components/Presentation/TimeHistogram.vue
@@ -3,6 +3,7 @@ import { defineComponent, watchEffect, ref } from '@vue/composition-api';
 import { select } from 'd3-selection';
 import { max } from 'd3-array';
 import { axisBottom } from 'd3-axis';
+import { brushX } from 'd3-brush';
 import { scaleLinear, scaleTime } from 'd3-scale';
 
 /**
@@ -116,6 +117,30 @@ export default defineComponent({
           .attr('font-size', '10px')
           .html((d) => d.length);
       }
+
+      let rightExtent = 0;
+      const dataRects = svg.selectAll('rect');
+      [...dataRects].forEach((rect) => {
+        const transform = rect.getAttribute('transform');
+        const dx = parseFloat(transform.substring(transform.indexOf('(') + 1, transform.lastIndexOf(')'))
+          .split(',')[0]);
+        const rectWidth = parseFloat(rect.getAttribute('width'));
+        rightExtent = Math.ceil(Math.max(rightExtent, dx + rectWidth));
+      });
+
+      // add the brush
+      const onBrushEnd = ({ selection }) => {
+        console.log('in onBrushEnd', selection);
+      };
+      const brush = brushX()
+        .extent([[0, 0], [rightExtent, props.height - margin.bottom + 0.5]])
+        .on('end', onBrushEnd);
+
+      const defaultSelection = [0, rightExtent];
+
+      const gb = svg.append('g')
+        .call(brush)
+        .call(brush.move, defaultSelection);
 
       // add the x Axis
       svg

--- a/web/src/components/Presentation/TimeHistogram.vue
+++ b/web/src/components/Presentation/TimeHistogram.vue
@@ -131,8 +131,6 @@ export default defineComponent({
 
       // add the brush
       const onBrushEnd = (event) => {
-        // if start, end = extent, clear the query
-        // if start = end, clear the query
         const { selection, sourceEvent } = event;
         if (selection && sourceEvent) {
           const start = x.invert(selection[0]);

--- a/web/src/components/Presentation/TimeHistogram.vue
+++ b/web/src/components/Presentation/TimeHistogram.vue
@@ -143,7 +143,7 @@ export default defineComponent({
         }
       };
       const brush = brushX()
-        .extent([[0, 0], [x.range()[1], props.height - margin.bottom + 0.5]])
+        .extent([[0, 0], [x.range()[1], props.height - (margin.bottom + 19)]])
         .on('end', onBrushEnd);
 
       const bg = svg.append('g')

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -22,7 +22,7 @@ import { makeSetsFromBitmask } from '@/encoding';
 
 const helpBarchart = 'Displays the number of omics processing runs for each data type available. Click on a bar to filter by data type.';
 const helpMap = 'Displays geographical location (latitude, longitude) of sample collection sites. Click on a cluster to zoom in.  Click "Search this regon" to limit search to the current map bounds.';
-const helpTimeline = 'Displays sample collections grouped by collection month. Scroll the slider to narrow in on a sample collection date range.';
+const helpTimeline = 'Displays sample collections grouped by collection month. Click and drag on the timeline to filter by collection date. The selected region can be moved by dragging it from the center. The region can be resized by clicking and dragging at the end. Click outside the region to clear it.';
 const helpUpset = 'This upset plot shows the number of samples with corresponding omic data associated. For example: there are 43 samples from 1 study that have metagenomics, metatranscriptomics, and natural organic matter characterizations.';
 
 const staticUpsetTooltips = {

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -22,7 +22,7 @@ import { makeSetsFromBitmask } from '@/encoding';
 
 const helpBarchart = 'Displays the number of omics processing runs for each data type available. Click on a bar to filter by data type.';
 const helpMap = 'Displays geographical location (latitude, longitude) of sample collection sites. Click on a cluster to zoom in.  Click "Search this regon" to limit search to the current map bounds.';
-const helpTimeline = 'Displays sample collections grouped by collection month. Click and drag on the timeline to filter by collection date. The selected region can be moved by dragging it from the center. The region can be resized by clicking and dragging at the end. Click outside the region to clear it.';
+const helpTimeline = 'Displays sample collections grouped by collection date. Click and drag on the timeline to filter by collection date. The selected region can be moved by dragging it from the center. The region can be resized by clicking and dragging at the edges. Click outside the region to clear it.';
 const helpUpset = 'This upset plot shows the number of samples with corresponding omic data associated. For example: there are 43 samples from 1 study that have metagenomics, metatranscriptomics, and natural organic matter characterizations.';
 
 const staticUpsetTooltips = {


### PR DESCRIPTION
Fixes #675

Instead of using a slider to interact with the date histogram on the home page of the data portal, users can now click and drag to select an area. The selection can be moved, stretched, and shrank by interacting with the highlighted area. The area is responsive to a change in the query (i.e. selecting a date range from the sidebar).