### PR TITLE
Filter on biosamples before studies

### DIFF
--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -9,7 +9,7 @@ from itertools import groupby
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, Field, PositiveInt
-from sqlalchemy import ARRAY, Column, and_, cast, desc, func, inspect, or_
+from sqlalchemy import ARRAY, Column, and_, cast, desc, exists, func, inspect, or_
 from sqlalchemy.orm import Query, Session, aliased, with_expression
 from sqlalchemy.orm.util import AliasedClass
 from sqlalchemy.sql.expression import ClauseElement, intersect, union
@@ -652,6 +652,13 @@ class StudyQuerySchema(BaseQuerySchema):
                 op_summary_subquery.c.omics_processing_summary,
             ),
         )
+
+    def query(self, db: Session):
+        study_query = super().query(db)
+        sample_query = BiosampleQuerySchema(conditions=self.conditions).query(db)
+        studies_from_sample_query = sample_query.with_entities(models.Biosample.study_id).distinct()
+        study_query = study_query.where(self.table.model.id.in_(studies_from_sample_query))
+        return study_query
 
     def execute(self, db: Session) -> Query:
         sample_subquery = BiosampleQuerySchema(conditions=self.conditions).query(db).subquery()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -99,6 +99,30 @@ def test_basic_query(db: Session, table):
     assert tests[table][0].id in {r.id for r in q.all()}
 
 
+def test_study_search_biosample_conditions(db: Session):
+    _ = fakes.BiosampleFactory(longitude=10, latitude=0)
+    _ = fakes.BiosampleFactory(longitude=0, latitude=50)
+    sample_3 = fakes.BiosampleFactory(longitude=10, latitude=50)
+    db.commit()
+
+    condition_lat_range = {
+        "table": "biosample",
+        "field": "latitude",
+        "op": "between",
+        "value": [49, 51],
+    }
+    condition_long_range = {
+        "table": "biosample",
+        "field": "longitude",
+        "op": "between",
+        "value": [9, 11],
+    }
+    q = query.StudyQuerySchema(conditions=[condition_lat_range, condition_long_range])
+    results = {s.id for s in q.execute(db)}
+    assert len(results) == 1
+    assert sample_3.study_id in results
+
+
 @pytest.mark.parametrize(
     "op,value,expected",
     [

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -100,8 +100,9 @@ def test_basic_query(db: Session, table):
 
 
 def test_study_search_biosample_conditions(db: Session):
-    _ = fakes.BiosampleFactory(longitude=10, latitude=0)
-    _ = fakes.BiosampleFactory(longitude=0, latitude=50)
+    test_study = fakes.StudyFactory()
+    _ = fakes.BiosampleFactory(longitude=10, latitude=0, study=test_study)
+    _ = fakes.BiosampleFactory(longitude=0, latitude=50, study=test_study)
     sample_3 = fakes.BiosampleFactory(longitude=10, latitude=50)
     db.commit()
 


### PR DESCRIPTION
Fix #1085 

The SQL query generated by the `BaseQuerySchema` class has a problem when performing a query for a model with conditions that apply to related models.

In the linked issue, this manifested in incorrect `Study` results when multiple filters were applied to the `Biosample` model.

Now, `Study` search results are "sanity checked" against `Biosample` search results for queries that include filters on `Biosample`.

A new test was added to simulate the query described in the issue that validates this approach.