### PR TITLE
Merge conflicting migrations

### DIFF
--- a/nmdc_server/alembic.ini
+++ b/nmdc_server/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = nmdc_server/migrations
+script_location = migrations
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/nmdc_server/alembic.ini
+++ b/nmdc_server/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # path to migration scripts
-script_location = migrations
+script_location = nmdc_server/migrations
 
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s

--- a/nmdc_server/migrations/versions/3be1e63ce89b_.py
+++ b/nmdc_server/migrations/versions/3be1e63ce89b_.py
@@ -1,0 +1,22 @@
+"""empty message
+
+Revision ID: 3be1e63ce89b
+Revises: ae7a3eba08c5, 86f42a05252b
+Create Date: 2022-11-29 11:26:29.357442
+
+"""
+from typing import Optional, Tuple
+
+# revision identifiers, used by Alembic.
+revision: str = "3be1e63ce89b"
+down_revision: Tuple[str, str] = ("ae7a3eba08c5", "86f42a05252b")
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
#797 and #798 contained alembic migration files that resulted in a state of multiple `head` revisions, which broke running `nmdc_server`.

This PR addresses this by merging the revisions via `alembic merge heads`