### PR TITLE
Upgrade to data-harmonizer@1.4.6

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "d3-selection": "^3.0.0",
     "d3-time": "^3.0.0",
     "d3-time-format": "^4.1.0",
-    "data-harmonizer": "1.4.5",
+    "data-harmonizer": "1.4.6",
     "filesize": "^8.0.6",
     "jquery": "3.5.1",
     "leaflet": "^1.7.1",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4275,10 +4275,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-data-harmonizer@1.4.5:
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/data-harmonizer/-/data-harmonizer-1.4.5.tgz#c1ce1fe1bdb7a6967c13360911dd8860daa4eef3"
-  integrity sha512-g5wVSU1B3QxSt3M7rVR1COyKLTya61gT8yBCpp7v1yjWjwsnmLC9Rpbo/J6jVL13HeFtyCyxKEXjwAPUsfn9wg==
+data-harmonizer@1.4.6:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/data-harmonizer/-/data-harmonizer-1.4.6.tgz#72450c87baafc09855f30b7e2d5e1882e251b6b1"
+  integrity sha512-fLpIzhFETE9R2n6lmfK32B6m5Law69BFlFZgKfRoiU4LzM5Zql2I6tSTy4xTaziHfOoBchnjSvqRknIsUrinCw==
   dependencies:
     "@selectize/selectize" "^0.13.5"
     date-fns "^2.28.0"


### PR DESCRIPTION
No changes to functionality in this release. It is built in a new way that attempts to reduce the main bundle size.