### PR TITLE
Use `directConnection=True` for mongo client

### DIFF
--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -58,6 +58,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
         username=settings.mongo_user,
         password=settings.mongo_password,
         port=settings.mongo_port,
+        directConnection=True,
     )
     mongodb = client[settings.mongo_database]
 


### PR DESCRIPTION
This prevents trying to connect to a replicaset. See https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#pymongo4-migration-direct-connection