### PR TITLE
Update nmdc-schema for client app

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
     "linkify-it": "^4.0.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.2",
-    "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v6.0.4",
+    "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v10.0.0",
     "nmdc-submission-schema": "https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-10.0.0.tar.gz",
     "popper.js": "1.16.1",
     "protobufjs": "^6.11.3",

--- a/web/src/components/MenuContent.vue
+++ b/web/src/components/MenuContent.vue
@@ -2,7 +2,7 @@
 import {
   defineComponent, PropType, onBeforeUnmount, computed,
 } from '@vue/composition-api';
-import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
+import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 
 import { fieldDisplayName } from '@/util';
 import { getField, types } from '@/encoding';

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash';
 import axios from 'axios';
 import { setupCache } from 'axios-cache-adapter';
-import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
+import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 
 const cache = setupCache({
   key: (req) => req.url + JSON.stringify(req.params) + JSON.stringify(req.data),

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from '@vue/composition-api';
-import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
+import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 import Definitions from '@/definitions';
 import { studyForm, studyFormValid } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -6,7 +6,7 @@ import {
   watch,
   nextTick,
 } from '@vue/composition-api';
-import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
+import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 import Definitions from '@/definitions';
 import {
   contextForm,

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -7,7 +7,7 @@ import {
   ref,
   watch,
 } from '@vue/composition-api';
-import NmdcSchema from 'nmdc-schema/jsonschema/nmdc.schema.json';
+import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 import { addressForm, addressFormValid, BiosafetyLevels } from '../store';
 import { addressToString } from '../store/api';
 import SubmissionContextShippingSummary from './SubmissionContextShippingSummary.vue';

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7562,9 +7562,9 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-"nmdc-schema@https://github.com/microbiomedata/nmdc-schema#v6.0.4":
+"nmdc-schema@https://github.com/microbiomedata/nmdc-schema#v10.0.0":
   version "0.0.0"
-  resolved "https://github.com/microbiomedata/nmdc-schema#e9b7da691079989a7e72ecc350f59058c6787557"
+  resolved "https://github.com/microbiomedata/nmdc-schema#9211a67e6254c025e8ac811f500bcaefda75aabb"
 
 "nmdc-submission-schema@https://files.pythonhosted.org/packages/source/n/nmdc-submission-schema/nmdc_submission_schema-10.0.0.tar.gz":
   version "0.0.0"


### PR DESCRIPTION
Fix #1125 

Big jump 6.0.4 -> 10.0.0

We use this for facet descriptions in the search sidebar, and some enums and descriptions in the submission portal. 

The structure of the package directory changed, so the import statements were updated to match.