### PR TITLE
Reformat with black v24

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # .git-blame-ignore-revs
 # removed blank lines before code blocks
 8d6cb9d723f925a89bc79f5492f9166d819e5fe6
+# Reformat files with black v24
+b96c270d51c7f4a5aba10dac30d203be502daceb

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -18,6 +18,7 @@ between all tables represented in `table.py`.  In practice, there is a lot of
 duplicated logic that is shared in subclasses in this module.  Also, many
 combinations of tables are never used and are thus unimplemented.
 """
+
 from typing import TYPE_CHECKING, Iterable, List, Type
 
 from sqlalchemy import func, or_

--- a/nmdc_server/ingest/pipeline.py
+++ b/nmdc_server/ingest/pipeline.py
@@ -17,8 +17,7 @@ ko_regex = re.compile(r"^KEGG\.ORTHOLOGY")
 
 
 class LoadObject(Protocol):
-    def __call__(self, db: Session, obj: Dict[str, Any], **kwargs: Any) -> LoadObjectReturn:
-        ...
+    def __call__(self, db: Session, obj: Dict[str, Any], **kwargs: Any) -> LoadObjectReturn: ...
 
 
 # Load metagenome annotation as well as the gene function annotations produced.

--- a/nmdc_server/migrations/versions/0a3edcd64e1f_add_study_image.py
+++ b/nmdc_server/migrations/versions/0a3edcd64e1f_add_study_image.py
@@ -5,6 +5,7 @@ Revises: 60b8a4b0c60e
 Create Date: 2023-03-31 19:37:14.137698
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/0f87ba7add08_lock_submissions.py
+++ b/nmdc_server/migrations/versions/0f87ba7add08_lock_submissions.py
@@ -5,6 +5,7 @@ Revises: de3d2eaa2a59
 Create Date: 2023-11-28 21:44:38.913030
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/11a7decdcc60_massive_identifiers.py
+++ b/nmdc_server/migrations/versions/11a7decdcc60_massive_identifiers.py
@@ -5,6 +5,7 @@ Revises: b96ecfffa792
 Create Date: 2023-03-20 19:54:08.406526
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/1de891717fc0_multivalued_dois.py
+++ b/nmdc_server/migrations/versions/1de891717fc0_multivalued_dois.py
@@ -5,6 +5,7 @@ Revises: dad555bb9212
 Create Date: 2023-08-23 19:22:15.660679
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/23e0702d2321_multi_tab_metadata_submission_format.py
+++ b/nmdc_server/migrations/versions/23e0702d2321_multi_tab_metadata_submission_format.py
@@ -5,6 +5,7 @@ Revises: ae7a3eba08c5
 Create Date: 2023-01-18 00:25:23.881413
 
 """
+
 import collections
 import json
 import pathlib

--- a/nmdc_server/migrations/versions/60b8a4b0c60e_read_qc_nullables.py
+++ b/nmdc_server/migrations/versions/60b8a4b0c60e_read_qc_nullables.py
@@ -5,6 +5,7 @@ Revises: b51ae399d49f
 Create Date: 2023-03-28 20:38:56.658391
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/780ab86a4f27_squashed_initial.py
+++ b/nmdc_server/migrations/versions/780ab86a4f27_squashed_initial.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2022-06-08 19:49:41.862184
 
 """
+
 # flake8: noqa
 from typing import Optional
 

--- a/nmdc_server/migrations/versions/7b9f5a789198_submission_schema_v1_0_0.py
+++ b/nmdc_server/migrations/versions/7b9f5a789198_submission_schema_v1_0_0.py
@@ -15,6 +15,7 @@ Revises: 7ba2cb5f236e
 Create Date: 2023-03-21 23:29:41.957897
 
 """
+
 from typing import Optional
 from uuid import uuid4
 

--- a/nmdc_server/migrations/versions/7ba2cb5f236e_remove_gene_function_tables.py
+++ b/nmdc_server/migrations/versions/7ba2cb5f236e_remove_gene_function_tables.py
@@ -5,6 +5,7 @@ Revises: 11a7decdcc60
 Create Date: 2023-03-20 22:10:29.149713
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/86f42a05252b_ck_doi_format.py
+++ b/nmdc_server/migrations/versions/86f42a05252b_ck_doi_format.py
@@ -5,6 +5,7 @@ Revises: ffaec255fe68
 Create Date: 2022-10-27 16:44:51.540940
 
 """
+
 from typing import Optional
 
 from alembic import op

--- a/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
+++ b/nmdc_server/migrations/versions/9bbb32f36d19_context_address_form.py
@@ -5,6 +5,7 @@ Revises: 23e0702d2321
 Create Date: 2023-02-02 19:54:44.340586
 
 """
+
 from datetime import datetime
 from typing import List, Optional
 from uuid import uuid4

