### PR TITLE
Count disctinct omics IDs

### DIFF
--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -570,7 +570,7 @@ class StudyQuerySchema(BaseQuerySchema):
         query = (
             db.query(
                 op_summary_alias.annotations["omics_type"].astext.label("omics_processing_type"),
-                func.count(op_summary_alias.id).label("omics_processing_count"),
+                func.count(func.distinct(op_summary_alias.id)).label("omics_processing_count"),
                 op_summary_alias.study_id.label("omics_processing_study_id_sub"),
             )
             .join(subquery, subquery.c.id == op_summary_alias.id)


### PR DESCRIPTION
Fix #1028 

Chip counts for omics processing types in the study portion of the data portal were incorrect. For NEON, the number of `omics_processing` records related to that study is 1473, which was reflected properly by the omics bar chart, but not by the chip count in the study section (which reported 4111).

We were double-counting `omics_processing` records that had multiple `biosample` inputs.

For the study queries, we now correctly count *distinct* `omics_processing` IDs when aggregating for the chip counts.