### PR TITLE
Specify join condition for submissions and users

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -527,7 +527,9 @@ async def list_submissions(
     try:
         await admin_required(user)
     except HTTPException:
-        query = query.join(User).filter(User.orcid == user.orcid)
+        query = query.join(User, SubmissionMetadata.author_id == User.id).filter(
+            User.orcid == user.orcid
+        )
     return pagination.response(query)
 
 

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -85,7 +85,7 @@ async def login_required(
 
 
 async def admin_required(user: models.User = Depends(login_required)) -> models.User:
-    if settings.environment != "production":
+    if settings.environment != "production" and settings.environment != "testing":
         return user
     if user.is_admin:
         return user

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -9,9 +9,22 @@ from nmdc_server.auth import Token
 from nmdc_server.schemas_submission import SubmissionMetadataSchema
 
 
-def test_try_edit_locked_submission(db: Session, client: TestClient, token: Token):
+def test_list_submissions(db: Session, client: TestClient, token: Token, logged_in_user):
+    submission = fakes.MetadataSubmissionFactory(
+        author=logged_in_user, author_orcid=logged_in_user.orcid
+    )
+    db.commit()
+
+    response = client.request(method="GET", url="/api/metadata_submission")
+    assert response.status_code == 200
+    assert response.json()["results"][0]["id"] == str(submission.id)
+
+
+def test_try_edit_locked_submission(db: Session, client: TestClient, token: Token, logged_in_user):
     # Locked by a random user at utcnow by default
     submission = fakes.MetadataSubmissionFactory(
+        author=logged_in_user,
+        author_orcid=logged_in_user.orcid,
         locked_by=fakes.UserFactory(),
         lock_updated=datetime.utcnow(),
     )
@@ -26,10 +39,15 @@ def test_try_edit_locked_submission(db: Session, client: TestClient, token: Toke
     assert response.status_code == 400
 
 
-def test_try_edit_expired_locked_submission(db: Session, client: TestClient, token: Token):
+def test_try_edit_expired_locked_submission(
+    db: Session, client: TestClient, token: Token, logged_in_user
+):
     # initialize test submission with expired lock
     submission = fakes.MetadataSubmissionFactory(
-        locked_by=fakes.UserFactory(), lock_updated=datetime.utcnow() - timedelta(hours=1)
+        author=logged_in_user,
+        author_orcid=logged_in_user.orcid,
+        locked_by=fakes.UserFactory(),
+        lock_updated=datetime.utcnow() - timedelta(hours=1),
     )
     payload = SubmissionMetadataSchema(**submission.__dict__).json()
     db.commit()
@@ -44,6 +62,8 @@ def test_try_edit_locked_by_current_user_submission(
     db: Session, client: TestClient, token: Token, logged_in_user
 ):
     submission = fakes.MetadataSubmissionFactory(
+        author=logged_in_user,
+        author_orcid=logged_in_user.orcid,
         locked_by=logged_in_user,
         lock_updated=datetime.utcnow(),
     )


### PR DESCRIPTION
Fix #1113 

Since microbiomedata/nmdc-server#1098 introduced new FK relationship (`locked_by`) between the `submission_metadata` and `user_logins` tables, a join condition needed to be specified for SQLAlchemy, when joining those tables. This was not done in the submissions list endpoint, which broke it in development.

This change adds the join condition to `api.py::list_submissions` function, and adds a test. It also alters how `auth.py::admin_required` works. The `user.is_admin` check is no longer skipped in the `"testing"` environment. Existing tests were also updated to accommodate this change.