### PR TITLE
Add related biosample to detail page

### DIFF
--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -58,12 +58,33 @@ export default defineComponent({
       return ret;
     });
 
+    const relatedBiosamples = computed(() => {
+      const relatedBiosampleIds = new Set();
+      if (props.type !== 'biosample') {
+        return relatedBiosampleIds;
+      }
+      const biosample = props.item as BiosampleSearchResult;
+      if (biosample.omics_processing.length) {
+        biosample.omics_processing.forEach((omicsProcessing: any) => {
+          if (omicsProcessing.biosample_inputs) {
+            omicsProcessing.biosample_inputs.forEach((biosampleInput: BiosampleSearchResult) => {
+              if (biosampleInput.id && biosampleInput.id !== biosample.id) {
+                relatedBiosampleIds.add(biosampleInput.id);
+              }
+            });
+          }
+        });
+      }
+      return relatedBiosampleIds;
+    });
+
     const alternateIdentifiers = computed(() => props.item.alternate_identifiers
       .map((id) => ({ name: id, target: `https://identifiers.org/${id}` })));
     return {
       // computed
       alternateIdentifiers,
       displayFields,
+      relatedBiosamples,
     };
   },
 });
@@ -100,6 +121,28 @@ export default defineComponent({
         :key="emslId"
         v-bind="{ item, field: 'emsl_biosample_identifiers', index, displayName: 'EMSL Identifier' }"
       />
+    </v-list>
+    <v-list v-if="type === 'biosample' && relatedBiosamples.size">
+      <div class="display-1">
+        Related Biosamples
+      </div>
+      <v-list-item
+        v-for="biosampleId in relatedBiosamples"
+        :key="biosampleId"
+        :href="'/details/sample/' + biosampleId"
+      >
+        <v-list-item-avatar>
+          <v-icon>mdi-link</v-icon>
+        </v-list-item-avatar>
+        <v-list-item-content>
+          <v-list-item-title>
+            ID
+          </v-list-item-title>
+          <v-list-item-subtitle>
+            {{ biosampleId }}
+          </v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
     </v-list>
   </div>
 </template>


### PR DESCRIPTION
This appears to be a first. We are displaying some data on a detail page that doesn't directly come from the object itself. Because of this I opted to not use `AttributeItem`.

Now, when applicable, a new section appears on the biosample detail page that contains a list of related biosamples. This list is built by looking at related `omics_processing` records, and noting what additional biosamples are used as inputs to those.

Fix #1008 

![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/7f6b342b-0e80-4bf6-ac2e-f36ab435b8ea)
