### PR TITLE
Allow searching text for study name and description

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -71,11 +71,14 @@ def text_search(terms: str, limit=6, db: Session = Depends(get_db)):
         "field": "title",
         "op": "like",
     }
+    # These two lists are of objects of separate types
     filters = crud.text_search(db, terms, limit)
-    filters.append(query.SimpleConditionSchema(**study_name_filter))
-    filters.append(query.SimpleConditionSchema(**study_description_filter))
-    filters.append(query.SimpleConditionSchema(**study_title_filter))
-    return filters
+    plaintext_filters = [
+        query.SimpleConditionSchema(**study_name_filter),
+        query.SimpleConditionSchema(**study_description_filter),
+        query.SimpleConditionSchema(**study_title_filter),
+    ]
+    return [*filters, *plaintext_filters]
 
 
 # database summary

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -52,36 +52,29 @@ async def my_orcid(request: Request, orcid: str = Depends(get_current_user_orcid
     response_model=List[query.ConditionResultSchema],
 )
 def text_search(terms: str, limit=6, db: Session = Depends(get_db)):
-    data = {
-        "table": "study",
-        "value": terms.lower(),
-        "field": "principal_investigator_name",
-        "op": "like",
-    }
-    data2 = {
+    # Add 'ilike' filters for study columns users may want to search by
+    study_name_filter = {
         "table": "study",
         "value": terms.lower(),
         "field": "name",
         "op": "like",
     }
-    data3 = {
+    study_description_filter = {
         "table": "study",
         "value": terms.lower(),
         "field": "description",
         "op": "like",
     }
-    data4 = {
+    study_title_filter = {
         "table": "study",
         "value": terms.lower(),
         "field": "title",
         "op": "like",
     }
-    custom_search_index = query.SimpleConditionSchema(**data)
     filters = crud.text_search(db, terms, limit)
-    filters.append(custom_search_index)
-    filters.append(query.SimpleConditionSchema(**data2))
-    filters.append(query.SimpleConditionSchema(**data3))
-    filters.append(query.SimpleConditionSchema(**data4))
+    filters.append(query.SimpleConditionSchema(**study_name_filter))
+    filters.append(query.SimpleConditionSchema(**study_description_filter))
+    filters.append(query.SimpleConditionSchema(**study_title_filter))
     return filters
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -58,9 +58,30 @@ def text_search(terms: str, limit=6, db: Session = Depends(get_db)):
         "field": "principal_investigator_name",
         "op": "like",
     }
+    data2 = {
+        "table": "study",
+        "value": terms.lower(),
+        "field": "name",
+        "op": "like",
+    }
+    data3 = {
+        "table": "study",
+        "value": terms.lower(),
+        "field": "description",
+        "op": "like",
+    }
+    data4 = {
+        "table": "study",
+        "value": terms.lower(),
+        "field": "title",
+        "op": "like",
+    }
     custom_search_index = query.SimpleConditionSchema(**data)
     filters = crud.text_search(db, terms, limit)
     filters.append(custom_search_index)
+    filters.append(query.SimpleConditionSchema(**data2))
+    filters.append(query.SimpleConditionSchema(**data3))
+    filters.append(query.SimpleConditionSchema(**data4))
     return filters
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -46,9 +46,22 @@ async def my_orcid(request: Request, orcid: str = Depends(get_current_user_orcid
 
 
 # autocomplete search
-@router.get("/search", tags=["aggregation"], response_model=List[query.ConditionResultSchema])
+@router.get(
+    "/search",
+    tags=["aggregation"],
+    response_model=List[query.ConditionResultSchema],
+)
 def text_search(terms: str, limit=6, db: Session = Depends(get_db)):
-    return crud.text_search(db, terms, limit)
+    data = {
+        "table": "study",
+        "value": terms.lower(),
+        "field": "principal_investigator_name",
+        "op": "like",
+    }
+    custom_search_index = query.SimpleConditionSchema(**data)
+    filters = crud.text_search(db, terms, limit)
+    filters.append(custom_search_index)
+    return filters
 
 
 # database summary

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -23,6 +23,12 @@ def cli(ctx):
 
 
 @cli.command()
+def create_or_replace_nmdc_functions():
+    """Create or replace custom NMDC functions for the SQL Databases"""
+    jobs.update_nmdc_functions()
+
+
+@cli.command()
 @click.option("--ingest-db", is_flag=True, default=False)
 def migrate(ingest_db: bool):
     """Upgrade the database schema."""

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -72,10 +72,6 @@ def text_search(db: Session, terms: str, limit: int) -> List[models.SearchIndex]
         .limit(limit)
         .all()
     )
-    data = {"table": "study", "value": terms.lower(), "field": "principal_investigator_name"}
-    custom_search_index = models.SearchIndex(**data)
-    facets.append(custom_search_index)
-    print(facets)
     return facets
 
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -65,13 +65,18 @@ def get_aggregated_stats(db: Session) -> schemas.AggregationSummary:
 
 def text_search(db: Session, terms: str, limit: int) -> List[models.SearchIndex]:
     searchtext = f"%{terms.lower()}%"
-    return (
+    facets = (
         db.query(models.SearchIndex)
         .filter(models.SearchIndex.value.ilike(searchtext))
         .order_by(models.SearchIndex.count.desc())
         .limit(limit)
         .all()
     )
+    data = {"table": "study", "value": terms.lower(), "field": "principal_investigator_name"}
+    custom_search_index = models.SearchIndex(**data)
+    facets.append(custom_search_index)
+    print(facets)
+    return facets
 
 
 def get_environmental_sankey(

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -20,11 +20,25 @@ def ping():
     return True
 
 
+def update_nmdc_functions():
+    """Update NMDC custom functions for both databases."""
+    logger = get_logger(__name__)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.setLevel(logging.INFO)
+    for db_info in [(database.SessionLocal, "active"), (database.SessionLocalIngest, "ingest")]:
+        db_to_update, db_type = db_info
+        with db_to_update() as db:
+            logger.info(f"Updating NMDC functions for the {db_type} database.")
+            db.execute(database.update_nmdc_functions_sql)
+            db.commit()
+
+
 def migrate(ingest_db: bool = False):
     """Update the database to the latest HEAD.
 
     This function will also create the schema if necessary.
     """
+    update_nmdc_functions()
     if ingest_db:
         database_uri = settings.ingest_database_uri
         session_maker = database.SessionLocalIngest

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -75,6 +75,7 @@ class Operation(Enum):
     less = "<"
     less_equal = "<="
     not_equal = "!="
+    like = "like"
 
 
 # These dicts serve to provide special logic when filter conditions
@@ -179,6 +180,8 @@ class SimpleConditionSchema(BaseConditionSchema):
                 return column <= self.value
             elif self.op == Operation.not_equal:
                 return column != self.value
+            elif self.op == Operation.like:
+                return column.ilike(f"%{self.value}%")
         if hasattr(model, "annotations"):
             json_field = model.annotations  # type: ignore
         else:

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -186,6 +186,10 @@ class SimpleConditionSchema(BaseConditionSchema):
             json_field = model.annotations  # type: ignore
         else:
             raise InvalidAttributeException(self.table.value, self.field)
+        if self.op == Operation.like:
+            return func.nmdc_compare(
+                json_field[self.field].astext, self.op.value, f"%{self.value}%"
+            )
         return func.nmdc_compare(json_field[self.field].astext, self.op.value, self.value)
 
 

--- a/web/src/components/FacetedSearch.vue
+++ b/web/src/components/FacetedSearch.vue
@@ -85,6 +85,18 @@ export default Vue.extend({
     hasActiveConditions(category: string): boolean {
       return this.conditions.some((cond) => `${cond.table}_${cond.field}` === category);
     },
+    tableName(table: string): string {
+      if (table === 'study') {
+        return 'Study';
+      }
+      if (table === 'biosample') {
+        return 'Biosample';
+      }
+      if (table === 'omics_processing') {
+        return 'Omics Processing';
+      }
+      return '';
+    },
   },
 });
 </script>
@@ -176,6 +188,7 @@ export default Vue.extend({
           </v-list-item-title>
           <v-list-item-subtitle>
             {{ fieldDisplayName(condition.field) }}
+            <span v-if="condition.op === 'like'">({{ tableName(condition.table) }})</span>
           </v-list-item-subtitle>
         </v-list-item-content>
         <v-list-item-icon class="align-self-center">

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -247,7 +247,7 @@ export interface EnvironmentSankeyResponse {
   [index: number]: EnvironmentSankeyEntity;
 }
 
-export type opType = 'between' | '<' | '<=' | '>' | '>=' | '==' | '!=' | 'has';
+export type opType = 'between' | '<' | '<=' | '>' | '>=' | '==' | '!=' | 'has' | 'like';
 export const opMap: Record<opType, string> = {
   between: 'between',
   has: 'has',
@@ -257,6 +257,7 @@ export const opMap: Record<opType, string> = {
   '>=': 'gte',
   '!=': 'not',
   '==': 'is',
+  like: 'like',
 };
 
 // See https://github.com/microbiomedata/nmdc-server/pull/403 for documentation


### PR DESCRIPTION
Fix #965 
Fix #1071 

This PR adds some additional query options when using the text search bar, as well as establishes a framework for including more in the future. For this iteration, we have added plaintext searching for:

`title` of `Study`
`description` of `Study`
`name` of `Study`

In order to accomplish this, our DSL query language has been updated to support using the SQL `ilike` function. This was a straightforward change for properties represented directly as columns on the `study` table, but required some additional work for values stored in the `annotation` column (JSON).

There is also a new CLI command, `nmdc-server create-or-replace-nmdc-functions` which updates the custom NMDC functions used for ingest and search at a whim, rather than relying on the SQLAlchemy event system. See linked issue #1071 for some additional details.

Updating these functions is also folded into the `nmdc-server migrate` command, which is invoked in our prestart script. This should populate the needed function when the app spins up.