### PR TITLE
Aggregate omics counts for gene function search

### DIFF
--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -631,7 +631,9 @@ class StudyQuerySchema(BaseQuerySchema):
         # Here we only insert filter conditions that are actually relevant for
         # this aggregation.  This reduces the complexity of subquery greatly.
         op_filter_conditions = [
-            c for c in self.conditions if c.table.value in {"omics_processing", "biosample"}
+            c
+            for c in self.conditions
+            if c.table.value in {"omics_processing", "biosample", "gene_function"}
         ]
         op_summary_subquery = self._count_omics_processing_summary(
             db, op_filter_conditions


### PR DESCRIPTION
Fix #1072 

Each filter in our queries keeps track of what table it is applied to. For example, a filter on "PI Name" would apply to the `study` table. Our backend search layer often makes use of this information to build appropriate SQL queries.

One spot in particular is during the study search. Part of creating this query is updating the omics processing counts per study. This is what appears in the omics counts chips on the data portal in the study search results section.

Before this change, the omics processing counts were only updated if a search contained a filter on the `omics_processing` or `biosample` tables. A filter on the KEGG terms uses the `gene_function` table, so the counts weren't being updated based on that filter.

This change makes sure that filters on KEGG terms are included in the query that generates the omics processing counts per study.

The following screenshot demonstrates a search in my local environment (subset of production data) for a KEGG term without the change:
![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/bc6c7b7e-f0c3-4f6f-b7eb-93fa845b26cb)


And here is a screenshot with the change:
![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/5dc13ee2-0e35-4a41-bbfa-3af7e9ec2857)
