### PR TITLE
Fix how Rancher workloads are redeployed in GitHub workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,6 @@ env:
   # Used to determine if we add the special `prod` Docker image tag
   IS_PROD_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
 
-  # Used when sending redeploy action requests to Rancher
-  RANCHER_NAMESPACE: ${{ startsWith(github.ref, 'refs/tags/v') && 'nmdc' || 'nmdc-dev' }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -65,17 +62,30 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
+    if: ${{ env.IS_ORIGINAL_REPO }}
+
+    env:
+      WORKLOAD_API_BASE: https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads
 
     strategy:
       matrix:
         deployment: [ backend, frontend, worker ]
 
     steps:
-      - name: Redeploy ${{ env.RANCHER_NAMESPACE }}:${{ env.IS_PROD_RELEASE && '' || 'portal-' }}${{ matrix.deployment }}
-        if: ${{ env.IS_ORIGINAL_REPO }}
+      - name: Redeploy nmdc-dev:portal-${{ matrix.deployment }}
+        if: ${{ !env.IS_PROD_RELEASE }}
         uses: fjogeleit/http-request-action@v1
         with:
-          url: https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads/deployment:${{ env.RANCHER_NAMESPACE }}:${{ env.IS_PROD_RELEASE && '' || 'portal-' }}${{ matrix.deployment }}?action=redeploy
+          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc-dev:portal-${{ matrix.deployment }}?action=redeploy
+          method: POST
+          username: ${{ secrets.SPIN_USER }}
+          password: ${{ secrets.SPIN_PASSWORD }}
+
+      - name: Redeploy nmdc:${{ matrix.deployment }}
+        if: ${{ env.IS_PROD_RELEASE }}
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc:${{ matrix.deployment }}?action=redeploy
           method: POST
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,3 +89,12 @@ jobs:
           method: POST
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
+
+      - name: Redeploy nmdc-sandbox:${{ matrix.deployment }}
+        if: ${{ env.IS_PROD_RELEASE }}
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc-sandbox:${{ matrix.deployment }}?action=redeploy
+          method: POST
+          username: ${{ secrets.SPIN_USER }}
+          password: ${{ secrets.SPIN_PASSWORD }}


### PR DESCRIPTION
Previously there was logic to try to resolve the differences between workload names in the dev and prod Rancher namespaces (e.g. `portal-backend` on dev and `backend` on prod). This logic was faulty and was a little opaque. These changes remove that logic and split the dev redeploy and prod redeploy into separate steps with appropriate `if` clauses. It's a little more verbose now, but at least it's more clear what it's doing. It also makes it simpler to add an additional step to redeploy the sandbox workloads as part of a production release.

Fixes #1121
Fixes #1122 
