### PR TITLE
Fix XLSX export bug when entire DH is empty

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -233,16 +233,21 @@ export default defineComponent({
       const nextData = { ...sampleData.value };
       const templateKey = `${templateName}_data`;
       const environmentKey = `${templateList.value[0]}_data`;
+
+      // ensure the necessary keys exist in the data object
+      if (!nextData[environmentKey]) {
+        nextData[environmentKey] = [];
+      }
+      if (!nextData[templateKey]) {
+        nextData[templateKey] = [];
+      }
+
       // add/update any rows from the first tab to the active tab if they apply and if
       // they aren't there already.
-      (nextData[environmentKey] || []).forEach((row) => {
+      nextData[environmentKey].forEach((row) => {
         const rowId = row[SCHEMA_ID];
         const existing = nextData[templateKey] && nextData[templateKey].find((r) => r[SCHEMA_ID] === rowId);
-
         if (!existing && rowIsVisibleForTemplate(row, templateName)) {
-          if (!nextData[templateKey]) {
-            nextData[templateKey] = [];
-          }
           const newRow = {} as Record<string, any>;
           COMMON_COLUMNS.forEach((col) => {
             newRow[col] = row[col];
@@ -257,7 +262,7 @@ export default defineComponent({
       });
       // remove any rows from the active tab if they were removed from the first tab
       // or no longer apply to the active tab
-      if (nextData[templateKey]) {
+      if (nextData[templateKey].length > 0) {
         nextData[templateKey] = nextData[templateKey].filter((row) => {
           if (!rowIsVisibleForTemplate(row, templateName)) {
             return false;

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -418,6 +418,9 @@ export class HarmonizerApi {
   }
 
   static flattenArrayValues(tableData: Record<string, any>[]) {
+    if (!tableData) {
+      return [];
+    }
     return tableData.map((row) => Object.fromEntries(
       Object.entries(row).map(([key, value]) => {
         let flatValue = value;


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/issues/issues/76

This handles an edge case that I missed in the original fix for that issue. Specifically, these changes ensure that the necessary fields are populated in the `sampleData` object even in the case where _no_ data has been entered in DH interface. To test: create a new submission, once you reach the DH screen click the "Download XLSX" button before any other interaction.