### PR TITLE
Upgrade data-harmonizer library version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "d3-selection": "^3.0.0",
     "d3-time": "^3.0.0",
     "d3-time-format": "^4.1.0",
-    "data-harmonizer": "1.4.0",
+    "data-harmonizer": "1.4.5",
     "filesize": "^8.0.6",
     "jquery": "3.5.1",
     "leaflet": "^1.7.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4275,10 +4275,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-harmonizer@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/data-harmonizer/-/data-harmonizer-1.4.0.tgz#0124426c62edee47fb0aea95a1291cb6e53a7c30"
-  integrity sha512-V9m0sQBy+zvus31rNMaMI/f/Gynh15LzdUlrcHrJ2QxjhYbm05dRWBFzw/cQWgt2qfkH8JePb5e7k8NtIFtvMg==
+data-harmonizer@1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/data-harmonizer/-/data-harmonizer-1.4.5.tgz#c1ce1fe1bdb7a6967c13360911dd8860daa4eef3"
+  integrity sha512-g5wVSU1B3QxSt3M7rVR1COyKLTya61gT8yBCpp7v1yjWjwsnmLC9Rpbo/J6jVL13HeFtyCyxKEXjwAPUsfn9wg==
   dependencies:
     "@selectize/selectize" "^0.13.5"
     date-fns "^2.28.0"


### PR DESCRIPTION
The latest version of the `data-harmonizer` package includes a fix to how it parses/formats multivalued slot values to/from delimited strings. This fixes a bug in the submission portal where rows with multiple values in the "analysis/data type" column would not be persisted across multiple DataHarmonizer tabs. 

The fix can be verified by:
1. On any submission portal entry, go to the DataHarmonizer screen. For any row select multiple values for the "analysis/data type" column. It should say, for example, "metabolomics; metagenomics" (note the space after the semicolon).
2. Click the "Validate" button
3. Verify that the "analysis/data type" cell you edited has not changed. It should still read "metabolomics; metagenomics" with a space after the semicolon.



