### PR TITLE
Add submission portal documentation links

### DIFF
--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -4,8 +4,10 @@ import Definitions from '@/definitions';
 import {
   multiOmicsForm, multiOmicsFormValid, multiOmicsAssociations, templateChoiceDisabled, contextForm,
 } from '../store';
+import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
+  components: { SubmissionDocsLink },
   setup() {
     const formRef = ref();
 
@@ -32,6 +34,7 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Multi-omics Data
+      <submission-docs-link documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#multi-omics-data" />
     </div>
     <div class="text-h5">
       Information about the type of samples being submitted.

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -34,7 +34,7 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Multi-omics Data
-      <submission-docs-link documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#multi-omics-data" />
+      <submission-docs-link anchor="multi-omics-data" />
     </div>
     <div class="text-h5">
       Information about the type of samples being submitted.

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -3,8 +3,10 @@ import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
 import Definitions from '@/definitions';
 import { studyForm, studyFormValid } from '../store';
+import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
+  components: { SubmissionDocsLink },
   setup() {
     const formRef = ref();
 
@@ -44,6 +46,9 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Study Information
+      <submission-docs-link
+        documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#study"
+      />
     </div>
     <div class="text-h5">
       {{ NmdcSchema.$defs.Study.description }}

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -46,9 +46,7 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Study Information
-      <submission-docs-link
-        documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#study"
-      />
+      <submission-docs-link anchor="study" />
     </div>
     <div class="text-h5">
       {{ NmdcSchema.$defs.Study.description }}

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -84,9 +84,7 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Submission Context
-      <submission-docs-link
-        documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#submission-context"
-      />
+      <submission-docs-link anchor="submission-context" />
     </div>
     <div class="text-h5">
       Data and sample status

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -15,9 +15,10 @@ import {
   addressFormValid,
 } from '../store';
 import SubmissionContextShippingForm from './SubmissionContextShippingForm.vue';
+import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
-  components: { SubmissionContextShippingForm },
+  components: { SubmissionContextShippingForm, SubmissionDocsLink },
   setup() {
     const formRef = ref();
     const facilityEnum = NmdcSchema.$defs.ProcessingInstitutionEnum.enum.filter(
@@ -83,6 +84,9 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Submission Context
+      <submission-docs-link
+        documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#submission-context"
+      />
     </div>
     <div class="text-h5">
       Data and sample status

--- a/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
@@ -1,12 +1,22 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { computed, defineComponent } from '@vue/composition-api';
 
 export default defineComponent({
   props: {
-    documentationUrl: {
+    baseUrl: {
       type: String,
       default: 'https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html',
     },
+    anchor: {
+      type: String,
+      default: '',
+    },
+  },
+  setup(props) {
+    const fullUrl = computed(() => props.baseUrl + (props.anchor ? `#${props.anchor}` : ''));
+    return {
+      fullUrl,
+    };
   },
 });
 </script>
@@ -14,7 +24,7 @@ export default defineComponent({
 <template>
   <a
     class="ml-2"
-    :href="documentationUrl"
+    :href="fullUrl"
     target="_blank"
   >
     <v-icon>

--- a/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
@@ -1,0 +1,24 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  props: {
+    documentationUrl: {
+      type: String,
+      default: 'https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html',
+    },
+  },
+});
+</script>
+
+<template>
+  <a
+    class="ml-2"
+    :href="documentationUrl"
+    target="_blank"
+  >
+    <v-icon>
+      mdi-information-outline
+    </v-icon>
+  </a>
+</template>

--- a/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
@@ -22,13 +22,26 @@ export default defineComponent({
 </script>
 
 <template>
-  <a
-    class="ml-2"
-    :href="fullUrl"
-    target="_blank"
-  >
-    <v-icon>
-      mdi-information-outline
-    </v-icon>
-  </a>
+  <v-tooltip bottom>
+    View documentation
+    <template #activator="{ on, attrs }">
+      <a
+        class="ml-2"
+        :href="fullUrl"
+        target="_blank"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-btn
+          color="primary"
+          text
+          icon
+        >
+          <v-icon size="24px">
+            mdi-information
+          </v-icon>
+        </v-btn>
+      </a>
+    </template>
+  </v-tooltip>
 </template>

--- a/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionDocsLink.vue
@@ -29,6 +29,7 @@ export default defineComponent({
         class="ml-2"
         :href="fullUrl"
         target="_blank"
+        rel="noopener noreferrer"
         v-bind="attrs"
         v-on="on"
       >

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -10,6 +10,7 @@ import {
 } from '../store';
 import * as api from '../store/api';
 import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
+import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 const headers: DataTableHeader[] = [
   {
@@ -46,6 +47,7 @@ const headers: DataTableHeader[] = [
 ];
 
 export default defineComponent({
+  components: { SubmissionDocsLink },
   setup() {
     const router = useRouter();
     const itemsPerPage = 10;
@@ -92,6 +94,7 @@ export default defineComponent({
   <v-card flat>
     <v-card-title class="text-h4">
       NMDC Submission Portal
+      <submission-docs-link />
     </v-card-title>
     <v-card-text>
       This is the submission portal, where researchers can provide their own study and sample metadata for inclusion in NMDC.

--- a/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
+++ b/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
@@ -26,7 +26,7 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Environment Package
-      <submission-docs-link documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#environmental-package" />
+      <submission-docs-link anchor="environmental-package" />
     </div>
     <div class="text-h5">
       Choose environment package for your data.

--- a/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
+++ b/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
@@ -2,8 +2,10 @@
 import { defineComponent, computed } from '@vue/composition-api';
 import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
 import { templateChoiceDisabled, templateList, packageName } from '../store';
+import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
+  components: { SubmissionDocsLink },
   setup() {
     const templateListDisplayNames = computed(() => templateList.value
       .map((templateKey) => HARMONIZER_TEMPLATES[templateKey].displayName)
@@ -24,6 +26,7 @@ export default defineComponent({
   <div>
     <div class="text-h2">
       Environment Package
+      <submission-docs-link documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#environmental-package" />
     </div>
     <div class="text-h5">
       Choose environment package for your data.

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -24,6 +24,7 @@ import {
 } from './store';
 import FindReplace from './Components/FindReplace.vue';
 import SubmissionStepper from './Components/SubmissionStepper.vue';
+import SubmissionDocsLink from './Components/SubmissionDocsLink.vue';
 
 interface ValidationErrors {
   [error: string]: [number, number][],
@@ -65,7 +66,7 @@ const JGI_MG = 'jgi_mg';
 const JGT_MT = 'jgi_mt';
 
 export default defineComponent({
-  components: { FindReplace, SubmissionStepper },
+  components: { FindReplace, SubmissionStepper, SubmissionDocsLink },
 
   setup(_, { root }) {
     const harmonizerElement = ref();
@@ -529,6 +530,7 @@ export default defineComponent({
             Re-validate
           </v-btn>
         </v-card>
+        <submission-docs-link documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#sample-metadata" />
         <v-spacer />
         <v-autocomplete
           v-model="jumpToModel"

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -530,7 +530,7 @@ export default defineComponent({
             Re-validate
           </v-btn>
         </v-card>
-        <submission-docs-link documentation-url="https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html#sample-metadata" />
+        <submission-docs-link anchor="sample-metadata" />
         <v-spacer />
         <v-autocomplete
           v-model="jumpToModel"


### PR DESCRIPTION
fix microbiomedata/issues/issues/239

This PR creates a new component, `SubmissionDocsLink`, which simply provides an icon to be used as a link to documentation. The component has been added to each step of the submission portal with links to the corresponding section in the submission portal [user documentation](https://nmdc-documentation.readthedocs.io/en/latest/howto_guides/submit2nmdc.html).