### PR TITLE
Implement WordPress-style app bar

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,14 +1,13 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
 import AppHeader from '@/components/Presentation/AppHeader.vue';
-import { setConditions, stateRefs } from '@/store/';
+import { stateRefs } from '@/store/';
 
 export default defineComponent({
   name: 'App',
   components: { AppHeader },
   setup() {
     return {
-      setConditions,
       stateRefs,
     };
   },
@@ -17,7 +16,7 @@ export default defineComponent({
 
 <template>
   <v-app>
-    <app-header @logoClicked="setConditions([])" />
+    <app-header />
     <keep-alive>
       <router-view />
     </keep-alive>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
-import AuthButton from '@/components/Presentation/AuthButton.vue';
+import AppHeader from '@/components/Presentation/AppHeader.vue';
 import { setConditions, stateRefs } from '@/store/';
 
 export default defineComponent({
   name: 'App',
-  components: { AuthButton },
+  components: { AppHeader },
   setup() {
     return {
       setConditions,
@@ -17,111 +17,7 @@ export default defineComponent({
 
 <template>
   <v-app>
-    <v-app-bar
-      app
-      color="white"
-      clipped-left
-      elevation="1"
-    >
-      <a
-        style="height: 100%"
-        @click="setConditions([])"
-      >
-        <img
-          src="/NMDC_logo_long.jpg"
-          height="100%"
-          alt="Page home"
-        >
-      </a>
-      <v-spacer />
-
-      <v-btn
-        depressed
-        small
-        href="https://nmdc-documentation.readthedocs.io/en/latest/tutorials/nav_data_portal.html"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mx-2"
-      >
-        Video Tutorial
-        <v-icon
-          class="pl-2"
-          small
-        >
-          mdi-open-in-new
-        </v-icon>
-      </v-btn>
-
-      <v-btn
-        depressed
-        small
-        href="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/portal_guide.html"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mx-2"
-      >
-        User Guide
-        <v-icon
-          class="pl-2"
-          small
-        >
-          mdi-open-in-new
-        </v-icon>
-      </v-btn>
-
-      <v-btn
-        depressed
-        small
-        href="https://nmdc-documentation.readthedocs.io/en/latest/index.html"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mx-2"
-      >
-        NMDC Docs
-        <v-icon
-          class="pl-2"
-          small
-        >
-          mdi-open-in-new
-        </v-icon>
-      </v-btn>
-
-      <v-btn
-        depressed
-        small
-        href="https://microbiomedata.org/"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="mx-2"
-      >
-        NMDC Home
-        <v-icon
-          class="pl-2"
-          small
-        >
-          mdi-open-in-new
-        </v-icon>
-      </v-btn>
-
-      <v-divider vertical />
-
-      <v-btn
-        depressed
-        small
-        color="secondary"
-        :to="{ name: 'Submission Home' }"
-        class="mx-2"
-      >
-        Submission Portal
-        <v-icon
-          class="pl-2"
-          small
-        >
-          mdi-form-select
-        </v-icon>
-      </v-btn>
-      <AuthButton />
-    </v-app-bar>
+    <app-header @logoClicked="setConditions([])" />
     <keep-alive>
       <router-view />
     </keep-alive>

--- a/web/src/components/Presentation/AppHeader.vue
+++ b/web/src/components/Presentation/AppHeader.vue
@@ -26,11 +26,11 @@ export default defineComponent({
   >
     <a
       class="header-logo"
-      @click="$emit('logoClicked')"
+      href="https://microbiomedata.org/"
     >
       <img
         src="/NMDC_logo_long.jpg"
-        alt="Page home"
+        alt="Home page"
       >
     </a>
 

--- a/web/src/components/Presentation/AppHeader.vue
+++ b/web/src/components/Presentation/AppHeader.vue
@@ -1,0 +1,144 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+import AuthButton from '@/components/Presentation/AuthButton.vue';
+import Menus from '@/menus';
+
+export default defineComponent({
+  components: {
+    AuthButton,
+  },
+  setup() {
+    return {
+      Menus,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-app-bar
+    app
+    class="navigation-button-text-animate"
+    color="white"
+    clipped-left
+    elevation="4"
+    height="82"
+  >
+    <a
+      class="header-logo"
+      @click="$emit('logoClicked')"
+    >
+      <img
+        src="/NMDC_logo_long.jpg"
+        alt="Page home"
+      >
+    </a>
+
+    <v-spacer />
+
+    <template v-for="(menu) in Menus">
+      <v-btn
+        v-if="!menu.items || !menu.items.length"
+        :key="menu.label"
+        plain
+        small
+        :ripple="false"
+        :href="menu.href"
+      >
+        <div class="navigation-button-text">
+          {{ menu.label }}
+        </div>
+      </v-btn>
+
+      <v-menu
+        v-else
+        :key="menu.label"
+        bottom
+        right
+        offset-y
+        content-class="navigation-button-text-animate elevation-4"
+        :open-on-hover="true"
+        transition="fade-transition"
+      >
+        <template #activator="{ on, attrs }">
+          <v-btn
+            plain
+            small
+            :ripple="false"
+            :href="menu.href"
+            v-bind="attrs"
+            v-on="on"
+          >
+            <div class="navigation-button-text">
+              {{ menu.label }}
+            </div>
+            <v-icon small>
+              mdi-chevron-down
+            </v-icon>
+          </v-btn>
+        </template>
+
+        <v-list
+          dense
+          expand
+          flat
+          nav
+        >
+          <v-list-item
+            v-for="item in menu.items"
+            :key="item.label"
+            :href="item.href"
+            :to="item.to"
+            :ripple="false"
+            class="text-uppercase"
+          >
+            <v-list-item-content>
+              <v-list-item-title>
+                <div class="navigation-button-text">
+                  {{ item.label }}
+                </div>
+              </v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </template>
+
+    <v-divider vertical />
+
+    <AuthButton nav />
+  </v-app-bar>
+</template>
+
+<style lang="scss" scoped>
+  .header-logo {
+    height: 100%;
+    img {
+      padding: 9px 0;
+      height: 100%;
+    }
+  }
+
+  .navigation-button-text-animate {
+    .navigation-button-text {
+      display: inline-block;
+      padding: 2px 0;
+      background-image: linear-gradient(var(--v-primary-base), var(--v-primary-base));
+      background-position: 0 100%;
+      background-repeat: no-repeat;
+      background-size: 0 1px;
+      transition-property: background-size;
+      transition-duration: 0.15s;
+      transition-timing-function: ease;
+    }
+
+    .v-btn, .v-list-item {
+      &.v-btn--active, &:hover, &:focus, &.v-list-item--active {
+        .navigation-button-text {
+          color: var(--v-primary-base);
+          background-size: 100% 1px;
+        }
+      }
+    }
+  }
+</style>

--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -3,6 +3,12 @@ import { defineComponent } from '@vue/composition-api';
 import { stateRefs } from '@/store';
 
 export default defineComponent({
+  props: {
+    nav: {
+      type: Boolean,
+      default: false,
+    },
+  },
   setup() {
     return {
       me: stateRefs.user,
@@ -15,8 +21,10 @@ export default defineComponent({
   <div>
     <template v-if="me">
       <v-btn
-        text
-        color="grey darken-2"
+        :text="!nav"
+        :plain="nav"
+        :small="nav"
+        :ripple="!nav"
       >
         <v-icon left>
           mdi-account-circle
@@ -24,8 +32,10 @@ export default defineComponent({
         {{ me }}
       </v-btn>
       <v-btn
-        icon
-        color="grey darken-2"
+        :icon="!nav"
+        :plain="nav"
+        :small="nav"
+        :ripple="!nav"
         href="/logout"
       >
         <v-icon>mdi-logout</v-icon>
@@ -33,8 +43,9 @@ export default defineComponent({
     </template>
     <template v-else>
       <v-btn
-        text
-        color="grey darken-2"
+        :text="!nav"
+        :plain="nav"
+        :small="nav"
         href="/login"
       >
         <img

--- a/web/src/menus.ts
+++ b/web/src/menus.ts
@@ -1,0 +1,124 @@
+const Menus = [
+  {
+    label: 'About',
+    href: 'https://microbiomedata.org/about/',
+    items: [
+      {
+        label: 'Team',
+        href: 'https://microbiomedata.org/team/',
+      },
+      {
+        label: 'Advisory',
+        href: 'https://microbiomedata.org/advisory/',
+      },
+      {
+        label: 'IDEA Strategic Plan',
+        href: 'https://microbiomedata.org/idea-strategic-plan/',
+      },
+      {
+        label: 'Code of Conduct',
+        href: 'https://microbiomedata.org/nmdc-code-of-conduct/',
+      },
+      {
+        label: 'Acknowledgements',
+        href: 'https://microbiomedata.org/acknowledgements/',
+      },
+    ],
+  },
+  {
+    label: 'Data',
+    href: 'https://microbiomedata.org/data/',
+    items: [
+      {
+        label: 'Metadata',
+        href: 'https://microbiomedata.org/metadata/',
+      },
+      {
+        label: 'Workflows',
+        href: 'https://microbiomedata.org/workflows/',
+      },
+      {
+        label: 'Fair',
+        href: 'https://microbiomedata.org/fair/',
+      },
+      {
+        label: 'Data Use Policy',
+        href: 'https://microbiomedata.org/nmdc-data-use-policy/',
+      },
+    ],
+  },
+  {
+    label: 'Products',
+    items: [
+      {
+        label: 'Data Portal',
+        to: '/',
+      },
+      {
+        label: 'Submission Portal',
+        to: '/submission/home',
+      },
+      {
+        label: 'NMDC EDGE',
+        href: 'https://nmdc-edge.org',
+      },
+    ],
+  },
+  {
+    label: 'Community',
+    href: 'https://microbiomedata.org/community/',
+    items: [
+      {
+        label: 'Ambassadors',
+        href: 'https://microbiomedata.org/ambassadors/',
+      },
+      {
+        label: 'Champions',
+        href: 'https://microbiomedata.org/community/championsprogram/',
+      },
+      {
+        label: 'Community Conversations',
+        href: 'https://microbiomedata.org/community/community-conversations/',
+      },
+      {
+        label: 'Events',
+        href: 'https://microbiomedata.org/events/',
+      },
+      {
+        label: 'News',
+        href: 'https://microbiomedata.org/news/',
+      },
+    ],
+  },
+  {
+    label: 'Resources',
+    items: [
+      {
+        label: 'Annual Reports',
+        href: 'https://microbiomedata.org/annual_report/',
+      },
+      {
+        label: 'Media Materials',
+        href: 'https://microbiomedata.org/media/',
+      },
+      {
+        label: 'Data Management',
+        href: 'https://microbiomedata.org/data-management/',
+      },
+      {
+        label: 'Letter of Support',
+        href: 'https://docs.google.com/forms/d/e/1FAIpQLScF4yChmxXZG1v1fXa-2ydyN8QEyTYsKYd9jWICcrwdaG222A/viewform?usp=sf_link',
+      },
+      {
+        label: 'Publications',
+        href: 'https://microbiomedata.org/publications/',
+      },
+    ],
+  },
+  {
+    label: 'Contact',
+    href: 'https://microbiomedata.org/contact/',
+  },
+];
+
+export default Menus;

--- a/web/src/plugins/vuetify.js
+++ b/web/src/plugins/vuetify.js
@@ -6,6 +6,7 @@ Vue.use(Vuetify);
 
 export default new Vuetify({
   theme: {
+    options: { customProperties: true },
     themes: {
       light: colors,
     },

--- a/web/src/views/Search/SearchHelpMenu.vue
+++ b/web/src/views/Search/SearchHelpMenu.vue
@@ -1,0 +1,45 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({});
+</script>
+
+<template>
+  <v-menu
+    open-on-hover
+    bottom
+    left
+    offset-y
+    close-delay="200"
+  >
+    <template #activator="{ on, attrs }">
+      <v-btn
+        icon
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-icon>
+          mdi-help-circle
+        </v-icon>
+      </v-btn>
+    </template>
+
+    <v-list>
+      <v-list-item
+        href="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/portal_guide.html"
+      >
+        <v-list-item-title>User Guide</v-list-item-title>
+      </v-list-item>
+      <v-list-item
+        href="https://nmdc-documentation.readthedocs.io/en/latest/index.html"
+      >
+        <v-list-item-title>NMDC Docs</v-list-item-title>
+      </v-list-item>
+      <v-list-item
+        href="https://nmdc-documentation.readthedocs.io/en/latest/tutorials/nav_data_portal.html"
+      >
+        <v-list-item-title>Video Tutorial</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -18,6 +18,7 @@ import BulkDownload from '@/components/BulkDownload.vue';
 import EnvironmentVisGroup from './EnvironmentVisGroup.vue';
 import BiosampleVisGroup from './BiosampleVisGroup.vue';
 import SearchSidebar from './SearchSidebar.vue';
+import SearchHelpMenu from './SearchHelpMenu.vue';
 
 export default defineComponent({
   name: 'SearchLayout',
@@ -29,6 +30,7 @@ export default defineComponent({
     SampleListExpansion,
     SearchResults,
     SearchSidebar,
+    SearchHelpMenu,
   },
 
   setup() {
@@ -142,17 +144,25 @@ export default defineComponent({
       >
         <v-row>
           <v-col>
-            <v-tabs
-              v-model="vistab"
-              height="30px"
-            >
-              <v-tab key="omics">
-                Omics
-              </v-tab>
-              <v-tab key="environments">
-                Environment
-              </v-tab>
-            </v-tabs>
+            <v-row>
+              <v-col>
+                <v-tabs
+                  v-model="vistab"
+                  height="30px"
+                >
+                  <v-tab key="omics">
+                    Omics
+                  </v-tab>
+                  <v-tab key="environments">
+                    Environment
+                  </v-tab>
+                </v-tabs>
+              </v-col>
+              <v-spacer />
+              <v-col class="d-flex justify-end flex-grow-0 flex-shrink-0">
+                <search-help-menu />
+              </v-col>
+            </v-row>
             <v-tabs-items
               v-model="vistab"
               class="my-3"


### PR DESCRIPTION
Related to https://github.com/microbiomedata/issues/issues/123.

These changes are mainly aimed at getting the portal's nav header to have similar organization and styling as the WordPress site's header. I don't want to close the issue with these changes because I'm sure there will be a few rounds of iterating on the exact content of the menus. Finally once that's all sorted out, I'll go back and update the WordPress header to ensure the content there matches. 