### PR TITLE
Eliminate unnecessary DH data refreshes

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -90,7 +90,7 @@ export default defineComponent({
 
     const submitDialog = ref(false);
 
-    watch(activeTemplateData, () => {
+    watch(activeTemplate, () => {
       harmonizerApi.loadData(activeTemplateData.value);
       // if we're not on the first tab, the common columns should be read-only
       if (activeTemplateKey.value !== templateList.value[0]) {


### PR DESCRIPTION
I _think_ this fixes #916. 

The code in the watcher callback is needed when switching tabs: new data is loaded into the DH instance and a few other DH options are optionally set. However, by watching `activeTemplateData` that callback is fired way too often. `activeTemplateData` is [computed](https://github.com/microbiomedata/nmdc-server/blob/29aa87698b082769a97faf7cd788c58bb3ab1468/web/src/views/SubmissionPortal/HarmonizerView.vue#L83-L88) from `sampleData` and `sampleData` is [updated](https://github.com/microbiomedata/nmdc-server/blob/29aa87698b082769a97faf7cd788c58bb3ab1468/web/src/views/SubmissionPortal/HarmonizerView.vue#LL139C15-L139C15) anytime a cell is edited. Most of the time these extra reloads are benign. But it seems like there are scenarios (I guess based on how wide the full table is and where you're scrolled within it) where Handsontable doesn't restore the scroll position correctly after loading data and the end result to the user is the jumpiness. 

With this change the callback is only executed when the user switches tabs, which was the original intent of the watcher in the first place. 