### PR TITLE
Context and address form validation

### DIFF
--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-unused-vars': 2,
         'no-undef': 'off',
+        'no-shadow': 'off',
       },
     },
   ],

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -21,7 +21,7 @@ export default defineComponent({
     const projectAwardValidationRules = () => [(v: string) => {
       const awardChosen = v === 'MONet' || v === 'FICUS' || v === contextForm.otherAward;
       const valid = awardChosen || contextForm.facilities.length === 0;
-      return valid || 'If submitting to a use facility, this field is required.'
+      return valid || 'If submitting to a use facility, this field is required.';
     }];
     const otherAwardValidationRules = () => [(v: string) => {
       const awardTypes = Object.values(AwardTypes) as string[];

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -38,7 +38,7 @@ export default defineComponent({
       }
       return true;
     }];
-    const reValidate = () => {
+    const revalidate = () => {
       nextTick(() => formRef.value.validate());
     };
 
@@ -49,7 +49,7 @@ export default defineComponent({
         if (award && awardTypes.includes(award)) {
           contextForm.otherAward = '';
         }
-        reValidate();
+        revalidate();
       },
     );
 
@@ -65,7 +65,7 @@ export default defineComponent({
       contextFormValid,
       projectAwardValidationRules,
       otherAwardValidationRules,
-      reValidate,
+      revalidate,
     };
   },
 });
@@ -89,7 +89,7 @@ export default defineComponent({
         v-model="contextForm.dataGenerated"
         label="Has data already been generated for your study? *"
         :rules="[v => (v === true || v === false) || 'This field is required']"
-        @change="reValidate"
+        @change="revalidate"
       >
         <v-radio
           label="No"
@@ -110,7 +110,7 @@ export default defineComponent({
         validate-on-blur
         outlined
         dense
-        @change="reValidate"
+        @change="revalidate"
       />
       <v-checkbox
         v-if="contextForm.dataGenerated"
@@ -133,7 +133,7 @@ export default defineComponent({
           :label="facility"
           :value="facility"
           hide-details
-          @change="reValidate"
+          @change="revalidate"
         />
         <submission-context-shipping-form
           v-if="contextForm.dataGenerated === false && contextForm.facilities.includes('EMSL')"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -6,6 +6,7 @@ import {
   watch,
   nextTick,
 } from '@vue/composition-api';
+import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
 import Definitions from '@/definitions';
 import {
   contextForm,
@@ -18,6 +19,9 @@ export default defineComponent({
   components: { SubmissionContextShippingForm },
   setup() {
     const formRef = ref();
+    const facilityEnum = NmdcSchema.$defs.ProcessingInstitutionEnum.enum.filter(
+      (facility: string) => ['EMSL', 'JGI'].includes(facility),
+    );
     const projectAwardValidationRules = () => [(v: string) => {
       const awardChosen = v === 'MONet' || v === 'FICUS' || v === contextForm.otherAward;
       const valid = awardChosen || contextForm.facilities.length === 0;
@@ -55,6 +59,7 @@ export default defineComponent({
 
     return {
       Definitions,
+      facilityEnum,
       formRef,
       contextForm,
       contextFormValid,
@@ -122,17 +127,11 @@ export default defineComponent({
           Are you submitting metadata for samples that will be sent to a DOE user facility?
         </legend>
         <v-checkbox
+          v-for="facility in facilityEnum"
+          :key="facility"
           v-model="contextForm.facilities"
-          label="EMSL"
-          value="EMSL"
-          hide-details
-          @change="reValidate"
-        />
-        <v-checkbox
-          v-model="contextForm.facilities"
-          class="mt-2"
-          label="JGI"
-          value="JGI"
+          :label="facility"
+          :value="facility"
           hide-details
           @change="reValidate"
         />

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -105,6 +105,7 @@ export default defineComponent({
         validate-on-blur
         outlined
         dense
+        @change="reValidate"
       />
       <v-checkbox
         v-if="contextForm.dataGenerated"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -34,14 +34,9 @@ export default defineComponent({
       }
       return true;
     }];
-
-    watch(
-      () => contextForm.facilities,
-      () => {
-        nextTick(() => formRef.value.validate());
-      },
-      { deep: true },
-    );
+    const reValidate = () => {
+      nextTick(() => formRef.value.validate());
+    };
 
     watch(
       () => contextForm.award,
@@ -50,7 +45,7 @@ export default defineComponent({
         if (award && awardTypes.includes(award)) {
           contextForm.otherAward = '';
         }
-        nextTick(() => formRef.value.validate());
+        reValidate();
       },
     );
 
@@ -65,6 +60,7 @@ export default defineComponent({
       contextFormValid,
       projectAwardValidationRules,
       otherAwardValidationRules,
+      reValidate,
     };
   },
 });
@@ -88,6 +84,7 @@ export default defineComponent({
         v-model="contextForm.dataGenerated"
         label="Has data already been generated for your study?*"
         :rules="[v => (v === true || v === false) || 'This field is required']"
+        @change="reValidate"
       >
         <v-radio
           label="No"
@@ -128,6 +125,7 @@ export default defineComponent({
           label="EMSL"
           value="EMSL"
           hide-details
+          @change="reValidate"
         />
         <v-checkbox
           v-model="contextForm.facilities"
@@ -135,6 +133,7 @@ export default defineComponent({
           label="JGI"
           value="JGI"
           hide-details
+          @change="reValidate"
         />
         <submission-context-shipping-form
           v-if="contextForm.dataGenerated === false && contextForm.facilities.includes('EMSL')"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -82,7 +82,7 @@ export default defineComponent({
     >
       <v-radio-group
         v-model="contextForm.dataGenerated"
-        label="Has data already been generated for your study?*"
+        label="Has data already been generated for your study? *"
         :rules="[v => (v === true || v === false) || 'This field is required']"
         @change="reValidate"
       >
@@ -119,7 +119,7 @@ export default defineComponent({
           class="v-label theme--light mb-2"
           style="font-size: 14px;"
         >
-          Are you submitting metadata for samples that will be sent to a DOE user factility?
+          Are you submitting metadata for samples that will be sent to a DOE user facility?
         </legend>
         <v-checkbox
           v-model="contextForm.facilities"
@@ -142,7 +142,7 @@ export default defineComponent({
         <v-radio-group
           v-if="contextForm.dataGenerated === false && contextForm.facilities.length > 0"
           v-model="contextForm.award"
-          label="What kind of project have you been awarded?*"
+          label="What kind of project have you been awarded? *"
           :rules="projectAwardValidationRules()"
         >
           <v-radio

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -11,7 +11,7 @@ export default defineComponent({
     const showAddressForm = ref(false);
     const datePicker = ref(false);
     const sampleItems = ref(['water_extract_soil']);
-    const biosafetyLevels = Object.values(BiosafetyLevels);
+    const biosafetyLevelValues = Object.values(BiosafetyLevels);
 
     const shipperSummary = computed(() => {
       let result = '';
@@ -35,7 +35,8 @@ export default defineComponent({
       showAddressForm,
       datePicker,
       sampleItems,
-      biosafetyLevels,
+      biosafetyLevelValues,
+      BiosafetyLevels,
       addressSummary,
     };
   },
@@ -261,66 +262,68 @@ export default defineComponent({
               />
               <v-spacer />
             </div>
-            <v-subheader>
-              <span class="text-h6">Institutional Review Board (IRB) Information</span>
-            </v-subheader>
-            <v-divider class="mb-2" />
-            <v-text-field
-              v-model="addressForm.irbNumber"
-              label="IRB Number"
-              outlined
-              dense
-            />
-            <v-text-field
-              v-model="addressForm.irbAddress.name"
-              label="IRB Contact Name"
-              outlined
-              dense
-            />
-            <v-text-field
-              v-model="addressForm.irbAddress.email"
-              label="E-mail Address"
-              outlined
-              dense
-            />
-            <v-text-field
-              v-model="addressForm.irbAddress.phone"
-              label="Phone Number"
-              outlined
-              dense
-            />
-            <v-text-field
-              v-model="addressForm.irbAddress.line1"
-              label="Address Line 1"
-              outlined
-              dense
-            />
-            <v-text-field
-              v-model="addressForm.irbAddress.line2"
-              label="Address Line 2"
-              outlined
-              dense
-            />
-            <v-text-field
-              v-model="addressForm.irbAddress.city"
-              label="City"
-              outlined
-              dense
-            />
-            <div class="d-flex">
+            <div v-if="addressForm.biosafetyLevel === BiosafetyLevels.BSL2">
+              <v-subheader>
+                <span class="text-h6">Institutional Review Board (IRB) Information</span>
+              </v-subheader>
+              <v-divider class="mb-2" />
               <v-text-field
-                v-model="addressForm.irbAddress.state"
-                label="State"
-                outlined
-                dense
-                class="mr-4"
-              />
-              <v-text-field
-                v-model="addressForm.irbAddress.postalCode"
-                label="Zip Code"
+                v-model="addressForm.irbNumber"
+                label="IRB Number"
                 outlined
                 dense
               />
+              <v-text-field
+                v-model="addressForm.irbAddress.name"
+                label="IRB Contact Name"
+                outlined
+                dense
+              />
+              <v-text-field
+                v-model="addressForm.irbAddress.email"
+                label="E-mail Address"
+                outlined
+                dense
+              />
+              <v-text-field
+                v-model="addressForm.irbAddress.phone"
+                label="Phone Number"
+                outlined
+                dense
+              />
+              <v-text-field
+                v-model="addressForm.irbAddress.line1"
+                label="Address Line 1"
+                outlined
+                dense
+              />
+              <v-text-field
+                v-model="addressForm.irbAddress.line2"
+                label="Address Line 2"
+                outlined
+                dense
+              />
+              <v-text-field
+                v-model="addressForm.irbAddress.city"
+                label="City"
+                outlined
+                dense
+              />
+              <div class="d-flex">
+                <v-text-field
+                  v-model="addressForm.irbAddress.state"
+                  label="State"
+                  outlined
+                  dense
+                  class="mr-4"
+                />
+                <v-text-field
+                  v-model="addressForm.irbAddress.postalCode"
+                  label="Zip Code"
+                  outlined
+                  dense
+                />
+              </div>
             </div>
             <v-subheader>
               <span class="text-h6">Additional Comments</span>

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { computed, defineComponent, ref } from '@vue/composition-api';
-import { addressForm, addressFormValid } from '../store';
+import { addressForm, addressFormValid, BiosafetyLevels } from '../store';
 import { addressToString } from '../store/api';
 import SubmissionContextShippingSummary from './SubmissionContextShippingSummary.vue';
 
@@ -11,7 +11,7 @@ export default defineComponent({
     const showAddressForm = ref(false);
     const datePicker = ref(false);
     const sampleItems = ref(['water_extract_soil']);
-    const biosafetyLevels = ref(['BSL2']);
+    const biosafetyLevels = Object.values(BiosafetyLevels);
 
     const shipperSummary = computed(() => {
       let result = '';

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { computed, defineComponent, ref } from '@vue/composition-api';
+import {
+  computed,
+  defineComponent,
+  ref,
+} from '@vue/composition-api';
+import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
 import { addressForm, addressFormValid, BiosafetyLevels } from '../store';
 import { addressToString } from '../store/api';
 import SubmissionContextShippingSummary from './SubmissionContextShippingSummary.vue';
@@ -11,6 +16,7 @@ export default defineComponent({
     const showAddressForm = ref(false);
     const datePicker = ref(false);
     const sampleItems = ref(['water_extract_soil']);
+    const sampleEnumValues = NmdcSchema.$defs.SampleTypeEnum.enum;
     const biosafetyLevelValues = Object.values(BiosafetyLevels);
 
     const shipperSummary = computed(() => {
@@ -38,6 +44,7 @@ export default defineComponent({
       biosafetyLevelValues,
       BiosafetyLevels,
       addressSummary,
+      sampleEnumValues,
     };
   },
 });
@@ -202,7 +209,7 @@ export default defineComponent({
             <v-select
               v-model="addressForm.sample"
               class="mt-2"
-              :items="sampleItems"
+              :items="sampleEnumValues"
               label="Sample"
               dense
               outlined
@@ -250,7 +257,7 @@ export default defineComponent({
               <v-select
                 v-model="addressForm.biosafetyLevel"
                 class="mr-4"
-                :items="biosafetyLevels"
+                :items="biosafetyLevelValues"
                 label="Biosafety Level"
                 dense
                 outlined

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -9,6 +9,11 @@ import { getVariant, HARMONIZER_TEMPLATES } from '../harmonizerApi';
 // TODO: Remove in version 3;
 Vue.use(CompositionApi);
 
+enum BiosafetyLevels {
+  BSL1 = 'BSL1',
+  BSL2 = 'BSL2'
+}
+
 const hasChanged = ref(0);
 /**
  * Submission Context Step
@@ -193,6 +198,7 @@ async function loadRecord(id: string) {
 watch(payloadObject, () => { hasChanged.value += 1; }, { deep: true });
 
 export {
+  BiosafetyLevels,
   /* state */
   multiOmicsForm,
   multiOmicsAssociations,

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -14,6 +14,11 @@ enum BiosafetyLevels {
   BSL2 = 'BSL2'
 }
 
+enum AwardTypes {
+  MONET = 'MONet',
+  FICUS = 'FICUS'
+}
+
 const hasChanged = ref(0);
 /**
  * Submission Context Step
@@ -199,6 +204,7 @@ watch(payloadObject, () => { hasChanged.value += 1; }, { deep: true });
 
 export {
   BiosafetyLevels,
+  AwardTypes,
   /* state */
   multiOmicsForm,
   multiOmicsAssociations,


### PR DESCRIPTION
This PR builds some front-end validation into the new context and address forms. Validation added in this PR is as follows:

**Context Form**
1. The "Has data already been generated for your study?" choice is required
2. If data has been generated, the DOI field is required (this field has been moved from the multiomics form)
3. If a facility (EMSL or JGI) is selected from the "Are you submitting metadata for samples that will be sent to a DOE user factility?" an award type is required
4. If the Award type is "Other," the associated text field must have a non-empty string

**Address Form**
1. Only show IRB fields if biosafety level is BSL2


**Additional Changes**
1. New `enums` for `BiosafetyLevels` and `AwardTypes`
2. Sample type drop down (address form) pulls in values from the NMDC schema