### PR TITLE
Fix DOI representation

### DIFF
--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -56,9 +56,7 @@ def load(db: Session, cursor: Cursor):
         obj["principal_investigator_id"] = get_or_create_pi(db, pi_name, pi_url, pi_orcid)
         obj["principal_investigator_websites"] = obj.pop("websites", [])
 
-        obj["publication_dois"] = [
-            transform_doi(d) for d in obj.pop("publications", [])
-        ]
+        obj["publication_dois"] = [transform_doi(d) for d in obj.pop("publications", [])]
         if "doi" in obj:
             obj["doi"]["has_raw_value"] = transform_doi(obj["doi"]["has_raw_value"])
 

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -32,7 +32,7 @@ def migrate(ingest_db: bool = False):
         database_uri = settings.current_db_uri
         session_maker = database.SessionLocal
 
-    with session_maker.begin():
+    with session_maker.begin(): # type: ignore
         alembic_cfg = Config(str(HERE / "alembic.ini"))
         alembic_cfg.set_main_option("script_location", str(HERE / "migrations"))
         alembic_cfg.set_main_option("sqlalchemy.url", database_uri)

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -32,7 +32,7 @@ def migrate(ingest_db: bool = False):
         database_uri = settings.current_db_uri
         session_maker = database.SessionLocal
 
-    with session_maker.begin(): # type: ignore
+    with session_maker.begin():  # type: ignore
         alembic_cfg = Config(str(HERE / "alembic.ini"))
         alembic_cfg.set_main_option("script_location", str(HERE / "migrations"))
         alembic_cfg.set_main_option("sqlalchemy.url", database_uri)

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -32,7 +32,7 @@ def migrate(ingest_db: bool = False):
         database_uri = settings.current_db_uri
         session_maker = database.SessionLocal
 
-    with session_maker():
+    with session_maker.begin():
         alembic_cfg = Config(str(HERE / "alembic.ini"))
         alembic_cfg.set_main_option("script_location", str(HERE / "migrations"))
         alembic_cfg.set_main_option("sqlalchemy.url", database_uri)

--- a/nmdc_server/migrations/versions/86f42a05252b_ck_doi_format.py
+++ b/nmdc_server/migrations/versions/86f42a05252b_ck_doi_format.py
@@ -1,0 +1,65 @@
+"""empty message
+
+Revision ID: 86f42a05252b
+Revises: ffaec255fe68
+Create Date: 2022-10-27 16:44:51.540940
+
+"""
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '86f42a05252b'
+down_revision: Optional[str] = 'ffaec255fe68'
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    # drop FK constraints for tables that point to doi_info
+    op.drop_constraint(
+        "fk_study_doi_doi_info",
+        "study",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_publication_doi_doi_info",
+        "publication",
+        type_="foreignkey",
+    )
+
+    # transform DOIs to standardized format
+    op.execute(r"UPDATE study SET doi = substring(doi FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')")
+    op.execute(r"UPDATE publication SET doi = substring(doi FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')")
+    op.execute(r"UPDATE doi_info SET id = substring(id FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')")
+
+    # add CHECK constraint for standardized DOI format
+    op.create_check_constraint(
+        "ck_doi_format",
+        "doi_info",
+        r"id ~* '^10.\d{4,9}/[-._;()/:a-zA-Z0-9]+$'",
+    )
+
+    # add back FK constraints for tables that point to doi_info
+    op.create_foreign_key(
+        "fk_publication_doi_doi_info",
+        "publication",
+        "doi_info",
+        ["doi"], ["id"],
+    )
+    op.create_foreign_key(
+        "fk_study_doi_doi_info",
+        "study",
+        "doi_info",
+        ["doi"], ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "ck_doi_format",
+        "doi_info",
+        type_="check"
+    )

