### PR TITLE
Used namespacedSecrets endpoint to get/update rancher secrets in ingest

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -107,7 +107,7 @@ def ingest(verbose, function_limit, skip_annotation, swap_rancher_secrets):
         secret_url = (
             f"{settings.rancher_api_base_url}"
             f"/project/{settings.rancher_project_id}"
-            f"/secrets/{settings.rancher_postgres_secret_id}"
+            f"/namespacedSecrets/{settings.rancher_postgres_secret_id}"
         )
         response = requests.get(secret_url, headers=headers)
         response.raise_for_status()


### PR DESCRIPTION
Just a quick revision to #1103. I had been testing that locally against the "development" project (which we don't really use anymore). This updates the ingest CLI to use the correct endpoint for the "production" project where we used namespaced secrets. 