### PR TITLE
Indicate pooled sample inputs on `DataObjectTable`s

### DIFF
--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, onMounted, PropType, reactive,
+  computed, defineComponent, PropType, reactive,
 } from '@vue/composition-api';
 import { flattenDeep } from 'lodash';
 
@@ -133,10 +133,6 @@ export default defineComponent({
       termsDialog.value = false;
       acceptTerms();
     }
-
-    onMounted(() => {
-      console.log(props.omicsProcessing);
-    });
 
     return {
       onAcceptTerms,

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, PropType, reactive,
+  computed, defineComponent, onMounted, PropType, reactive,
 } from '@vue/composition-api';
 import { flattenDeep } from 'lodash';
 
@@ -113,6 +113,10 @@ export default defineComponent({
       termsDialog.value = false;
       acceptTerms();
     }
+
+    onMounted(() => {
+      console.log(props.omicsProcessing);
+    });
 
     return {
       onAcceptTerms,

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -85,8 +85,17 @@ export default defineComponent({
       value: false,
     });
 
+    function getOmicsDataWithInputIds(omicsProcessing: OmicsProcessingResult) {
+      const biosampleInputIds = omicsProcessing.biosample_inputs.map((input) => input.id);
+      return omicsProcessing.omics_data.map((omics) => {
+        const omicsCopy = { ...omics };
+        omicsCopy.inputIds = biosampleInputIds;
+        return omicsCopy;
+      });
+    }
+
     const items = computed(() => flattenDeep(
-      flattenDeep(props.omicsProcessing.map((p) => (p.omics_data)))
+      flattenDeep(props.omicsProcessing.map((p) => (getOmicsDataWithInputIds(p))))
         .map((omics_data) => omics_data.outputs
           .filter((data) => data.file_type && data.file_type_description)
           .map((data_object, i) => ({
@@ -155,6 +164,19 @@ export default defineComponent({
         >
           <td colspan="6">
             <b>Workflow Activity:</b> {{ item.group_name }}
+            <br>
+            <div v-if="item.omics_data.inputIds.length > 1">
+              <v-icon>
+                mdi-flask-outline
+              </v-icon>
+              <b>Associated biosample inputs: </b>
+              <span
+                v-for="biosampleId in item.omics_data.inputIds"
+                :key="biosampleId"
+              >
+                {{ biosampleId }},
+              </span>
+            </div>
           </td>
         </tr>
         <tr>

--- a/web/src/components/SampleListExpansion.vue
+++ b/web/src/components/SampleListExpansion.vue
@@ -89,6 +89,7 @@ export default defineComponent({
         :omics-processing="projects"
         :omics-type="omicsType"
         :logged-in-user="loggedInUser"
+        :biosample="result"
       />
     </template>
   </div>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -87,7 +87,7 @@ export default defineComponent({
     }
 
     const biosampleType = types.biosample;
-    const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter, 150);
+    const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter);
 
     const studyType = types.study;
     const studySummaryData = useFacetSummaryData({
@@ -281,7 +281,6 @@ export default defineComponent({
                 :results="biosample.data.results.results"
                 :page="biosample.data.pageSync"
                 :subtitle-key="'study_id'"
-                :title-key="'id'"
                 :loading="biosample.loading.value"
                 @set-page="biosample.setPage($event)"
                 @selected="$router.push({ name: 'Sample', params: { id: $event }})"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -87,7 +87,7 @@ export default defineComponent({
     }
 
     const biosampleType = types.biosample;
-    const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter);
+    const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter, 150);
 
     const studyType = types.study;
     const studySummaryData = useFacetSummaryData({
@@ -281,6 +281,7 @@ export default defineComponent({
                 :results="biosample.data.results.results"
                 :page="biosample.data.pageSync"
                 :subtitle-key="'study_id'"
+                :title-key="'id'"
                 :loading="biosample.loading.value"
                 @set-page="biosample.setPage($event)"
                 @selected="$router.push({ name: 'Sample', params: { id: $event }})"


### PR DESCRIPTION
Fix #975 (partial)

This PR adds related Biosample inputs to the search results page. That is, if workflows had multiple biosample inputs (e.g. a pooled sample was used as the input), it will be indicated in the data object data for those biosamples:

![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/395e47a8-a628-429d-b649-96a8e73ea04e)

Note that this PR does not update the biosample detail page.