### PR TITLE
Persist facility, award, and shipping data

### DIFF
--- a/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
+++ b/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
@@ -79,10 +79,10 @@ def upgrade():
         if isinstance(metadata_submission, List):
             continue
 
-        if not metadata_submission.get("context_form", None):
-            metadata_submission["context_form"] = ContextForm().dict()
-        if not metadata_submission.get("address_form"):
-            metadata_submission["address_form"] = AddressForm().dict()
+        if not metadata_submission.get("contextForm", None):
+            metadata_submission["contextForm"] = ContextForm().dict()
+        if not metadata_submission.get("addressForm"):
+            metadata_submission["addressForm"] = AddressForm().dict()
         mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
     session.bulk_update_mappings(SubmissionMetadata, mappings)
     session.commit()
@@ -96,10 +96,10 @@ def downgrade():
         if isinstance(metadata_submission, List):
             continue
 
-        if metadata_submission["context_form"]:
-            del metadata_submission["context_form"]
-        if metadata_submission["address_form"]:
-            del metadata_submission["address_form"]
+        if metadata_submission.get("contextForm", None):
+            del metadata_submission["contextForm"]
+        if metadata_submission.get("addressForm", None):
+            del metadata_submission["addressForm"]
         mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
     session.bulk_update_mappings(SubmissionMetadata, mappings)
     session.commit()

--- a/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
+++ b/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
@@ -64,6 +64,7 @@ class AddressForm(BaseModel):
 
 
 class ContextForm(BaseModel):
+    datasetDoi: str = ""
     dataGenerated: Optional[bool] = None
     facilityGenerated: Optional[bool] = None
     facilities: List[str] = []
@@ -80,7 +81,11 @@ def upgrade():
             continue
 
         if not metadata_submission.get("contextForm", None):
-            metadata_submission["contextForm"] = ContextForm().dict()
+            context_form = ContextForm().dict()
+            context_form["datasetDoi"] = metadata_submission.get("multiOmicsForm", {}).get(
+                "datasetDoi", ""
+            )
+            metadata_submission["contextForm"] = context_form
         if not metadata_submission.get("addressForm"):
             metadata_submission["addressForm"] = AddressForm().dict()
         mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
@@ -97,6 +102,8 @@ def downgrade():
             continue
 
         if metadata_submission.get("contextForm", None):
+            context_form = metadata_submission["contextForm"]
+            metadata_submission["multiOmicsForm"]["datasetDoi"] = context_form.get("datasetDoi", "")
             del metadata_submission["contextForm"]
         if metadata_submission.get("addressForm", None):
             del metadata_submission["addressForm"]

--- a/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
+++ b/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import uuid4
 
-import sqlalchemy as sa
 from alembic import op
 from pydantic import BaseModel
 from sqlalchemy import Column, orm
@@ -77,7 +76,10 @@ def upgrade():
     mappings = []
     for submission_metadata in session.query(SubmissionMetadata):
         metadata_submission = submission_metadata.metadata_submission
-        if not metadata_submission.get("context_form"):
+        if isinstance(metadata_submission, List):
+            continue
+
+        if not metadata_submission.get("context_form", None):
             metadata_submission["context_form"] = ContextForm().dict()
         if not metadata_submission.get("address_form"):
             metadata_submission["address_form"] = AddressForm().dict()
@@ -91,6 +93,9 @@ def downgrade():
     mappings = []
     for submission_metadata in session.query(SubmissionMetadata):
         metadata_submission = submission_metadata.metadata_submission
+        if isinstance(metadata_submission, List):
+            continue
+
         if metadata_submission["context_form"]:
             del metadata_submission["context_form"]
         if metadata_submission["address_form"]:

