### PR TITLE
Update Rancher URLs to reference new development environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: fjogeleit/http-request-action@v1.3.3
         if: ${{ matrix.image == 'server' && github.event_name == 'push' }}
         with:
-          url: 'https://rancher2.spin.nersc.gov/v3/project/c-fwj56:p-nlxq2/workloads/deployment:nmdc-dev:backend?action=redeploy'
+          url: 'https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads/deployment:nmdc-dev:portal-backend?action=redeploy'
           method: 'POST'
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
@@ -62,7 +62,7 @@ jobs:
         uses: fjogeleit/http-request-action@v1.3.3
         if: ${{ matrix.image == 'client' && github.event_name == 'push' }}
         with:
-          url: 'https://rancher2.spin.nersc.gov/v3/project/c-fwj56:p-nlxq2/workloads/deployment:nmdc-dev:frontend?action=redeploy'
+          url: 'https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads/deployment:nmdc-dev:portal-frontend?action=redeploy'
           method: 'POST'
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
@@ -82,7 +82,7 @@ jobs:
         uses: fjogeleit/http-request-action@v1.3.3
         if: ${{ matrix.image == 'worker' && github.event_name == 'push' }}
         with:
-          url: 'https://rancher2.spin.nersc.gov/v3/project/c-fwj56:p-nlxq2/workloads/deployment:nmdc-dev:worker?action=redeploy'
+          url: 'https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads/deployment:nmdc-dev:portal-worker?action=redeploy'
           method: 'POST'
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}


### PR DESCRIPTION
In this branch, I modified the GitHub Actions workflow that updates deployments on Rancher, to do so in the new development environment instead of the old development environment.

### Regarding the "project ID" portion of the URL:

I got that by following these steps (I came up with these steps via trial-and-error):
1. Visit Rancher and go to the relevant cluster
2. Open the web browser's DevTools, go to the "Network" tab, and clear the list of requests (if any)
3. Reload the web page
4. In the list of requests, find the request for `namespaces`
5. In that request, go to the "Preview" tab to see the response
6. In the response, find the `data` array and—in that array—the namespace whose `id` is `nmdc-dev`, and look at its `metadata.annotations`
7. Get the value of the annotation whose key is `field.cattle.io/projectId`

#### Screenshot

<img width="672" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/bf68cb64-b5a9-4fa9-8fe3-2bfc12649c00">

#### Result

- In the old development environment (i.e. the `nmdc-dev` namespace on the `development` cluster), the annotation has the value `"c-fwj56:p-nlxq2"`
- In the new development environment (i.e. the `nmdc-dev` namespace on the `production` cluster), the annotation has the value `"c-tmq7p:p-bkv45"`

### Regarding the deployment names:

- In the old development environment, the relevant deployments had the names `backend`, `frontend`, and `worker`
- In the new development environment, they have different names; which are `portal-backend`, `portal-frontend`, and `portal-worker`, respectively

Fixes https://github.com/microbiomedata/nmdc-server/issues/994