### PR TITLE
Add ORCID integration info to login button

### DIFF
--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -50,20 +50,63 @@ export default defineComponent({
       </v-btn>
     </template>
     <template v-else>
-      <v-btn
-        :text="!nav"
-        :plain="nav"
-        :small="nav"
-        href="/login"
+      <v-menu
+        bottom
+        max-width="500"
+        :open-on-hover="true"
+        transition="fade-transition"
+        offset-y
+        content-class="login-btn-orcid-help"
+        class="login-btn-orcid-help"
       >
-        <img
-          width="28px"
-          class="mr-2"
-          alt="OrcId login"
-          src="https://orcid.org/assets/vectors/orcid.logo.icon.svg"
-        >
-        OrcID Login
-      </v-btn>
+        <template #activator="{ on, attrs }">
+          <v-btn
+            :text="!nav"
+            :plain="nav"
+            :small="nav"
+            href="/login"
+            v-bind="attrs"
+            v-on="on"
+          >
+            <img
+              width="28px"
+              class="mr-2"
+              alt="OrcId login"
+              src="https://orcid.org/assets/vectors/orcid.logo.icon.svg"
+            >
+            OrcID Login
+          </v-btn>
+        </template>
+        <v-card>
+          <v-card-title>ORCID Account Integration</v-card-title>
+          <v-card-text>
+            <p>
+              NMDC is collecting your ORCID ID so we can turn on features
+              like file downloads and the ability to create and manage metadata submissions through
+              our Submission Portal.
+            </p>
+            <p>
+              When you click the "Login" button, we will ask you to share your
+              ID using an authenticated process, either by registering for an ORCID ID or, if you
+              already have one, to sign into your ORCID account, then granting permission to get your
+              ORCID ID. We do this to ensure that you are correctly identified and securely connected to
+              your ORCID ID.
+            </p>
+
+            <p>Learn more about <a href="https://orcid.org/blog/2017/02/20/whats-so-special-about-signing">what's so special about signing in?</a></p>
+
+            <p>
+              Additionally, we will use information from your ORCID record, like your name, to connect you with your NMDC submissions.
+            </p>
+          </v-card-text>
+        </v-card>
+      </v-menu>
     </template>
   </div>
 </template>
+
+<style scoped>
+.login-btn-orcid-help {
+  background-color: white;
+}
+</style>

--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -89,14 +89,12 @@ export default defineComponent({
               Click the "ORCID Login" button, to either register for an ORCID ID or, if you
               already have one, to sign into your ORCID account, then grant permission for NMDC to access your
               ORCID ID. This allows us to verify your identity and securely connect to
-              your ORCID ID.
+              your ORCID ID. Additionally we may use information, such as your name and email, to associate your 
+              ORCID record with your NMDC submissions. 
             </p>
 
-            <p>Learn more about <a href="https://orcid.org/blog/2017/02/20/whats-so-special-about-signing">what's so special about signing in?</a></p>
+            <p>Learn more about <a href="https://orcid.org/blog/2017/02/20/whats-so-special-about-signing">what's so special about signing in.</a></p>
 
-            <p>
-              Additionally, we will use information from your ORCID record, such as your name, to associate you with your NMDC submissions.
-            </p>
           </v-card-text>
         </v-card>
       </v-menu>

--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -81,22 +81,21 @@ export default defineComponent({
           <v-card-title>ORCID Account Integration</v-card-title>
           <v-card-text>
             <p>
-              NMDC is collecting your ORCID ID so we can turn on features
-              like file downloads and the ability to create and manage metadata submissions through
+              NMDC requires an ORCID ID to log in. When logged in you have access to features such as downloading 
+              files and the ability to create and manage metadata submissions through
               our Submission Portal.
             </p>
             <p>
-              When you click the "Login" button, we will ask you to share your
-              ID using an authenticated process, either by registering for an ORCID ID or, if you
-              already have one, to sign into your ORCID account, then granting permission to get your
-              ORCID ID. We do this to ensure that you are correctly identified and securely connected to
+              Click the "ORCID Login" button, to either register for an ORCID ID or, if you
+              already have one, to sign into your ORCID account, then grant permission for NMDC to access your
+              ORCID ID. This allows us to verify your identity and securely connect to
               your ORCID ID.
             </p>
 
             <p>Learn more about <a href="https://orcid.org/blog/2017/02/20/whats-so-special-about-signing">what's so special about signing in?</a></p>
 
             <p>
-              Additionally, we will use information from your ORCID record, like your name, to connect you with your NMDC submissions.
+              Additionally, we will use information from your ORCID record, such as your name, to associate you with your NMDC submissions.
             </p>
           </v-card-text>
         </v-card>

--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -89,7 +89,7 @@ export default defineComponent({
               Click the "ORCID Login" button, to either register for an ORCID ID or, if you
               already have one, to sign into your ORCID account, then grant permission for NMDC to access your
               ORCID ID. This allows us to verify your identity and securely connect to
-              your ORCID ID. Additionally we may use information, such as your name and email, to associate your 
+              your ORCID ID. Additionally, we may use information, such as your name and email, to associate your 
               ORCID record with your NMDC submissions. 
             </p>
 


### PR DESCRIPTION
Fix #970 

This PR moves us closer to ORCID integration compliance by adding some information about how we intend to use users' ORCID IDs to the login workflow.

Now, if a user is logged out, hovering over the login button will display a modal that has some information about our use of ORCID.
