### PR TITLE
Force re-render of image on url change

### DIFF
--- a/web/src/components/InvestigatorBio.vue
+++ b/web/src/components/InvestigatorBio.vue
@@ -38,6 +38,7 @@ export default defineComponent({
     >
       <v-img
         v-if="item.image_url"
+        :key="item.image_url"
         :src="item.image_url"
         width="200"
       />


### PR DESCRIPTION
Problematic behavior:
https://user-images.githubusercontent.com/7085625/230164855-9b99683a-2eec-4fc7-972e-4df22c49a551.mp4

The `v-image` component wasn't getting re-rendered when the source changed, and since our source images have different sizes, this caused visual problems when switching between studies.

Adding `v-bind:key` to the `v-image` component forces a re-render whenever the value of the key changes.

Fixed:
https://user-images.githubusercontent.com/7085625/230165744-ac07c80d-29e4-44c9-a4df-54f63b550d71.mp4


