### PR TITLE
Don't display "unauthenticated" next to ORCID IDs

### DIFF
--- a/web/src/components/Presentation/OrcidId.vue
+++ b/web/src/components/Presentation/OrcidId.vue
@@ -47,6 +47,7 @@ export default defineComponent({
         {{ orcidId }}
       </span>
     </a>
+    <!-- Hold off on this until its's determind to be the right thing to do -->
     <!--span
       v-if="!authenticated"
       class="ml-1"

--- a/web/src/components/Presentation/OrcidId.vue
+++ b/web/src/components/Presentation/OrcidId.vue
@@ -47,11 +47,11 @@ export default defineComponent({
         {{ orcidId }}
       </span>
     </a>
-    <span
+    <!--span
       v-if="!authenticated"
       class="ml-1"
     >
       (Unauthenticated)
-    </span>
+    </span-->
   </div>
 </template>


### PR DESCRIPTION
This may or may not be required, so we should hold off until we know for sure.