--- a/nmdc_server/migrations/versions/86f42a05252b_ck_doi_format.py
+++ b/nmdc_server/migrations/versions/86f42a05252b_ck_doi_format.py
@@ -7,12 +7,11 @@ Create Date: 2022-10-27 16:44:51.540940
 """
 from typing import Optional
 
-import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = '86f42a05252b'
-down_revision: Optional[str] = 'ffaec255fe68'
+revision: str = "86f42a05252b"
+down_revision: Optional[str] = "ffaec255fe68"
 branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 
@@ -32,7 +31,9 @@ def upgrade():
 
     # transform DOIs to standardized format
     op.execute(r"UPDATE study SET doi = substring(doi FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')")
-    op.execute(r"UPDATE publication SET doi = substring(doi FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')")
+    op.execute(
+        r"UPDATE publication SET doi = substring(doi FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')"
+    )
     op.execute(r"UPDATE doi_info SET id = substring(id FROM '10.\d{4,9}/[-._;()/\:a-zA-Z0-9]+')")
 
     # add CHECK constraint for standardized DOI format
@@ -47,19 +48,17 @@ def upgrade():
         "fk_publication_doi_doi_info",
         "publication",
         "doi_info",
-        ["doi"], ["id"],
+        ["doi"],
+        ["id"],
     )
     op.create_foreign_key(
         "fk_study_doi_doi_info",
         "study",
         "doi_info",
-        ["doi"], ["id"],
+        ["doi"],
+        ["id"],
     )
 
 
 def downgrade():
-    op.drop_constraint(
-        "ck_doi_format",
-        "doi_info",
-        type_="check"
-    )
+    op.drop_constraint("ck_doi_format", "doi_info", type_="check")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -183,7 +183,7 @@ class DOIInfo(Base):
     id = Column(
         String,
         CheckConstraint(r"id ~* '^10.\d{4,9}/[-._;()/:a-zA-Z0-9]+$'", name="ck_doi_format"),
-        primary_key=True
+        primary_key=True,
     )
     info = Column(JSONB, nullable=False, default=dict)
 

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -180,7 +180,11 @@ class PrincipalInvestigator(Base):
 class DOIInfo(Base):
     __tablename__ = "doi_info"
 
-    id = Column(String, primary_key=True)
+    id = Column(
+        String,
+        CheckConstraint(r"id ~* '^10.\d{4,9}/[-._;()/:a-zA-Z0-9]+$'", name="ck_doi_format"),
+        primary_key=True
+    )
     info = Column(JSONB, nullable=False, default=dict)
 
 

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -243,7 +243,7 @@ class Study(Base, AnnotatedModel):
         return gold_url("https://gold.jgi.doe.gov/study?id=", self.id)
 
     @property
-    def publication_doi_info(self) -> Dict[str, Any]:
+    def doi_map(self) -> Dict[str, Any]:
         doi_info = {
             d.publication.doi: d.publication.doi_object.info
             for d in self.publication_dois  # type: ignore

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -258,7 +258,7 @@ class Study(StudyBase):
     sample_count: Optional[int]
     omics_counts: Optional[List[OmicsCounts]]
     omics_processing_counts: Optional[List[OmicsCounts]]
-    publication_doi_info: Dict[str, Any] = {}
+    doi_map: Dict[str, Any] = {}
     multiomics: int
 
     class Config:

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -121,7 +121,7 @@ export interface StudySearchResults extends BaseSearchResult {
   principal_investigator_name: string;
   principal_investigator_image_url: string;
   principal_investigator: PrincipalInvestigator;
-  publication_doi_info: Record<string, {
+  doi_map: Record<string, {
     type: string;
   }>,
   publication_dois: string[];

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -121,6 +121,7 @@ export interface StudySearchResults extends BaseSearchResult {
   principal_investigator_name: string;
   principal_investigator_image_url: string;
   principal_investigator: PrincipalInvestigator;
+  doi: string;
   doi_map: Record<string, {
     type: string;
   }>,

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -188,7 +188,10 @@ export default defineComponent({
               Study Details
             </div>
             <v-list>
-              <AttributeItem v-bind="{ item, field: 'doi' }" />
+              <AttributeItem
+                v-if="item.doi"
+                v-bind="{ item, field: 'doi' }"
+              />
               <AttributeItem
                 v-bind="{ item, field: 'id', bindClick: true }"
                 @click="seeStudyInContext"
@@ -260,8 +263,13 @@ export default defineComponent({
         </v-col>
         <v-col cols="5">
           <div class="ma-4 pa-2 grey lighten-4">
-            <v-subheader>Dataset Citation</v-subheader>
-            <v-list class="transparent">
+            <v-subheader v-if="item.doi">
+              Dataset Citation
+            </v-subheader>
+            <v-list
+              v-if="item.doi"
+              class="transparent"
+            >
               <v-divider />
               <v-list-item>
                 <v-list-item-content

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -120,14 +120,10 @@ export default defineComponent({
       if (doiMap) {
         data.doiCitation = null;
         data.publications = [];
-        const unformattedPublications = Object.values(doiMap);
-
-        [data.doiCitation] = unformattedPublications
-          .filter((c) => c.type === 'dataset' && c.type)
-          .map((c) => formatAPA(new Cite(c)));
-        data.publications = unformattedPublications
-          .filter((c) => c.type !== 'dataset' && c.type)
-          .map((c) => formatAPA(new Cite(c)));
+        data.doiCitation = CitationOverrides[_item.doi] || formatAPA(new Cite(_item.doi));
+        data.publications = _item.publication_dois
+          .filter((doi) => doi in doiMap)
+          .map((doi) => formatAPA(new Cite(doiMap[doi])));
       }
     });
 
@@ -269,7 +265,7 @@ export default defineComponent({
               <v-divider />
               <v-list-item>
                 <v-list-item-content
-                  v-text="data.doiCitation || CitationOverrides[item.doi] || item.doi"
+                  v-text="data.doiCitation || item.doi"
                 />
                 <v-list-item-action>
                   <v-tooltip top>

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -113,11 +113,11 @@ export default defineComponent({
     }
 
     watch(item, async (_item) => {
-      const publicationDoiInfo = _item?.publication_doi_info;
-      if (publicationDoiInfo) {
+      const doiMap = _item?.doi_map;
+      if (doiMap) {
         data.doiCitation = null;
         data.publications = [];
-        const unformattedPublications = Object.values(publicationDoiInfo);
+        const unformattedPublications = Object.values(doiMap);
 
         [data.doiCitation] = unformattedPublications
           .filter((c) => c.type === 'dataset' && c.type)

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -19,7 +19,7 @@ import InvestigatorBio from '@/components/InvestigatorBio.vue';
  * Override citations for certain DOIs
  */
 const CitationOverrides = {
-  'https://doi.org/10.46936/10.25585/60000017': 'Doktycz, M. (2020) BioScales - Defining plant gene function and its connection to ecosystem nitrogen and carbon cycling [Data set]. DOE Joint Genome Institute. https://doi.org/10.46936/10.25585/60000017',
+  '10.46936/10.25585/60000017': 'Doktycz, M. (2020) BioScales - Defining plant gene function and its connection to ecosystem nitrogen and carbon cycling [Data set]. DOE Joint Genome Institute. https://doi.org/10.46936/10.25585/60000017',
 };
 
 export default defineComponent({

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -18,7 +18,10 @@ import InvestigatorBio from '@/components/InvestigatorBio.vue';
 /**
  * Override citations for certain DOIs
  */
-const CitationOverrides = {
+ interface CitationOverridesType {
+  [key: string]: string;
+}
+const CitationOverrides: CitationOverridesType = {
   '10.46936/10.25585/60000017': 'Doktycz, M. (2020) BioScales - Defining plant gene function and its connection to ecosystem nitrogen and carbon cycling [Data set]. DOE Joint Genome Institute. https://doi.org/10.46936/10.25585/60000017',
 };
 


### PR DESCRIPTION
Closes #772

A study's DOI information is related to:

- the study's produced dataset
- publications using the dataset

Historically, the type of each of the study's DOIs was indicated via attributes on the DOI information. The schema has since changed  so that each study can indicate separately its dataset's DOI and publication DOIs. The backend supports this schema, but the frontend was not updated to.

This PR:

- updates the frontend to use the explicit DOI form
- normalizes the form of DOI data (previously could be a URL or just the DOI)
- conditionally renders the dataset's DOI to hide this information if not available

