### PR TITLE
Rename data portal API

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -22,7 +22,7 @@ def attach_sentry(app: FastAPI):
 
 def create_app(env: typing.Mapping[str, str], secure_cookies: bool = True) -> FastAPI:
     app = FastAPI(
-        title="NMDC Dataset API",
+        title="NMDC Data and Submission Portal API",
         version=__version__,
         docs_url="/api/docs",
         openapi_url="/api/openapi.json",


### PR DESCRIPTION
`NMDC Dataset API` -> `NMDC Data and Submission Portal API`

@aclum @jeffbaumes any objections to this change? This affects the title at the top of the swagger page. I think the proposed title better reflects what the user is actually looking at. I am open to any tweaks as reviewers see fit.

![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/6c7d3289-6ce3-4860-8e96-8496a7a39d74)
