### PR TITLE
Remove unnecessary message

### DIFF
--- a/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
+++ b/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
@@ -54,10 +54,6 @@ export default defineComponent({
         DataHarmonizer Template Choice
       </p>
       Your DataHarmonizer template is "{{ templateList.join(' + ') }}".
-      <span v-if="disableOptionsWithoutVariations">
-        Because you have chosen data types specific to processing institutions,
-        only packages with matching institution template variations are enabled.
-      </span>
     </v-alert>
     <v-alert
       v-else


### PR DESCRIPTION
Fixes #855 

I missed taking this message out when working on #831. The variable controlling whether this message is shown was removed (since we no longer restrict packages based on processing institution), but I unintentionally left the message itself in the template.