### PR TITLE
Increase study limit

### DIFF
--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -87,7 +87,7 @@ export default defineComponent({
       table: ref('study'),
       conditions: stateRefs.conditions,
     });
-    const study = usePaginatedResults(studySummaryData.otherConditions, api.searchStudy, undefined, 10);
+    const study = usePaginatedResults(studySummaryData.otherConditions, api.searchStudy, undefined, 50);
     const studyResults = computed(() => Object.values(study.data.results.results).map((r) => ({
       ...r,
       name: r.annotations.title || r.name,


### PR DESCRIPTION
When we make a request for studies, we limit the number of results by utilizing `usePaginatedResults`. Eventually we'll actually want to add pagination to the study UI (#914), but for now, I'm increasing the limit to 50 to accommodate new studies that need to be ingested.