### PR TITLE
Wrap URLs in InvestigatorBio

### DIFF
--- a/web/src/components/InvestigatorBio.vue
+++ b/web/src/components/InvestigatorBio.vue
@@ -69,7 +69,7 @@ export default defineComponent({
             v-for="site in piWebsites"
             :key="site"
             class="blue--text py-1"
-            style="cursor: pointer; text-decoration: none; display: block;"
+            style="cursor: pointer; text-decoration: none; display: block; word-break: break-all"
             :href="site"
           >
             <v-icon


### PR DESCRIPTION
This prevents stacking the PI/study image until the window becomes much narrower. It has the added benefit of unifying text wrapping behavior between web browsers. See the conversation in the linked issue for more details.

Fix #942 