### PR TITLE
Specify join for envo term when faceting omics_processing

### DIFF
--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -218,15 +218,21 @@ class BiosampleFilter(BaseFilter):
         return self.join_omics_processing(query)
 
 
-class EnvBroadScaleFilter(BiosampleFilter):
+class EnvoTermFilter(BiosampleFilter):
+
+    def join_omics_processing(self, query: Query) -> Query:
+        join_with_biosample_query = super().join_omics_processing(query)
+        return self.join_envo(self.table, join_with_biosample_query)
+
+class EnvBroadScaleFilter(EnvoTermFilter):
     table = Table.env_broad_scale
 
 
-class EnvLocalScaleFilter(BiosampleFilter):
+class EnvLocalScaleFilter(EnvoTermFilter):
     table = Table.env_local_scale
 
 
-class EnvMediumFilter(BiosampleFilter):
+class EnvMediumFilter(EnvoTermFilter):
     table = Table.env_medium
 
 

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -219,10 +219,10 @@ class BiosampleFilter(BaseFilter):
 
 
 class EnvoTermFilter(BiosampleFilter):
-
     def join_omics_processing(self, query: Query) -> Query:
         join_with_biosample_query = super().join_omics_processing(query)
         return self.join_envo(self.table, join_with_biosample_query)
+
 
 class EnvBroadScaleFilter(EnvoTermFilter):
     table = Table.env_broad_scale

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -198,7 +198,10 @@ class BiosampleFilter(BaseFilter):
     table = Table.biosample
 
     def join_omics_processing(self, query: Query) -> Query:
-        return query.join(models.biosample_input_association).join(models.Biosample)
+        return self.join_self(
+            query.join(models.biosample_input_association).join(models.Biosample),
+            Table.biosample,
+        )
 
     def join_biosample(self, query: Query) -> Query:
         return self.join_self(query, Table.biosample)
@@ -218,21 +221,15 @@ class BiosampleFilter(BaseFilter):
         return self.join_omics_processing(query)
 
 
-class EnvoTermFilter(BiosampleFilter):
-    def join_omics_processing(self, query: Query) -> Query:
-        join_with_biosample_query = super().join_omics_processing(query)
-        return self.join_envo(self.table, join_with_biosample_query)
-
-
-class EnvBroadScaleFilter(EnvoTermFilter):
+class EnvBroadScaleFilter(BiosampleFilter):
     table = Table.env_broad_scale
 
 
-class EnvLocalScaleFilter(EnvoTermFilter):
+class EnvLocalScaleFilter(BiosampleFilter):
     table = Table.env_local_scale
 
 
-class EnvMediumFilter(EnvoTermFilter):
+class EnvMediumFilter(BiosampleFilter):
     table = Table.env_medium
 
 


### PR DESCRIPTION
Fix #1115 

This PR changes how subclasses of `BiosampleFilter` join to the `omics_procesing` table.

Previously, they didn't specify at all, so when a filter on an envo term was applied to a search on `omics_processing` records, there was a Cartesian product and no filtering was done.

Now, those subclasses that represent `<EnvoTerm>Filter`s use the `join_envo` function of the `BaseFilter` class to perform the join and correctly filter omics processing results.