--- a/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
+++ b/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
@@ -1,0 +1,100 @@
+"""additional submission build wizard step
+
+Revision ID: 9bbb32f36d19
+Revises: ae7a3eba08c5
+Create Date: 2023-02-02 19:54:44.340586
+
+"""
+from datetime import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from pydantic import BaseModel
+from sqlalchemy import Column, orm
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9bbb32f36d19"
+down_revision: Optional[str] = "ae7a3eba08c5"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+# Redefine SubmissionMetadata, including only what we need for this migration
+# to ensure this migration is self-contained.
+# https://stackoverflow.com/questions/17547119/accessing-models-in-alembic-migrations
+class SubmissionMetadata(Base):
+    __tablename__ = "submission_metadata"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    metadata_submission = Column(JSONB, nullable=False)
+
+
+# Similarly, redefine pydantic models for context_ and address_form
+class NmcdAddress(BaseModel):
+    name: str = ""
+    email: str = ""
+    phone: str = ""
+    line1: str = ""
+    line2: str = ""
+    city: str = ""
+    state: str = ""
+    postalCode: str = ""
+
+
+class AddressForm(BaseModel):
+    shipper: NmcdAddress = NmcdAddress()
+    expectedShippingDate: Optional[datetime] = None
+    shippingConditions: str = ""
+    sample: str = ""
+    description: str = ""
+    experimentalGoals: str = ""
+    randomization: str = ""
+    usdaRegulated: Optional[bool] = None
+    permitNumber: str = ""
+    biosafetyLevel: str = ""
+    irpOrHipaa: Optional[bool] = None
+    irbNumber: str = ""
+    irbAddress: NmcdAddress = NmcdAddress()
+    comments: str = ""
+
+
+class ContextForm(BaseModel):
+    dataGenerated: Optional[bool] = None
+    facilityGenerated: Optional[bool] = None
+    facilities: List[str] = []
+    award: Optional[str] = None
+    otherAward: str = ""
+
+
+def upgrade():
+    session = orm.Session(bind=op.get_bind())
+    mappings = []
+    for submission_metadata in session.query(SubmissionMetadata):
+        metadata_submission = submission_metadata.metadata_submission
+        if not metadata_submission.get("context_form"):
+            metadata_submission["context_form"] = ContextForm().dict()
+        if not metadata_submission.get("address_form"):
+            metadata_submission["address_form"] = AddressForm().dict()
+        mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
+    session.bulk_update_mappings(SubmissionMetadata, mappings)
+    session.commit()
+
+
+def downgrade():
+    session = orm.Session(bind=op.get_bind())
+    mappings = []
+    for submission_metadata in session.query(SubmissionMetadata):
+        metadata_submission = submission_metadata.metadata_submission
+        if metadata_submission["context_form"]:
+            del metadata_submission["context_form"]
+        if metadata_submission["address_form"]:
+            del metadata_submission["address_form"]
+        mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
+    session.bulk_update_mappings(SubmissionMetadata, mappings)
+    session.commit()

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -36,9 +36,47 @@ class MultiOmicsForm(BaseModel):
     omicsProcessingTypes: List[str]
 
 
+class NmcdAddress(BaseModel):
+    name: str
+    email: str
+    phone: str
+    line1: str
+    line2: str
+    city: str
+    state: str
+    postalCode: str
+
+
+class AddressForm(BaseModel):
+    shipper: NmcdAddress
+    expectedShippingDate: datetime
+    shippingConditions: str
+    sample: str
+    description: str
+    experimentalGoals: str
+    randomization: str
+    usdaRegulated: bool
+    permitNumber: str
+    biosafetyLevel: str
+    irpOrHipaa: bool
+    irbNumber: str
+    irbAddress: NmcdAddress
+    comments: str
+
+
+class ContextForm(BaseModel):
+    dataGenerated: Optional[bool]
+    facilityGenerated: Optional[bool]
+    facilities: List[str]
+    award: Optional[str]
+    otherAward: str
+
+
 class MetadataSubmissionRecord(BaseModel):
     packageName: str
     template: str
+    contextForm: ContextForm
+    addressForm: Optional[AddressForm]
     studyForm: StudyForm
     multiOmicsForm: MultiOmicsForm
     sampleData: List[List[Any]]

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -49,16 +49,16 @@ class NmcdAddress(BaseModel):
 
 class AddressForm(BaseModel):
     shipper: NmcdAddress
-    expectedShippingDate: datetime
+    expectedShippingDate: Optional[datetime]
     shippingConditions: str
     sample: str
     description: str
     experimentalGoals: str
     randomization: str
-    usdaRegulated: bool
+    usdaRegulated: Optional[bool]
     permitNumber: str
     biosafetyLevel: str
-    irpOrHipaa: bool
+    irpOrHipaa: Optional[bool]
     irbNumber: str
     irbAddress: NmcdAddress
     comments: str
@@ -76,7 +76,7 @@ class MetadataSubmissionRecord(BaseModel):
     packageName: str
     template: str
     contextForm: ContextForm
-    addressForm: Optional[AddressForm]
+    addressForm: AddressForm
     studyForm: StudyForm
     multiOmicsForm: MultiOmicsForm
     sampleData: List[List[Any]]

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -26,7 +26,6 @@ class StudyForm(BaseModel):
 
 
 class MultiOmicsForm(BaseModel):
-    datasetDoi: str
     alternativeNames: List[str]
     studyNumber: str
     GOLDStudyId: str
@@ -65,6 +64,7 @@ class AddressForm(BaseModel):
 
 
 class ContextForm(BaseModel):
+    datasetDoi: str
     dataGenerated: Optional[bool]
     facilityGenerated: Optional[bool]
     facilities: List[str]

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -22,8 +22,6 @@ export default defineComponent({
       templateChoiceDisabled,
       /* functions */
       reValidate,
-      /* Rules functions */
-      // datasetDoiRules,
     };
   },
 });
