### PR TITLE
Implement `/api/version` API endpoint that returns app version

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -9,13 +9,13 @@ from starlette.requests import Request
 from starlette.responses import RedirectResponse, StreamingResponse
 
 from nmdc_server import (
-    __version__,
     crud,
     jobs,
     models,
     query,
     schemas,
     schemas_submission,
+    __version__,
 )
 from nmdc_server.auth import (
     admin_required,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -23,6 +23,7 @@ from nmdc_server.database import get_db
 from nmdc_server.ingest.envo import nested_envo_trees
 from nmdc_server.models import IngestLock, SubmissionMetadata, User
 from nmdc_server.pagination import Pagination
+from nmdc_server import __version__
 
 router = APIRouter()
 
@@ -32,6 +33,12 @@ router = APIRouter()
 async def get_settings() -> Dict[str, Any]:
     settings = Settings()
     return {"disable_bulk_download": settings.disable_bulk_download.upper() == "YES"}
+
+
+# get application version number
+@router.get("/version", name="Get application version identifier")
+async def get_version() -> Dict[str, Any]:
+    return {"nmdc-server": __version__}
 
 
 # get the current user information
@@ -639,3 +646,5 @@ async def update_user(
     if body.id != id:
         raise HTTPException(status_code=400, detail="Invalid id")
     return crud.update_user(db, body)
+
+@router.get("/version")

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -646,5 +646,3 @@ async def update_user(
     if body.id != id:
         raise HTTPException(status_code=400, detail="Invalid id")
     return crud.update_user(db, body)
-
-@router.get("/version")

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -8,15 +8,7 @@ from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, StreamingResponse
 
-from nmdc_server import (
-    crud,
-    jobs,
-    models,
-    query,
-    schemas,
-    schemas_submission,
-    __version__,
-)
+from nmdc_server import crud, jobs, models, query, schemas, schemas_submission, __version__
 from nmdc_server.auth import (
     admin_required,
     get_current_user,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -8,7 +8,15 @@ from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, StreamingResponse
 
-from nmdc_server import crud, jobs, models, query, schemas, schemas_submission
+from nmdc_server import (
+    __version__,
+    crud,
+    jobs,
+    models,
+    query,
+    schemas,
+    schemas_submission,
+)
 from nmdc_server.auth import (
     admin_required,
     get_current_user,
@@ -23,7 +31,6 @@ from nmdc_server.database import get_db
 from nmdc_server.ingest.envo import nested_envo_trees
 from nmdc_server.models import IngestLock, SubmissionMetadata, User
 from nmdc_server.pagination import Pagination
-from nmdc_server import __version__
 
 router = APIRouter()
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.responses import RedirectResponse, StreamingResponse
 
-from nmdc_server import crud, jobs, models, query, schemas, schemas_submission, __version__
+from nmdc_server import __version__, crud, jobs, models, query, schemas, schemas_submission
 from nmdc_server.auth import (
     admin_required,
     get_current_user,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -33,7 +33,7 @@ def test_get_settings(client: TestClient):
 def test_get_version(client: TestClient):
     resp = client.get("/api/version")
     assert resp.status_code == 200
-    assert resp.json()["version"] == nmdc_server.__version__
+    assert resp.json()["nmdc-server"] == nmdc_server.__version__
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -30,6 +30,12 @@ def test_get_settings(client: TestClient):
     assert_status(resp)
 
 
+def test_get_version(client: TestClient):
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    assert resp.json()["version"] == nmdc_server.__version__
+
+
 @pytest.mark.parametrize(
     "condition,expected",
     [


### PR DESCRIPTION
### Summary

- Implemented an API endpoint (`/api/version`) that returns the application version number
- Added a test targeting that endpoint
- Note: Most of the commits in this branch are related to linting

Screenshot showing that the API returns the same version number as Swagger UI shows:

![image](https://github.com/microbiomedata/nmdc-server/assets/134325062/b4a4fcca-1eb3-4cea-b3b1-cbc6059cb233)
