### PR TITLE
Move location of openapi schema

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -25,6 +25,7 @@ def create_app(env: typing.Mapping[str, str]) -> FastAPI:
         title="NMDC Dataset API",
         version=__version__,
         docs_url="/api/docs",
+        openapi_url="/api/openapi.json",
     )
 
     @app.get("/docs", response_class=RedirectResponse, status_code=301, include_in_schema=False)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -20,7 +20,7 @@ def assert_status(response: Response, status: int = 200):
 
 
 def test_api_spec(client: TestClient):
-    resp = client.get("/openapi.json")
+    resp = client.get("/api/openapi.json")
     assert resp.status_code == 200
     assert resp.json()["info"]["version"] == nmdc_server.__version__
 


### PR DESCRIPTION
Solves #825 

This is to improve the data portal's API compatibility with the reverse proxy set up to unify this API with the NMDC runtime API. Due to how FastAPI's documentation endpoint works, we needed to move where the openapi json schema was served from to ensure compatibility with the unified API.

Previously, [api-dev.microbiomedata.org/api/docs](api-dev.microbiomedata.org/api/docs) was serving the runtime API documentation, where it should be serving the data portal API documentation.

To Test:
- visit /api/openapi.json and make sure the schema is served from that endpoint.