### PR TITLE
1023 disable empty data tables

### DIFF
--- a/web/src/components/SampleListExpansion.vue
+++ b/web/src/components/SampleListExpansion.vue
@@ -74,7 +74,9 @@ export default defineComponent({
         x-small
         :outlined="!isOpen(projects[0].id)"
         :color="isOpen(projects[0].id) ? 'primary' : 'default'"
+        :disabled="projects[0].omics_data.length == 0 ? true : false"
         class="mr-2 mt-2"
+
         @click="() => $emit('open-details', projects[0].id)"
       >
         {{ fieldDisplayName(omicsType) }}


### PR DESCRIPTION
partially handles #1023, this is admittedly an easy, incomplete fix

the button for expanding the data object table is disabled if there is no processed data.