### PR TITLE
Unify behavior of study page filters

### DIFF
--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -55,6 +55,23 @@ function setConditions(conditions: Condition[], push = false) {
 }
 
 /**
+ * For each condition, remove all others with a similar table & field.
+ */
+function setUniqueCondition(
+  field: string[],
+  table: string[],
+  conditions: Condition[],
+) {
+  const others = state.conditions.filter((c) => (
+    !field.includes(c.field)) || (!table.includes(c.table)
+  ));
+  setConditions([
+    ...conditions,
+    ...others,
+  ]);
+}
+
+/**
  * Restore state from localStorage and clear
  */
 function restoreState() {
@@ -117,23 +134,6 @@ async function getTreeData() {
     state.treeData = resp;
     Object.values(state.treeData.trees).forEach((nodeList) => nodeList.forEach(makeNodeMap));
   }
-}
-
-/**
- * For each condition, remove all others with a similar table & field.
- */
-function setUniqueCondition(
-  field: string[],
-  table: string[],
-  conditions: Condition[],
-) {
-  const others = state.conditions.filter((c) => (
-    !field.includes(c.field)) || (!table.includes(c.table)
-  ));
-  setConditions([
-    ...conditions,
-    ...others,
-  ]);
 }
 
 /**

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -105,7 +105,7 @@ export default defineComponent({
 
     const router = useRouter();
 
-    function setChecked(omicsType = '') {
+    function seeOmicsForStudy(omicsType = '') {
       setUniqueCondition(
         ['study_id', 'omics_type'],
         ['study', 'omics_processing'],
@@ -113,7 +113,7 @@ export default defineComponent({
           value: props.id,
           table: 'study',
           op: '==',
-          field: 'study_id',
+          field: 'id',
         }, {
           value: omicsType,
           table: 'omics_processing',
@@ -154,7 +154,7 @@ export default defineComponent({
       item,
       displayFields,
       /* Methods */
-      setChecked,
+      seeOmicsForStudy,
       relatedTypeDescription,
       openLink,
       formatAPA,
@@ -188,7 +188,7 @@ export default defineComponent({
                     :key="val.type"
                     small
                     class="mr-2 my-1"
-                    @click="setChecked(val.type)"
+                    @click="seeOmicsForStudy(val.type)"
                   >
                     {{ fieldDisplayName(val.type) }}: {{ val.count }}
                   </v-chip>


### PR DESCRIPTION
Fixes #933 

**Previous Behavior:**
When on a study page, if a user clicked the sample count, they would be taken back to the main data portal view, and the study list would be filtered to show only the study they were just looking at. If the user clicked one of the omics processing chips, they would be taken back to the main data portal view, and the study would be selected (indicated by the checkboxes next to the study titles). If a study is further down the list, the visual cue would be missing.
See linked issue for screenshots

**New Behavior**
Now, both actions produce the same result: a returning to the main data portal view with only the study of interest present in the studies list. If the user wants to see all studies, they have to remove the filter from the search sidebar.