### PR TITLE
Ensure clean git working directory to get correct version number

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
+.mypy_cache
 .tox
 .coverage
 .cache
+.venv
+.vscode
 env
 *.egg-info
 node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM tiangolo/uvicorn-gunicorn:python3.9-2023-06-05
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
+RUN rm /app/main.py
 
 RUN apt-get update && apt-get install -y postgresql-client
 
 RUN pip install -U pip setuptools wheel
-COPY pyproject.toml /app/
-RUN --mount=source=.git,target=/app/.git,type=bind pip install -e /app
+COPY . /app/
+RUN pip install -e /app
 
-COPY nmdc_server /app/nmdc_server
 COPY .env.production /app/.env
-COPY prestart.sh /app/prestart.sh
 WORKDIR /app/
 ENV MODULE_NAME nmdc_server.asgi
 ENV PORT 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "max_wal_size=2GB"
 
   worker:
-    image: ghcr.io/microbiomedata/nmdc-server/worker:latest
+    image: ghcr.io/microbiomedata/nmdc-server/worker:main
     depends_on:
       - redis
       - db
@@ -34,7 +34,7 @@ services:
       dockerfile: Dockerfile.worker
 
   backend:
-    image: ghcr.io/microbiomedata/nmdc-server/server:latest
+    image: ghcr.io/microbiomedata/nmdc-server/server:main
     depends_on:
       - db
       - redis
@@ -53,7 +53,7 @@ services:
       - "8000:8000"
 
   web:
-    image: ghcr.io/microbiomedata/nmdc-server/client:latest
+    image: ghcr.io/microbiomedata/nmdc-server/client:main
     depends_on:
       - backend
       - data


### PR DESCRIPTION
This is a follow-up to #1105. `setuptools-scm` uses the git working directory state as part of its [default versioning scheme](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme). So to get the right version number we need to ensure that the working directory is clean before `pip install`-ing the `nmdc-server` package. Two things were making it unclean:

* The base image (`tiangolo/uvicorn-gunicorn:python3.9-2023-06-05`) includes an `/app/main.py` file. It's not used in any way; it just had some placeholder hello world code. That file needed to be removed.
* I needed to copy _all_ the checked-in files into the `/app` folder. Since that includes the `.git` directory itself it no longer needs to be mounted. Unfortunately I think this will make the image size larger. I don't know if that will be a problem in practice or not. If it does we might need to explore ways of customizing `seuptools-scm`'s behavior.

Also as a follow-on to #1106 I updated the image tags in `docker-compose.yml`