### PR TITLE
Upgrade to submission schema 7.6.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.2",
     "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v6.0.4",
-    "nmdc-submission-schema": "https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-1.0.2.tar.gz",
+    "nmdc-submission-schema": "https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-7.6.0.tar.gz",
     "popper.js": "1.16.1",
     "protobufjs": "^6.11.3",
     "serialize-javascript": "^6.0.0",

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -51,14 +51,18 @@ const ColorKey = {
 
 const EXPORT_FILENAME = 'nmdc_sample_export.xlsx';
 
+const SAMP_NAME = 'samp_name';
+const SOURCE_MAT_ID = 'source_mat_id';
+const ANALYSIS_TYPE = 'analysis_type';
+
 // controls which field is used to merge data from different DH views
-const SCHEMA_ID = 'source_mat_id';
+const SCHEMA_ID = SAMP_NAME;
 
 // used in determining which rows are shown in each view
-const TYPE_FIELD = 'analysis_type';
+const TYPE_FIELD = ANALYSIS_TYPE;
 
 // TODO: should this be derived from schema?
-const COMMON_COLUMNS = ['samp_name', SCHEMA_ID, TYPE_FIELD];
+const COMMON_COLUMNS = [SAMP_NAME, SOURCE_MAT_ID, ANALYSIS_TYPE];
 
 // TODO: can this be imported from elsewhere?
 const EMSL = 'emsl';

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7566,9 +7566,9 @@ nice-try@^1.0.4:
   version "0.0.0"
   resolved "https://github.com/microbiomedata/nmdc-schema#e9b7da691079989a7e72ecc350f59058c6787557"
 
-"nmdc-submission-schema@https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-1.0.2.tar.gz":
+"nmdc-submission-schema@https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-7.6.0.tar.gz":
   version "0.0.0"
-  resolved "https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-1.0.2.tar.gz#955fd0c2358519c648c0ee3a907917a8183e70de"
+  resolved "https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-7.6.0.tar.gz#a26fc1a26691ddf6c02707b3f6a8acd45eebf4f4"
 
 no-case@^2.2.0:
   version "2.3.2"


### PR DESCRIPTION
This upgrades to the latest version of the submission schema, 7.6.0 (there was a change in the version numbering scheme to align the version numbers with the main schema, hence the large jump). Previously the `source_mat_id` column was used to link rows across different DH tabs. That slot is no longer required, so `samp_name` -- which is required and values must be unique -- is used instead. 