### PR TITLE
Fix inaccuracy in API endpoint name

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -291,7 +291,7 @@ async def get_study_image(study_id: str, db: Session = Depends(get_db)):
     "/omics_processing/search",
     response_model=query.OmicsProcessingSearchResponse,
     tags=["omics_processing"],
-    name="Search for studies",
+    name="Search for omics processings",
     description="Faceted search of omics_processing data.",
 )
 async def search_omics_processing(


### PR DESCRIPTION
I put "processings" in an attempt to pluralize the word "processing" (which I think is being used as a noun in this context).