--- a/nmdc_server/migrations/versions/ae7a3eba08c5_schema_v7.py
+++ b/nmdc_server/migrations/versions/ae7a3eba08c5_schema_v7.py
@@ -5,6 +5,7 @@ Revises: 86f42a05252b
 Create Date: 2022-10-20 19:15:19.741270
 
 """
+
 from typing import Optional
 
 from alembic import op

--- a/nmdc_server/migrations/versions/af8b2e3c91b2_biosample_omics_association.py
+++ b/nmdc_server/migrations/versions/af8b2e3c91b2_biosample_omics_association.py
@@ -5,6 +5,7 @@ Revises: dcc0a41b60af
 Create Date: 2023-07-10 18:18:46.785564
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/b51ae399d49f_add_gold_identifiers.py
+++ b/nmdc_server/migrations/versions/b51ae399d49f_add_gold_identifiers.py
@@ -5,6 +5,7 @@ Revises: 7b9f5a789198
 Create Date: 2023-03-27 15:38:36.490336
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/b8f3bcb681a1_separate_emsl_ids.py
+++ b/nmdc_server/migrations/versions/b8f3bcb681a1_separate_emsl_ids.py
@@ -5,6 +5,7 @@ Revises: 0a3edcd64e1f
 Create Date: 2023-04-04 20:30:37.491970
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/b96ecfffa792_remove_irb_information.py
+++ b/nmdc_server/migrations/versions/b96ecfffa792_remove_irb_information.py
@@ -5,6 +5,7 @@ Revises: 9bbb32f36d19
 Create Date: 2023-03-01 19:54:23.116184
 
 """
+
 from typing import Optional
 from uuid import uuid4
 

--- a/nmdc_server/migrations/versions/dad555bb9212_submission_schema_v7_7_2.py
+++ b/nmdc_server/migrations/versions/dad555bb9212_submission_schema_v7_7_2.py
@@ -8,6 +8,7 @@ Revises: af8b2e3c91b2
 Create Date: 2023-07-14 21:12:10.113468
 
 """
+
 from typing import Optional
 from uuid import uuid4
 

--- a/nmdc_server/migrations/versions/dcc0a41b60af_optional_file_size.py
+++ b/nmdc_server/migrations/versions/dcc0a41b60af_optional_file_size.py
@@ -5,6 +5,7 @@ Revises: b8f3bcb681a1
 Create Date: 2023-07-12 21:28:22.917163
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/de3d2eaa2a59_nullable_pi.py
+++ b/nmdc_server/migrations/versions/de3d2eaa2a59_nullable_pi.py
@@ -5,6 +5,7 @@ Revises: 1de891717fc0
 Create Date: 2023-10-06 19:32:42.311755
 
 """
+
 from typing import Optional
 
 from alembic import op

--- a/nmdc_server/migrations/versions/ded8702fcc7a_submission_roles.py
+++ b/nmdc_server/migrations/versions/ded8702fcc7a_submission_roles.py
@@ -5,6 +5,7 @@ Revises: 0f87ba7add08
 Create Date: 2024-01-10 22:34:09.294181
 
 """
+
 import enum
 from typing import Optional
 from uuid import uuid4

--- a/nmdc_server/migrations/versions/eb9d9e3f3fbc_user_model.py
+++ b/nmdc_server/migrations/versions/eb9d9e3f3fbc_user_model.py
@@ -5,6 +5,7 @@ Revises: 780ab86a4f27
 Create Date: 2022-06-09 16:03:35.013157
 
 """
+
 from typing import Optional
 
 import sqlalchemy as sa

--- a/nmdc_server/migrations/versions/ffaec255fe68_swap_columns.py
+++ b/nmdc_server/migrations/versions/ffaec255fe68_swap_columns.py
@@ -5,6 +5,7 @@ Revises: eb9d9e3f3fbc
 Create Date: 2022-08-25 02:13:12.732971
 
 """
+
 from typing import Optional
 from uuid import uuid4
 

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -2,6 +2,7 @@
 This module contains schemas that turn the query DSL into sqlalchemy query objects
 for both search and faceting aggregations.
 """
+
 import re
 from datetime import datetime
 from enum import Enum

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -4,6 +4,7 @@ This module contains pydantic schemas for data serialization.
 The schemas defined here are for simple CRUD methods on domain objects.
 Additional schemas exist in other modules for more specialized use cases.
 """
+
 from __future__ import annotations
 
 from datetime import date, datetime

--- a/nmdc_server/table.py
+++ b/nmdc_server/table.py
@@ -2,6 +2,7 @@
 This module contains enums that map from serialized table representations to
 actual database models (or aliased representations).
 """
+
 from enum import Enum
 from typing import Dict, Union
 


### PR DESCRIPTION
It looks like the `black` check is failing because it's picking up a new major version (24.1.1). This PR just reformats according to that version and adds the commit to the ignored revisions. 