### PR TITLE
Use `openssl-legacy-provider` during build with Node.js 18

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -57,6 +57,7 @@ RUN set -ex \
     done
 
 FROM node:lts as build-stage
+ENV NODE_OPTIONS=--openssl-legacy-provider
 WORKDIR /app
 COPY package*.json yarn.lock ./
 RUN yarn install


### PR DESCRIPTION
[CD failed on the last merge to main](https://github.com/microbiomedata/nmdc-server/actions/runs/3348377769/jobs/5547371480) triggered by the Node.js LTS version changing from 16 to 18. Setting this environment variable during the build stage seems to fix it.