### PR TITLE
Handle null gold slots

### DIFF
--- a/web/src/util.js
+++ b/web/src/util.js
@@ -91,7 +91,6 @@ export function makeTree(data, heirarchy) {
       const nodeKey = `${parentKey}${parentKey && '.'}${nodeName}`;
       const parent = nodeMap[parentKey];
       let node = nodeMap[nodeKey];
-      console.log(item);
       if (parent && nodeName) {
         if (!node) {
           node = {
@@ -118,7 +117,6 @@ export function makeTree(data, heirarchy) {
           topoSort.push(node);
         }
         node.count += item.count;
-        console.log(node.count);
       }
     });
   });

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -91,29 +91,35 @@ export function makeTree(data, heirarchy) {
       const nodeKey = `${parentKey}${parentKey && '.'}${nodeName}`;
       const parent = nodeMap[parentKey];
       let node = nodeMap[nodeKey];
-      if (!node) {
-        node = {
-          id: nodeKey,
-          parent,
-          name: nodeName,
-          label: nodeName,
-          heirarchyKey: heirarchy[depth],
-          count: 0,
-          depth: depth + 1,
-          children: undefined,
-          isDefaultExpanded: false,
-        };
-        nodeMap[nodeKey] = node;
-        if (parent.children === undefined) {
-          parent.children = [node];
-          parent.isDefaultExpanded = true;
-        } else {
-          parent.children.push(node);
-          parent.isDefaultExpanded = false;
+      console.log(item);
+      if (parent && nodeName) {
+        if (!node) {
+          node = {
+            id: nodeKey,
+            parent,
+            name: nodeName,
+            label: nodeName,
+            heirarchyKey: heirarchy[depth],
+            count: 0,
+            depth: depth + 1,
+            children: undefined,
+            isDefaultExpanded: false,
+          };
+          nodeMap[nodeKey] = node;
+
+          if (parent.children === undefined) {
+            parent.children = [node];
+            parent.isDefaultExpanded = true;
+          } else {
+            parent.children.push(node);
+            parent.isDefaultExpanded = false;
+          }
+
+          topoSort.push(node);
         }
-        topoSort.push(node);
+        node.count += item.count;
+        console.log(node.count);
       }
-      node.count += item.count;
     });
   });
   return {


### PR DESCRIPTION
This removes null values from the gold classification tree. It is important to note that this effects all the tree and as such should be discussed further. We may need a more sophisticated solution instead of this all or nothing approach.