### PR TITLE
Update ingest CLI to support scheduled ingest

### DIFF
--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -53,6 +53,14 @@ class Settings(BaseSettings):
     # App settings related to UI behavior
     disable_bulk_download: str = ""
 
+    # Rancher information to swap databases after ingest
+    rancher_api_base_url: Optional[str] = None
+    rancher_api_auth_token: Optional[str] = None
+    rancher_project_id: Optional[str] = None
+    rancher_postgres_secret_id: Optional[str] = None
+    rancher_backend_workload_id: Optional[str] = None
+    rancher_worker_workload_id: Optional[str] = None
+
     @property
     def current_db_uri(self) -> str:
         if self.environment == "testing":


### PR DESCRIPTION
Re: https://github.com/microbiomedata/nmdc-server/issues/1079

These changes are in support of having a cron job in Rancher for periodic automated ingests. The idea is that cron job will use the existing `server` Docker image to do an ingest via the existing `nmdc-server` CLI. Typically when we initiate an ingest manually we do so via the API with a `POST /api/jobs/ingest` request. I'm proposing _not_ using the API for the automated ingest because 1) the `/api/jobs/ingest` endpoint requires authentication and that would be challenging without persistent API authentication tokens and 2) we would probably need to add an additional endpoint to check on the job status after is has been finished in order to poll for success or failure. 

The changes here move the guts of the `ingest` celery task to a separate plain function (`do_ingest`) that can be called by both the celery task and the CLI to ensure they do the same operations. It also adds a `--swap-rancher-secrets` to the ingest CLI. If used, it will use the Rancher API to do the A/B database swap and redeploy the server and worker workloads. A number of environment variables need to be set in order to use that flag. 