### PR TITLE
Use context form data to present different controls

### DIFF
--- a/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
+++ b/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
@@ -88,6 +88,10 @@ def upgrade():
             metadata_submission["contextForm"] = context_form
         if not metadata_submission.get("addressForm"):
             metadata_submission["addressForm"] = AddressForm().dict()
+
+        if metadata_submission.get("multiOmicsForm"):
+            omics_form = metadata_submission["multiOmicsForm"]
+            del omics_form["NCBIBioProjectName"]
         mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
     session.bulk_update_mappings(SubmissionMetadata, mappings)
     session.commit()
@@ -107,6 +111,10 @@ def downgrade():
             del metadata_submission["contextForm"]
         if metadata_submission.get("addressForm", None):
             del metadata_submission["addressForm"]
+
+        if metadata_submission.get("multiOmicsForm"):
+            omics_form = metadata_submission["multiOmicsForm"]
+            omics_form["NCBIBioProjectName"] = ""
         mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
     session.bulk_update_mappings(SubmissionMetadata, mappings)
     session.commit()

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -30,7 +30,6 @@ class MultiOmicsForm(BaseModel):
     studyNumber: str
     GOLDStudyId: str
     JGIStudyId: str
-    NCBIBioProjectName: str
     NCBIBioProjectId: str
     omicsProcessingTypes: List[str]
 

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -62,15 +62,6 @@ export default defineComponent({
         outlined
         dense
       />
-
-      <v-text-field
-        v-model="multiOmicsForm.NCBIBioProjectName"
-        label="NCBI BioProject Title"
-        :hint="Definitions.studyNCBIProjectTitle"
-        persistent-hint
-        outlined
-        dense
-      />
       <v-text-field
         v-model="multiOmicsForm.NCBIBioProjectId"
         label="NCBI BioProject Accession"

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -64,6 +64,7 @@ export default defineComponent({
         chips
         small-chips
         dense
+        append-icon=""
       />
       <v-text-field
         v-model="multiOmicsForm.GOLDStudyId"

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -41,18 +41,6 @@ export default defineComponent({
       class="my-6 mb-10"
       style="max-width: 1000px;"
     >
-      <!-- DOI -->
-      <v-checkbox
-        v-model="multiOmicsAssociations.doi"
-        label="Data has already been generated"
-        hide-details
-        class="mb-2 mt-0"
-        @change="reValidate"
-      />
-      <div
-        class="my-5"
-      />
-
       <v-combobox
         v-model="multiOmicsForm.alternativeNames"
         label="Alternative Names"

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -2,7 +2,7 @@
 import { defineComponent, ref } from '@vue/composition-api';
 import Definitions from '@/definitions';
 import {
-  multiOmicsForm, multiOmicsFormValid, multiOmicsAssociations, templateChoiceDisabled,
+  multiOmicsForm, multiOmicsFormValid, multiOmicsAssociations, templateChoiceDisabled, contextForm,
 } from '../store';
 
 export default defineComponent({
@@ -20,6 +20,7 @@ export default defineComponent({
       multiOmicsFormValid,
       Definitions,
       templateChoiceDisabled,
+      contextForm,
       /* functions */
       reValidate,
     };
@@ -41,36 +42,37 @@ export default defineComponent({
       class="my-6 mb-10"
       style="max-width: 1000px;"
     >
-      <v-combobox
-        v-model="multiOmicsForm.alternativeNames"
-        label="Alternative Names"
-        :hint="Definitions.studyAlternativeNames"
-        persistent-hint
-        deletable-chips
-        multiple
-        outlined
-        chips
-        small-chips
-        dense
-        append-icon=""
-      />
-      <v-text-field
-        v-model="multiOmicsForm.GOLDStudyId"
-        label="GOLD Study ID"
-        :hint="Definitions.studyGoldID"
-        persistent-hint
-        outlined
-        dense
-      />
-      <v-text-field
-        v-model="multiOmicsForm.NCBIBioProjectId"
-        label="NCBI BioProject Accession"
-        :hint="Definitions.studyNCBIBioProjectAccession"
-        persistent-hint
-        outlined
-        dense
-      />
-
+      <div v-if="contextForm.facilities.length === 0">
+        <v-combobox
+          v-model="multiOmicsForm.alternativeNames"
+          label="Alternative Names"
+          :hint="Definitions.studyAlternativeNames"
+          persistent-hint
+          deletable-chips
+          multiple
+          outlined
+          chips
+          small-chips
+          dense
+          append-icon=""
+        />
+        <v-text-field
+          v-model="multiOmicsForm.GOLDStudyId"
+          label="GOLD Study ID"
+          :hint="Definitions.studyGoldID"
+          persistent-hint
+          outlined
+          dense
+        />
+        <v-text-field
+          v-model="multiOmicsForm.NCBIBioProjectId"
+          label="NCBI BioProject Accession"
+          :hint="Definitions.studyNCBIBioProjectAccession"
+          persistent-hint
+          outlined
+          dense
+        />
+      </div>
       <div class="text-h4">
         Data types *
       </div>
@@ -89,81 +91,84 @@ export default defineComponent({
       </v-alert>
 
       <!-- JGI -->
-      <div class="text-h6">
-        Joint Genome Institute (JGI)
+      <div v-if="contextForm.facilities.includes('JGI')">
+        <div class="text-h6">
+          Joint Genome Institute (JGI)
+        </div>
+        <v-checkbox
+          v-model="multiOmicsForm.omicsProcessingTypes"
+          label="Metagenome"
+          value="mg-jgi"
+          :disabled="templateChoiceDisabled"
+          hide-details
+        />
+        <v-checkbox
+          v-model="multiOmicsForm.omicsProcessingTypes"
+          label="Metatranscriptome"
+          value="mt-jgi"
+          :disabled="templateChoiceDisabled"
+          hide-details
+        />
+        <v-checkbox
+          v-model="multiOmicsForm.omicsProcessingTypes"
+          label="Metabolome"
+          value="mb-jgi"
+          disabled
+          hide-details
+        />
+        <v-text-field
+          v-if="multiOmicsForm.omicsProcessingTypes.some((v) => v.endsWith('jgi'))"
+          v-model="multiOmicsForm.JGIStudyId"
+          :rules="[ v => !!v || 'JGI Study ID is required when processing was done at JGI' ]"
+          label="JGI Study ID *"
+          hint="JGI Study ID is required when processing was done at JGI"
+          persistent-hint
+          class="mt-4"
+          outlined
+          validate-on-blur
+          dense
+        />
       </div>
-      <v-checkbox
-        v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metagenome"
-        value="mg-jgi"
-        :disabled="templateChoiceDisabled"
-        hide-details
-      />
-      <v-checkbox
-        v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metatranscriptome"
-        value="mt-jgi"
-        :disabled="templateChoiceDisabled"
-        hide-details
-      />
-      <v-checkbox
-        v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metabolome"
-        value="mb-jgi"
-        disabled
-        hide-details
-      />
-      <v-text-field
-        v-if="multiOmicsForm.omicsProcessingTypes.some((v) => v.endsWith('jgi'))"
-        v-model="multiOmicsForm.JGIStudyId"
-        :rules="[ v => !!v || 'JGI Study ID is required when processing was done at JGI' ]"
-        label="JGI Study ID *"
-        hint="JGI Study ID is required when processing was done at JGI"
-        persistent-hint
-        class="mt-4"
-        outlined
-        validate-on-blur
-        dense
-      />
 
       <!-- EMSL -->
-      <div class="text-h6 mt-4">
-        Environmental Molecular Science Laboratory (EMSL)
+      <div v-if="contextForm.facilities.includes('EMSL')">
+        <div class="text-h6 mt-4">
+          Environmental Molecular Science Laboratory (EMSL)
+        </div>
+        <v-checkbox
+          v-model="multiOmicsForm.omicsProcessingTypes"
+          label="Metaproteome"
+          value="mp-emsl"
+          :disabled="templateChoiceDisabled"
+          hide-details
+        />
+        <v-checkbox
+          v-model="multiOmicsForm.omicsProcessingTypes"
+          label="Metabolome"
+          value="mb-emsl"
+          :disabled="templateChoiceDisabled"
+          hide-details
+        />
+        <v-checkbox
+          v-model="multiOmicsForm.omicsProcessingTypes"
+          label="Natural Organic Matter (FT-ICR MS)"
+          value="nom-emsl"
+          :disabled="templateChoiceDisabled"
+          hide-details
+        />
+        <v-text-field
+          v-if="multiOmicsForm.omicsProcessingTypes.some((v) => v.endsWith('emsl'))"
+          v-model="multiOmicsForm.studyNumber"
+          :rules="[ v => !!v || 'EMSL Study Number is required when processing was done at EMSL' ]"
+          hint="EMSL Study Number is required when processing was done at EMSL"
+          persistent-hint
+          label="EMSL Proposal / Study Number *"
+          class="mt-4"
+          outlined
+          validate-on-blur
+          dense
+        />
       </div>
-      <v-checkbox
-        v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metaproteome"
-        value="mp-emsl"
-        :disabled="templateChoiceDisabled"
-        hide-details
-      />
-      <v-checkbox
-        v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metabolome"
-        value="mb-emsl"
-        :disabled="templateChoiceDisabled"
-        hide-details
-      />
-      <v-checkbox
-        v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Natural Organic Matter (FT-ICR MS)"
-        value="nom-emsl"
-        :disabled="templateChoiceDisabled"
-        hide-details
-      />
-      <v-text-field
-        v-if="multiOmicsForm.omicsProcessingTypes.some((v) => v.endsWith('emsl'))"
-        v-model="multiOmicsForm.studyNumber"
-        :rules="[ v => !!v || 'EMSL Study Number is required when processing was done at EMSL' ]"
-        hint="EMSL Study Number is required when processing was done at EMSL"
-        persistent-hint
-        label="EMSL Proposal / Study Number *"
-        class="mt-4"
-        outlined
-        validate-on-blur
-        dense
-      />
-
       <!-- Other -->
       <div class="text-h6 mt-4">
         Other Non-DOE

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -102,7 +102,6 @@ const multiOmicsFormDefault = {
   studyNumber: '',
   GOLDStudyId: '',
   JGIStudyId: '',
-  NCBIBioProjectName: '',
   NCBIBioProjectId: '',
   omicsProcessingTypes: [] as string[],
 };


### PR DESCRIPTION
## Data Already Generated

https://user-images.githubusercontent.com/7085625/217668631-6f56e328-cc0b-4c53-b80f-fc0f84d0f51e.mp4

## Data Not Already Generated, NO Facilities Chosen

https://user-images.githubusercontent.com/7085625/217669626-c7b45e56-2aff-45c6-925e-9e3717ffcf0b.mp4

## Data Not Already Generated, Facilities Chosen

https://user-images.githubusercontent.com/7085625/217671513-8e10cd80-0889-4532-82f8-551a77b5d44d.mp4



## Other Changes
This PR includes some other, minor updates, guided by notes on the [lucid chart.](https://lucid.app/lucidchart/75516c27-0974-4a77-ae92-73234e3f385e/edit?invitationId=inv_8fe7dca1-e52f-431c-9a0e-f1e6dd1e3a72&page=0_0#)
1. Removal of the arrow icon from the `v-combobox` component for alternate study names. Since we're not actually using this as an autocomplete with existing options, this arrow is just a confusing UI element
2. Removal of the NCBI project name field, in favor of just using the Accession number.
3. Clean up a checkbox that has been moved to the context form.