### PR TITLE
Keep better track of tabs to be validated

### DIFF
--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -149,9 +149,11 @@ const templateChoiceDisabled = computed(() => {
 
 const tabsValidated = ref({} as Record<string, boolean>);
 watch(templateList, () => {
+  const newTabsValidated = {} as Record<string, boolean>;
   forEach(templateList.value, (templateKey) => {
-    tabsValidated.value[templateKey] = false;
+    newTabsValidated[templateKey] = false;
   });
+  tabsValidated.value = newTabsValidated;
 });
 
 /** Submit page */


### PR DESCRIPTION
The `tabsValidated` object keeps track of which DH tabs have been validated. It is built from the `templateList`. Previously, if a template was removed from `templateList`, it would remain in `tabsValidated`, even though it could never be validated.

Fixes #936 

To test, perform the following steps using this branch and data-dev.microbiomedata.org.

1. Create a new submission
2. Choose No for "Data already generated", choose JGI (arbitrary, but JGI allows you to skip address form), and whatever project you'd like
3. Continue to Multi-omics form (enter whatever Study Information you want)
4. Select "Metagenome" and Metatranscriptome under JGI, enter a JGI ID
5. DESELECT metaT (or metaG, I don't think this matters)
6. Continue to the Data Harmonizer tab
7. Run validation for each tab
8. Submission is not enabled, even though all tabs are valid
9. Refresh the page and try again, submission button works

The problematic behavior in step 8 should not be present with the changes in this PR.