### PR TITLE
Use aliased tables for study search

### DIFF
--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -198,10 +198,7 @@ class BiosampleFilter(BaseFilter):
     table = Table.biosample
 
     def join_omics_processing(self, query: Query) -> Query:
-        return self.join_self(
-            query.join(models.OmicsProcessing, models.Biosample.omics_processing),
-            Table.biosample,
-        )
+        return query.join(models.biosample_input_association).join(models.Biosample)
 
     def join_biosample(self, query: Query) -> Query:
         return self.join_self(query, Table.biosample)
@@ -240,10 +237,7 @@ class OmicsProcessingFilter(BaseFilter):
         return self.join_self(query, Table.omics_processing)
 
     def join_biosample(self, query: Query) -> Query:
-        return self.join_self(
-            query.join(models.Biosample, models.OmicsProcessing.biosample_inputs),
-            Table.omics_processing,
-        )
+        return query.join(models.biosample_input_association).join(models.OmicsProcessing)
 
     def join_study(self, query: Query) -> Query:
         return self.join_self(


### PR DESCRIPTION
Fix #1002 

#991 did not properly update SQLAlchemy code to join `biosamples` through to `omics_processing` records, resulting in some cartesian products which reduced the functionality of aggregating on omics type.

Additionally study filtering was broken due to multiple references to tables in generated SQL code, so aliases are used for `biosample` and `omics_processing` in order to eliminate this error.

Now, searching using the data portal should be functional, and omics types aggregations and studies should update as expected.