### PR TITLE
Move documentation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ NMDC_HOST=http://localhost:8080
 docker-compose up -d
 ```
 
-View main application at `http://localhost:8080/` and the swagger page at `http://localhost:8080/docs`.
+View main application at `http://localhost:8080/` and the swagger page at `http://localhost:8080/api/docs`.
 
 ## Development Setup (outside docker)
 
@@ -58,7 +58,7 @@ pip install uvicorn tox
 uvicorn nmdc_server.asgi:app --reload
 ```
 
-View swagger page at `http://localhost:8000/docs`.
+View swagger page at `http://localhost:8000/api/docs`.
 
 ## Running ingest
 

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -23,6 +23,7 @@ def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     app = FastAPI(
         title="NMDC Dataset API",
         version=__version__,
+        docs_url="/api/docs",
     )
     attach_sentry(app)
 

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -2,6 +2,7 @@ import typing
 
 import sentry_sdk
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -25,8 +26,12 @@ def create_app(env: typing.Mapping[str, str]) -> FastAPI:
         version=__version__,
         docs_url="/api/docs",
     )
-    attach_sentry(app)
 
+    @app.get("/docs", response_class=RedirectResponse, status_code=301, include_in_schema=False)
+    async def redirect_docs():
+        return "/api/docs"
+
+    attach_sentry(app)
     errors.attach_error_handlers(app)
     app.include_router(api.router, prefix="/api")
     app.include_router(auth.router, prefix="")


### PR DESCRIPTION
Closes https://github.com/microbiomedata/issues/issues/19

This PR moves the API docs from "/docs" to "/api/docs".

Although references to "/docs" have been updated in the README.md, a [301 Moved Permanently](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301) response is added to the backend in case this is being referenced elsewhere.

Test this by:
- visiting "/api/docs" and ensuring the documentation is visible
- visiting "/docs" and ensuring you're redirected to "/api/docs"