### PR TITLE
Remove "Pilot" from site title

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -22,7 +22,7 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="<%= BASE_URL %>ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
-    <title>NMDC Pilot</title>
+    <title>NMDC</title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
   </head>


### PR DESCRIPTION
close #958 

Update website title to reflect that we are no longer in a pilot phase.