### PR TITLE
Allow copying study data between submissions

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -81,7 +81,6 @@ export default defineComponent({
       <v-dialog
         v-model="copyDataDialog"
         activator="parent"
-        width="auto"
       >
         <v-card>
           <v-card-title>

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -3,10 +3,15 @@ import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
 import Definitions from '@/definitions';
 import { studyForm, studyFormValid } from '../store';
+import SubmissionTable from './SubmissionTable.vue';
 
 export default defineComponent({
+  components: {
+    SubmissionTable,
+  },
   setup() {
     const formRef = ref();
+    const copyDataDialog = ref(false);
 
     function addContributor() {
       studyForm.contributors.push({
@@ -23,8 +28,13 @@ export default defineComponent({
       ];
     }
 
-    function copyInfoClicked(event) {
-      console.log(event);
+    function copyInfoClicked() {
+      copyDataDialog.value = true;
+    }
+
+    function copyData() {
+      console.log('Copying data...');
+      copyDataDialog.value = false;
     }
 
     onMounted(() => {
@@ -33,12 +43,14 @@ export default defineComponent({
 
     return {
       formRef,
+      copyDataDialog,
       studyForm,
       studyFormValid,
       NmdcSchema,
       Definitions,
       addContributor,
       requiredRules,
+      copyData,
       copyInfoClicked,
     };
   },
@@ -62,6 +74,29 @@ export default defineComponent({
         mdi-content-copy
       </v-icon>
       Copy from another submission
+      <v-dialog
+        v-model="copyDataDialog"
+        activator="parent"
+        width="auto"
+      >
+        <v-card>
+          <v-card-title>
+            Copy Study Data
+          </v-card-title>
+          <v-card-text>Copy study data from an existing submission.</v-card-text>
+          <submission-table
+            :action-title="`Copy`"
+            @submissionSelected="copyData"
+          />
+          <v-card-actions>
+            <v-btn
+              @click="copyDataDialog = false"
+            >
+              Cancel
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
     </v-btn>
     <v-form
       ref="formRef"

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -23,6 +23,10 @@ export default defineComponent({
       ];
     }
 
+    function copyInfoClicked(event) {
+      console.log(event);
+    }
+
     onMounted(() => {
       formRef.value.validate();
     });
@@ -35,6 +39,7 @@ export default defineComponent({
       Definitions,
       addContributor,
       requiredRules,
+      copyInfoClicked,
     };
   },
 });
@@ -45,9 +50,19 @@ export default defineComponent({
     <div class="text-h2">
       Study Information
     </div>
-    <div class="text-h5">
+    <div class="text-h5 mb-1">
       {{ NmdcSchema.$defs.Study.description }}
     </div>
+    <v-btn
+      color="primary"
+      depressed
+      @click="copyInfoClicked"
+    >
+      <v-icon class="pr-1">
+        mdi-content-copy
+      </v-icon>
+      Copy from another submission
+    </v-btn>
     <v-form
       ref="formRef"
       v-model="studyFormValid"

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@vue/composition-api';
+import {
+  defineComponent,
+  onMounted,
+  ref,
+  nextTick,
+} from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
 import { cloneDeep } from 'lodash';
 import Definitions from '@/definitions';
@@ -37,7 +42,7 @@ export default defineComponent({
     function copyData(item: MetadataSubmissionRecord) {
       const newStudyData = cloneDeep(item.metadata_submission.studyForm);
       Object.assign(studyForm, newStudyData);
-      formRef.value.validate();
+      nextTick(() => formRef.value.validate());
       copyDataDialog.value = false;
     }
 

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -1,9 +1,11 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
+import { cloneDeep } from 'lodash';
 import Definitions from '@/definitions';
 import { studyForm, studyFormValid } from '../store';
 import SubmissionTable from './SubmissionTable.vue';
+import { MetadataSubmissionRecord } from '../store/api';
 
 export default defineComponent({
   components: {
@@ -32,8 +34,10 @@ export default defineComponent({
       copyDataDialog.value = true;
     }
 
-    function copyData() {
-      console.log('Copying data...');
+    function copyData(item: MetadataSubmissionRecord) {
+      const newStudyData = cloneDeep(item.metadata_submission.studyForm);
+      Object.assign(studyForm, newStudyData);
+      formRef.value.validate();
       copyDataDialog.value = false;
     }
 

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -120,51 +120,5 @@ export default defineComponent({
       :action-title="`Resume`"
       @submissionSelected="resume"
     />
-    <!-- v-card outlined>
-      <v-data-table
-        :headers="headers"
-        :items="submission.data.results.results"
-        :server-items-length="submission.data.results.count"
-        :options.sync="options"
-        :loading="submission.loading.value"
-        :items-per-page.sync="submission.data.limit"
-        :footer-props="{ itemsPerPageOptions: [10, 20, 50] }"
-      >
-        <template #[`item.author.name`]="{ item }">
-          <a
-            :href="`https://orcid.org/${item.author.orcid}`"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {{ item.author.name || item.author.orcid }}
-          </a>
-        </template>
-        <template #[`item.metadata_submission.templates`]="{ item }">
-          {{ item.metadata_submission.templates.map((template) => HARMONIZER_TEMPLATES[template].displayName).join(' + ') }}
-        </template>
-        <template #[`item.created`]="{ item }">
-          {{ new Date(item.created).toLocaleString() }}
-        </template>
-        <template #[`item.status`]="{ item }">
-          <v-chip
-            :color="getStatus(item).color"
-          >
-            {{ getStatus(item).text }}
-          </v-chip>
-        </template>
-        <template #[`item.action`]="{ item }">
-          <v-btn
-            small
-            color="primary"
-            @click="() => resume(item)"
-          >
-            Resume
-            <v-icon class="pl-1">
-              mdi-arrow-right-circle
-            </v-icon>
-          </v-btn>
-        </template>
-      </v-data-table>
-    </v-card -->
   </v-card>
 </template>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -1,50 +1,11 @@
 <script lang="ts">
-import {
-  defineComponent, ref, watch,
-} from '@vue/composition-api';
-import { DataTableHeader } from 'vuetify';
+import { defineComponent } from '@vue/composition-api';
 import { useRouter } from '@/use/useRouter';
-import usePaginatedResults from '@/use/usePaginatedResults';
 import {
-  loadRecord, generateRecord, submissionStatus,
+  loadRecord, generateRecord,
 } from '../store';
 import * as api from '../store/api';
-import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
 import SubmissionTable from './SubmissionTable.vue';
-
-const headers: DataTableHeader[] = [
-  {
-    text: 'Study Name',
-    value: 'metadata_submission.studyForm.studyName',
-    sortable: false,
-  },
-  {
-    text: 'Author',
-    value: 'author.name',
-    sortable: false,
-  },
-  {
-    text: 'Template',
-    value: 'metadata_submission.templates',
-    sortable: false,
-  },
-  {
-    text: 'Status',
-    value: 'status',
-    sortable: false,
-  },
-  {
-    text: 'Created',
-    value: 'created',
-    sortable: false,
-  },
-  {
-    text: '',
-    value: 'action',
-    align: 'end',
-    sortable: false,
-  },
-];
 
 export default defineComponent({
   components: {
@@ -53,19 +14,6 @@ export default defineComponent({
 
   setup() {
     const router = useRouter();
-    const itemsPerPage = 10;
-    const options = ref({
-      page: 1,
-      itemsPerPage,
-    });
-
-    function getStatus(item: api.MetadataSubmissionRecord) {
-      const color = item.status === submissionStatus.Complete ? 'success' : 'default';
-      return {
-        text: item.status,
-        color,
-      };
-    }
 
     async function resume(item: api.MetadataSubmissionRecord) {
       await loadRecord(item.id);
@@ -77,17 +25,9 @@ export default defineComponent({
       router?.push({ name: 'Submission Context', params: { id: item.id } });
     }
 
-    const submission = usePaginatedResults(ref([]), api.listRecords, ref([]), itemsPerPage);
-    watch(options, () => submission.setPage(options.value.page), { deep: true });
-
     return {
-      HARMONIZER_TEMPLATES,
       createNewSubmission,
-      getStatus,
       resume,
-      headers,
-      options,
-      submission,
     };
   },
 });

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -10,6 +10,7 @@ import {
 } from '../store';
 import * as api from '../store/api';
 import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
+import SubmissionTable from './SubmissionTable.vue';
 
 const headers: DataTableHeader[] = [
   {
@@ -46,6 +47,10 @@ const headers: DataTableHeader[] = [
 ];
 
 export default defineComponent({
+  components: {
+    SubmissionTable,
+  },
+
   setup() {
     const router = useRouter();
     const itemsPerPage = 10;
@@ -111,7 +116,11 @@ export default defineComponent({
     <v-card-text>
       Pick up where you left off or review a previous submission.
     </v-card-text>
-    <v-card outlined>
+    <SubmissionTable
+      :action-title="`Resume`"
+      @submissionSelected="resume"
+    />
+    <!-- v-card outlined>
       <v-data-table
         :headers="headers"
         :items="submission.data.results.results"
@@ -156,6 +165,6 @@ export default defineComponent({
           </v-btn>
         </template>
       </v-data-table>
-    </v-card>
+    </v-card -->
   </v-card>
 </template>

--- a/web/src/views/SubmissionPortal/Components/SubmissionTable.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionTable.vue
@@ -1,0 +1,126 @@
+<script lang="ts">
+import { defineComponent, ref, watch } from '@vue/composition-api';
+import { DataTableHeader } from 'vuetify';
+import usePaginatedResults from '@/use/usePaginatedResults';
+import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
+import { submissionStatus } from '../store';
+import * as api from '../store/api';
+
+const headers: DataTableHeader[] = [
+  {
+    text: 'Study Name',
+    value: 'metadata_submission.studyForm.studyName',
+    sortable: false,
+  },
+  {
+    text: 'Author',
+    value: 'author.name',
+    sortable: false,
+  },
+  {
+    text: 'Template',
+    value: 'metadata_submission.templates',
+    sortable: false,
+  },
+  {
+    text: 'Status',
+    value: 'status',
+    sortable: false,
+  },
+  {
+    text: 'Created',
+    value: 'created',
+    sortable: false,
+  },
+  {
+    text: '',
+    value: 'action',
+    align: 'end',
+    sortable: false,
+  },
+];
+
+export default defineComponent({
+  props: {
+    actionTitle: {
+      type: String,
+      required: true,
+    },
+  },
+  setup() {
+    const itemsPerPage = 10;
+    const options = ref({
+      page: 1,
+      itemsPerPage,
+    });
+
+    function getStatus(item: api.MetadataSubmissionRecord) {
+      const color = item.status === submissionStatus.Complete ? 'success' : 'default';
+      return {
+        text: item.status,
+        color,
+      };
+    }
+
+    const submission = usePaginatedResults(ref([]), api.listRecords, ref([]), itemsPerPage);
+    watch(options, () => submission.setPage(options.value.page), { deep: true });
+
+    return {
+      HARMONIZER_TEMPLATES,
+      getStatus,
+      headers,
+      options,
+      submission,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-card outlined>
+    <v-data-table
+      :headers="headers"
+      :items="submission.data.results.results"
+      :server-items-length="submission.data.results.count"
+      :options.sync="options"
+      :loading="submission.loading.value"
+      :items-per-page.sync="submission.data.limit"
+      :footer-props="{ itemsPerPageOptions: [10, 20, 50] }"
+    >
+      <template #[`item.author.name`]="{ item }">
+        <a
+          :href="`https://orcid.org/${item.author.orcid}`"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {{ item.author.name || item.author.orcid }}
+        </a>
+      </template>
+      <template #[`item.metadata_submission.templates`]="{ item }">
+        {{ item.metadata_submission.templates.map((template) => HARMONIZER_TEMPLATES[template].displayName).join(' + ') }}
+      </template>
+      <template #[`item.created`]="{ item }">
+        {{ new Date(item.created).toLocaleString() }}
+      </template>
+      <template #[`item.status`]="{ item }">
+        <v-chip
+          :color="getStatus(item).color"
+        >
+          {{ getStatus(item).text }}
+        </v-chip>
+      </template>
+      <template #[`item.action`]="{ item }">
+        <v-btn
+          small
+          color="primary"
+          @click="$emit('submissionSelected', item)"
+        >
+          {{ actionTitle }}
+          <v-icon class="pl-1">
+            mdi-arrow-right-circle
+          </v-icon>
+        </v-btn>
+      </template>
+    </v-data-table>
+  </v-card>
+</template>


### PR DESCRIPTION
close #959 

![image](https://user-images.githubusercontent.com/7085625/236251192-288f4e89-5c43-4bd0-af00-7914a8bbdea6.png)
Copying study data can be done by first clicking this button.

![image](https://user-images.githubusercontent.com/7085625/236251495-07f6fa50-452b-48ae-b7db-e4a82b888910.png)
After clicking the button, a modal will appear containing all submissions that the current user can view. Clicking the "copy" button will copy the study information of the selected submission into the current submission.

This change refactors the initial submission list, so testing should include ensuring that the functionality of that view is intact.


https://github.com/microbiomedata/nmdc-server/assets/7085625/3dd42777-ee3d-4c19-93e6-ca6fa5557b57