@@ -51,19 +49,7 @@ export default defineComponent({
         class="mb-2 mt-0"
         @change="reValidate"
       />
-      <v-text-field
-        v-if="multiOmicsAssociations.doi"
-        v-model="multiOmicsForm.datasetDoi"
-        :rules="[ v => !!v || 'DOI is required when data has been generated already' ]"
-        :hint="Definitions.doi"
-        persistent-hint
-        label="Dataset DOI *"
-        validate-on-blur
-        outlined
-        dense
-      />
       <div
-        v-else
         class="my-5"
       />
 

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineComponent, ref } from '@vue/composition-api';
+import Definitions from '@/definitions';
 import {
   contextForm,
   contextFormValid,
@@ -21,6 +22,7 @@ export default defineComponent({
     const biosafetyLevels = ref(['BSL2']);
 
     return {
+      Definitions,
       formRef,
       contextForm,
       contextFormValid,
@@ -64,6 +66,17 @@ export default defineComponent({
           :value="true"
         />
       </v-radio-group>
+      <v-text-field
+        v-if="contextForm.dataGenerated"
+        v-model="contextForm.datasetDoi"
+        label="Dataset DOI *"
+        :hint="Definitions.doi"
+        :rules="[v => !!v || 'DOI is required when data has been generated already.' ]"
+        persistent-hint
+        validate-on-blur
+        outlined
+        dense
+      />
       <v-checkbox
         v-if="contextForm.dataGenerated"
         v-model="contextForm.facilityGenerated"

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -35,6 +35,7 @@ interface MetadataSubmission {
   packageName: keyof typeof HARMONIZER_TEMPLATES;
   template: string;
   contextForm: any;
+  addressForm: any;
   studyForm: any;
   multiOmicsForm: any;
   sampleData: any[][];

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -184,6 +184,8 @@ async function loadRecord(id: string) {
   packageName.value = val.metadata_submission.packageName;
   Object.assign(studyForm, val.metadata_submission.studyForm);
   Object.assign(multiOmicsForm, val.metadata_submission.multiOmicsForm);
+  Object.assign(contextForm, val.metadata_submission.contextForm);
+  Object.assign(addressForm, val.metadata_submission.addressForm);
   sampleData.value = val.metadata_submission.sampleData;
   hasChanged.value = 0;
 }

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -13,13 +13,6 @@ const hasChanged = ref(0);
 /**
  * Submission Context Step
  */
-const contextFormDefault = {
-  dataGenerated: undefined as undefined | boolean,
-  facilityGenerated: undefined as undefined | boolean,
-  facilities: [] as string[],
-  award: undefined as undefined | string,
-  otherAward: '',
-};
 const addressFormDefault = {
   // Shipper info
   shipper: {
@@ -56,6 +49,13 @@ const addressFormDefault = {
     postalCode: '',
   } as api.NmdcAddress,
   comments: '',
+};
+const contextFormDefault = {
+  dataGenerated: undefined as undefined | boolean,
+  facilityGenerated: undefined as undefined | boolean,
+  facilities: [] as string[],
+  award: undefined as undefined | string,
+  otherAward: '',
 };
 const contextForm = reactive(clone(contextFormDefault));
 const contextFormValid = ref(false);
@@ -150,6 +150,9 @@ function reset() {
   Object.assign(addressForm, addressFormDefault);
   addressFormValid.value = false;
   studyFormValid.value = false;
+  addressFormValid.value = false;
+  Object.assign(contextForm, contextFormDefault);
+  Object.assign(addressForm, addressFormDefault);
   Object.assign(studyForm, studyFormDefault);
   multiOmicsFormValid.value = false;
   Object.assign(multiOmicsForm, multiOmicsFormDefault);

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -52,6 +52,7 @@ const addressFormDefault = {
 };
 const contextFormDefault = {
   dataGenerated: undefined as undefined | boolean,
+  datasetDoi: '',
   facilityGenerated: undefined as undefined | boolean,
   facilities: [] as string[],
   award: undefined as undefined | string,
@@ -87,7 +88,6 @@ const studyForm = reactive(clone(studyFormDefault));
  * Multi-Omics Form Step
  */
 const multiOmicsFormDefault = {
-  datasetDoi: '',
   alternativeNames: [] as string[],
   studyNumber: '',
   GOLDStudyId: '',


### PR DESCRIPTION
This PR holds the set of changes that persist submission portal data collected from the new context/address form. For more information on how that form integrates into the existing workflow, see [this diagram](https://lucid.app/lucidchart/75516c27-0974-4a77-ae92-73234e3f385e/edit?invitationId=inv_8fe7dca1-e52f-431c-9a0e-f1e6dd1e3a72&page=0_0#).

This PR contains changes to our pydantic models. Since attempting to load old data (without context/address form) would result in errors, a database migration that converts metadata submissions to be compatible with model changes is also included in this set of changes.