### PR TITLE
Update python and nmdc-schema

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: [3.9, '3.10']
 
     steps:
     - uses: harmon758/postgresql-action@v1

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.9, 3.10]
 
     steps:
     - uses: harmon758/postgresql-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tiangolo/uvicorn-gunicorn:python3.8
+FROM tiangolo/uvicorn-gunicorn:python3.9
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
 RUN apt-get update && apt-get install -y postgresql-client

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
 RUN apt-get update && apt-get install -y postgresql-client

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="nmdc-server",
     version="0.1",
     packages=find_packages(),
-    python_requires=">=3.7.0",
+    python_requires=">=3.9.0",
     install_requires=[
         # pinned because recent versions throw an error when upgrading through
         # the api at nmdc_server/jobs.py:34
@@ -19,7 +19,7 @@ setup(
         "ipython==7.31.1",
         "itsdangerous==2.0.1",
         "mypy<0.920",
-        "nmdc-schema",
+        "nmdc-schema==3.2.0", # https://github.com/microbiomedata/nmdc-server/issues/803#issuecomment-1320214791
         "pint==0.18",
         "psycopg2==2.9.3",
         "pydantic==1.8.2",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "ipython==7.31.1",
         "itsdangerous==2.0.1",
         "mypy<0.920",
-        "nmdc-schema==3.2.0", # https://github.com/microbiomedata/nmdc-server/issues/803#issuecomment-1320214791
+        "nmdc-schema",
         "pint==0.18",
         "psycopg2==2.9.3",
         "pydantic==1.8.2",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py37, py38, lint, typecheck, black, ingest
+envlist = py39, py310, lint, typecheck, black, ingest
 skip_missing_interpreters = true
 
 [gh-actions]
 python =
-  3.7: py37
-  3.8: py38, lint, typecheck, black
+  3.9: py39
+  3.10: py310, lint, typecheck, black
 
 [testenv]
 deps =


### PR DESCRIPTION
This change updates the minimum python version required for `nmdc-server` to 3.9.

With #797, our migration script and database supports ingest of data compliant with NMDC schema version 7. This change will allow us to use the most recent release of the `nmdc-schema` package as well, since that required python>3.9.