### PR TITLE
Pin nginx to 1.22 for client build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:stable-alpine as nginx_builder
+FROM nginx:1.22-alpine as nginx_builder
 
 ENV ENABLED_MODULES=modzip
 RUN set -ex \
@@ -65,7 +65,7 @@ COPY . .
 RUN yarn run build
 
 
-FROM nginx:stable-alpine as production-stage
+FROM nginx:1.22-alpine as production-stage
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
 ENV ENABLED_MODULES=modzip


### PR DESCRIPTION
Similar to #732, our client side build process was broken by recent pushes to the stable nginx image. Pinning to 1.22.