### PR TITLE
Add permission level to study form

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -665,18 +665,8 @@ async def update_submission(
         db.add(pi_owner_role)
 
     contributors = body_dict["metadata_submission"].get("studyForm", {}).get("contributors", [])
-    for contributor in contributors:
-        if contributor["permissionLevel"] and contributor["orcid"]:
-            existing_role = crud.get_submission_role(db, id, contributor["orcid"])
-            permission_level = SubmissionEditorRole(contributor["permissionLevel"]).value
-            if existing_role:
-                if existing_role.role.value != permission_level:
-                    existing_role.role = permission_level
-            else:
-                contributor_role = SubmissionRole(
-                    submission_id=id, user_orcid=contributor["orcid"], role=permission_level
-                )
-                db.add(contributor_role)
+    contributors = [schemas_submission.Contributor(**c) for c in contributors]
+    crud.update_submission_contributor_roles(db, submission, contributors)
 
     crud.update_submission_lock(db, submission.id)
     if body_dict["status"]:

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -642,6 +642,29 @@ async def get_submission(
     raise HTTPException(status_code=403, detail="Must have access.")
 
 
+def can_save_submission(role: models.SubmissionRole, data: dict):
+    """Compare a patch payload with what the user can actually save."""
+    # Owner Fields
+    # all
+    viewer_fields = set()
+    metadata_contributor_fields = set(["sampleData", "metadata_submission"])
+    editor_fields = set(["packageName", "contextForm", "addressForm", "templates", "studyForm", "multiOmicsForm", "sampleData", "metadata_submission"])
+    attempted_patch_fields = set([key for key in data] + [key for key in data.get("metadata_submission", {})])
+    fields_for_permission = {
+        models.SubmissionEditorRole.editor: editor_fields,
+        models.SubmissionEditorRole.metadata_contributor: metadata_contributor_fields,
+        models.SubmissionEditorRole.viewer: viewer_fields,
+    }
+    permission_level = models.SubmissionEditorRole(role.role)
+    if permission_level == models.SubmissionEditorRole.owner:
+        return True
+    elif permission_level ==models.SubmissionEditorRole.viewer:
+        return False
+    else:
+        allowed_fields = fields_for_permission[permission_level]
+        return all([field in allowed_fields for field in attempted_patch_fields])
+
+
 @router.patch(
     "/metadata_submission/{id}",
     tags=["metadata_submission"],
@@ -659,7 +682,8 @@ async def update_submission(
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
 
-    if not (user.is_admin or crud.can_edit_entire_submission(db, id, user.orcid)):
+    current_user_role = crud.get_submission_role(db, id, user.orcid)
+    if not (user.is_admin or (current_user_role and can_save_submission(current_user_role, body_dict))):
         raise HTTPException(403, detail="Must have access.")
 
     has_lock = crud.try_get_submission_lock(db, submission.id, user.id)
@@ -669,23 +693,18 @@ async def update_submission(
             detail="This submission is currently being edited by a different user.",
         )
 
-    submission.metadata_submission = body_dict["metadata_submission"]
-    pi_orcid = body_dict["metadata_submission"].get("studyForm", {}).get("piOrcid", None)
-    if pi_orcid and pi_orcid not in submission.owners:
-        # Create an owner role for the PI if it doesn't exist
-        pi_owner_role = SubmissionRole(
-            submission_id=id, user_orcid=pi_orcid, role=SubmissionEditorRole.owner.value
-        )
-        db.add(pi_owner_role)
+    # Merge the submission metadata dicts
+    submission.metadata_submission = submission.metadata_submission | body_dict["metadata_submission"]
 
-    contributors = body_dict["metadata_submission"].get("studyForm", {}).get("contributors", [])
-    contributors = [schemas_submission.Contributor(**c) for c in contributors]
-    crud.update_submission_contributor_roles(db, submission, contributors)
+    # Update permissions and status iff the user is an "owner"
+    if current_user_role and current_user_role.role == models.SubmissionEditorRole.owner.value:
+        new_permissions = body_dict["metadata_submission"].get("permissions", {})
+        crud.update_submission_contributor_roles(db, submission, new_permissions)
 
+        if body_dict["status"]:
+            submission.status = body_dict["status"]
+        db.commit()
     crud.update_submission_lock(db, submission.id)
-    if body_dict["status"]:
-        submission.status = body_dict["status"]
-    db.commit()
     return submission
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -623,15 +623,15 @@ async def get_submission(
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
     _ = crud.try_get_submission_lock(db, submission.id, user.id)
-    if user.is_admin or crud.can_edit_entire_submission(db, id, user.orcid):
+    if user.is_admin or crud.can_read_submission(db, id, user.orcid):
         permission_level = None
         if user.is_admin or user.orcid in submission.owners:
             permission_level = models.SubmissionEditorRole.owner.value
         elif user.orcid in submission.editors:
             permission_level = models.SubmissionEditorRole.editor.value
-        elif user.orcid in submission.metadata_contributor:
+        elif user.orcid in submission.metadata_contributors:
             permission_level = models.SubmissionEditorRole.metadata_contributor.value
-        elif user.orcid in submission.viewer:
+        elif user.orcid in submission.viewers:
             permission_level = models.SubmissionEditorRole.viewer.value
         return schemas_submission.SubmissionMetadataSchema(
             **submission.__dict__,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -650,7 +650,7 @@ async def get_submission(
 )
 async def update_submission(
     id: str,
-    body: schemas_submission.SubmissionMetadataSchemaCreate,
+    body: schemas_submission.SubmissionMetadataSchemaPatch,
     db: Session = Depends(get_db),
     user: models.User = Depends(login_required),
 ):

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -669,13 +669,15 @@ async def update_submission(
         if contributor["permissionLevel"] and contributor["orcid"]:
             existing_role = crud.get_submission_role(db, id, contributor["orcid"])
             permission_level = SubmissionEditorRole(contributor["permissionLevel"]).value
-            if existing_role and existing_role.role.value != permission_level:
-                existing_role.role = permission_level
+            if existing_role:
+                if existing_role.role.value != permission_level:
+                    existing_role.role = permission_level
             else:
                 contributor_role = SubmissionRole(
                     submission_id=id, user_orcid=contributor["orcid"], role=permission_level
                 )
                 db.add(contributor_role)
+
     crud.update_submission_lock(db, submission.id)
     if body_dict["status"]:
         submission.status = body_dict["status"]

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -715,7 +715,7 @@ async def update_submission(
         if new_permissions is not None:
             crud.update_submission_contributor_roles(db, submission, new_permissions)
 
-        if body_dict["status"]:
+        if body_dict.get("status", None):
             submission.status = body_dict["status"]
         db.commit()
     crud.update_submission_lock(db, submission.id)

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -6,7 +6,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import and_
 from sqlalchemy.orm import Query, Session
 
-from nmdc_server import aggregations, bulk_download_schema, models, query, schemas
+from nmdc_server import aggregations, bulk_download_schema, models, query, schemas, schemas_submission
 from nmdc_server.data_object_filters import get_local_data_url
 from nmdc_server.logger import get_logger
 
@@ -580,3 +580,31 @@ def get_submissions_for_user(db: Session, user: models.User):
         models.SubmissionRole.user_orcid == user.orcid
     )
     return permitted_submissions
+
+
+def get_roles_for_submission(db: Session, submission: models.SubmissionMetadata):
+    return db.query(models.SubmissionRole).filter(models.SubmissionRole.submission_id == submission.id)
+
+
+def update_submission_contributor_roles(db: Session, submission: models.SubmissionMetadata, contributors: List[schemas_submission.Contributor]):
+    submission_roles: List[models.SubmissionRole] = get_roles_for_submission(db, submission).all()
+    contributors_by_orcid = {contributor.orcid: contributor for contributor in contributors}
+
+    for role in submission_roles:
+        if role.user_orcid in contributors_by_orcid:
+            contributor = contributors_by_orcid[role.user_orcid]
+            if not contributor.permissionLevel:
+                db.delete(role)
+            if role.role != contributor.permissionLevel and role.role != models.SubmissionEditorRole.owner:
+                # Don't edit owner roles
+                role.role = models.SubmissionEditorRole(contributor.permissionLevel).value
+        elif role.role != models.SubmissionEditorRole.owner:
+            # Don't delete owner roles
+            db.delete(role)
+
+    new_user_role_needed = set(contributors_by_orcid) - set([role.user_orcid for role in submission_roles])
+    for orcid in new_user_role_needed:
+        role_value = models.SubmissionEditorRole(contributors_by_orcid[orcid].permissionLevel).value
+        new_role = models.SubmissionRole(submission_id=submission.id, user_orcid=orcid, role=role_value)
+        db.add(new_role)
+    db.commit()

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -516,6 +516,19 @@ contributors_edit_roles = [
     models.SubmissionEditorRole.owner,
 ]
 
+def get_submission_role(db: Session, submission_id: str, user_orcid: str) -> Optional[models.SubmissionRole]:
+    role = (
+        db.query(models.SubmissionRole)
+        .filter(
+            and_(
+                models.SubmissionRole.user_orcid == user_orcid,
+                models.SubmissionRole.submission_id == submission_id,
+            )
+        )
+        .first()
+    )
+    return role
+
 
 def can_read_submission(db: Session, submission_id: str, user_orcid: str) -> Optional[bool]:
     role = (

--- a/nmdc_server/ingest/pipeline.py
+++ b/nmdc_server/ingest/pipeline.py
@@ -17,8 +17,7 @@ ko_regex = re.compile(r"^KEGG\.ORTHOLOGY")
 
 
 class LoadObject(Protocol):
-    def __call__(self, db: Session, obj: Dict[str, Any], **kwargs: Any) -> LoadObjectReturn:
-        ...
+    def __call__(self, db: Session, obj: Dict[str, Any], **kwargs: Any) -> LoadObjectReturn: ...
 
 
 # Load metagenome annotation as well as the gene function annotations produced.

--- a/nmdc_server/ingest/pipeline.py
+++ b/nmdc_server/ingest/pipeline.py
@@ -17,7 +17,8 @@ ko_regex = re.compile(r"^KEGG\.ORTHOLOGY")
 
 
 class LoadObject(Protocol):
-    def __call__(self, db: Session, obj: Dict[str, Any], **kwargs: Any) -> LoadObjectReturn: ...
+    def __call__(self, db: Session, obj: Dict[str, Any], **kwargs: Any) -> LoadObjectReturn:
+        ...
 
 
 # Load metagenome annotation as well as the gene function annotations produced.

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -758,7 +758,7 @@ class User(Base):
     is_admin = Column(Boolean, nullable=False, default=False)
 
 
-class SubmissionEditorRole(enum.Enum):
+class SubmissionEditorRole(str, enum.Enum):
     editor = "editor"
     owner = "owner"
     viewer = "viewer"

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -99,6 +99,8 @@ class SubmissionMetadataSchemaCreate(BaseModel):
 class SubmissionMetadataSchemaPatch(BaseModel):
     metadata_submission: PartialMetadataSubmissionRecord
     status: Optional[str]
+    # Map of ORCID iD to permission level
+    permissions: Optional[Dict[str, str]]
 
 class SubmissionMetadataSchema(SubmissionMetadataSchemaCreate):
     id: UUID

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -96,6 +96,8 @@ class SubmissionMetadataSchema(SubmissionMetadataSchemaCreate):
     lock_updated: Optional[datetime]
     locked_by: Optional[schemas.User]
 
+    permission_level: Optional[str]
+
     class Config:
         orm_mode = True
 
@@ -118,7 +120,6 @@ class SubmissionMetadataSchema(SubmissionMetadataSchemaCreate):
                 elif orcid in viewers:
                     contributor["role"] = SubmissionEditorRole.viewer.value
         return metadata_submission
-
 
 
 SubmissionMetadataSchema.update_forward_refs()

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -81,10 +81,24 @@ class MetadataSubmissionRecord(BaseModel):
     sampleData: Dict[str, List[Any]]
 
 
+class PartialMetadataSubmissionRecord(BaseModel):
+    packageName: Optional[str]
+    contextForm: Optional[ContextForm]
+    addressForm: Optional[AddressForm]
+    templates: Optional[List[str]]
+    studyForm: Optional[StudyForm]
+    multiOmicsForm: Optional[MultiOmicsForm]
+    sampleData: Optional[Dict[str, List[Any]]]
+
+
 class SubmissionMetadataSchemaCreate(BaseModel):
     metadata_submission: MetadataSubmissionRecord
     status: Optional[str]
 
+
+class SubmissionMetadataSchemaPatch(BaseModel):
+    metadata_submission: PartialMetadataSubmissionRecord
+    status: Optional[str]
 
 class SubmissionMetadataSchema(SubmissionMetadataSchemaCreate):
     id: UUID

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -11,6 +11,7 @@ class Contributor(BaseModel):
     name: str
     orcid: str
     roles: List[str]
+    permissionLevel: Optional[str]
 
 
 class StudyForm(BaseModel):

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -102,6 +102,7 @@ class SubmissionMetadataSchemaPatch(BaseModel):
     # Map of ORCID iD to permission level
     permissions: Optional[Dict[str, str]]
 
+
 class SubmissionMetadataSchema(SubmissionMetadataSchemaCreate):
     id: UUID
     author_orcid: str

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -173,7 +173,6 @@ def test_create_role_on_patch(db: Session, client: TestClient, token: Token, log
     payload = SubmissionMetadataSchemaPatch(**submission.__dict__)
     db.commit()
 
-    # payload.metadata_submission.studyForm.piOrcid = str(pi_orcid)
     payload.permissions = {str(pi_orcid): SubmissionEditorRole.owner.value}
     response = client.request(
         method="patch",

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -8,7 +8,7 @@ from starlette.testclient import TestClient
 from nmdc_server import fakes
 from nmdc_server.auth import Token
 from nmdc_server.models import SubmissionEditorRole, SubmissionRole
-from nmdc_server.schemas_submission import SubmissionMetadataSchema
+from nmdc_server.schemas_submission import SubmissionMetadataSchema, SubmissionMetadataSchemaPatch
 
 
 def test_list_submissions(db: Session, client: TestClient, token: Token, logged_in_user):
@@ -42,7 +42,7 @@ def test_try_edit_locked_submission(db: Session, client: TestClient, token: Toke
         user_orcid=logged_in_user.orcid,
         role=SubmissionEditorRole.owner,
     )
-    payload = SubmissionMetadataSchema(**submission.__dict__).json()
+    payload = SubmissionMetadataSchema(**submission.__dict__).json(exclude_unset=True)
     db.commit()
 
     response = client.request(
@@ -69,7 +69,7 @@ def test_try_edit_expired_locked_submission(
         user_orcid=logged_in_user.orcid,
         role=SubmissionEditorRole.owner,
     )
-    payload = SubmissionMetadataSchema(**submission.__dict__).json()
+    payload = SubmissionMetadataSchema(**submission.__dict__).json(exclude_unset=True)
     db.commit()
 
     response = client.request(
@@ -93,7 +93,7 @@ def test_try_edit_locked_by_current_user_submission(
         user_orcid=logged_in_user.orcid,
         role=SubmissionEditorRole.owner,
     )
-    payload = SubmissionMetadataSchema(**submission.__dict__).json()
+    payload = SubmissionMetadataSchema(**submission.__dict__).json(exclude_unset=True)
     db.commit()
 
     response = client.request(
@@ -162,7 +162,7 @@ def test_edit_submission_with_roles(
     assert response.status_code == code
 
 
-def test_owner_role_created_for_pi(db: Session, client: TestClient, token: Token, logged_in_user):
+def test_create_role_on_patch(db: Session, client: TestClient, token: Token, logged_in_user):
     pi_orcid = fakes.Faker("pystr")
     submission = fakes.MetadataSubmissionFactory(
         author=logged_in_user, author_orcid=logged_in_user.orcid
@@ -170,10 +170,11 @@ def test_owner_role_created_for_pi(db: Session, client: TestClient, token: Token
     fakes.SubmissionRoleFactory(
         submission=submission, submission_id=submission.id, user_orcid=logged_in_user.orcid
     )
-    payload = SubmissionMetadataSchema(**submission.__dict__)
+    payload = SubmissionMetadataSchemaPatch(**submission.__dict__)
     db.commit()
 
-    payload.metadata_submission.studyForm.piOrcid = str(pi_orcid)
+    # payload.metadata_submission.studyForm.piOrcid = str(pi_orcid)
+    payload.permissions = {str(pi_orcid): SubmissionEditorRole.owner.value}
     response = client.request(
         method="patch",
         url=f"/api/metadata_submission/{submission.id}",
@@ -189,3 +190,106 @@ def test_owner_role_created_for_pi(db: Session, client: TestClient, token: Token
     assert role.user_orcid == str(pi_orcid)
     assert role.submission_id == submission.id
     assert SubmissionEditorRole(role.role) == SubmissionEditorRole.owner
+
+
+@pytest.mark.parametrize("samples_only,code", [(True, 200), (False, 403)])
+def test_piecewise_patch_metadata_contributor(
+    db: Session, client: TestClient, token: Token, logged_in_user, samples_only, code
+):
+    user = fakes.UserFactory()
+    submission = fakes.MetadataSubmissionFactory(author=user, author_orcid=user.orcid)
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=logged_in_user.orcid,
+        role=SubmissionEditorRole.metadata_contributor,
+    )
+    full_payload = SubmissionMetadataSchemaPatch(**submission.__dict__)
+    db.commit()
+
+    if samples_only:
+        request_dict = {
+            "metadata_submission": {"sampleData": full_payload.metadata_submission.sampleData}
+        }
+        request_payload = SubmissionMetadataSchemaPatch(**request_dict).json(exclude_unset=True)
+    else:
+        request_payload = full_payload.json()
+
+    # Logged in user should not be able to submit full payload because it contains non-sample data
+    response = client.request(
+        method="patch",
+        url=f"/api/metadata_submission/{submission.id}",
+        json=json.loads(request_payload),
+    )
+    assert response.status_code == code
+
+
+def test_delete_role_on_patch(db: Session, client: TestClient, token: Token, logged_in_user):
+    user_orcid = fakes.Faker("pystr")
+    pi_orcid = fakes.Faker("pystr")
+    submission = fakes.MetadataSubmissionFactory(
+        author=logged_in_user, author_orcid=logged_in_user.orcid
+    )
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=logged_in_user.orcid,
+    )
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=pi_orcid,
+    )
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=user_orcid,
+        role=SubmissionEditorRole.viewer,
+    )
+    payload = SubmissionMetadataSchemaPatch(**submission.__dict__)
+    db.commit()
+
+    payload.permissions = {}
+
+    response = client.request(
+        method="patch",
+        url=f"/api/metadata_submission/{submission.id}",
+        json=json.loads(payload.json()),
+    )
+    assert response.status_code == 200
+    roles = db.query(SubmissionRole)
+    # logged_in_user's, pi's owner roles should still exist
+    assert roles.count() == 2
+    assert all([role.role == SubmissionEditorRole.owner for role in roles.all()])
+
+
+def test_update_role_on_patch(db: Session, client: TestClient, token: Token, logged_in_user):
+    user_orcid = fakes.Faker("pystr")
+    submission = fakes.MetadataSubmissionFactory(
+        author=logged_in_user, author_orcid=logged_in_user.orcid
+    )
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=logged_in_user.orcid,
+    )
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=user_orcid,
+        role=SubmissionEditorRole.viewer,
+    )
+    payload = SubmissionMetadataSchemaPatch(**submission.__dict__)
+    db.commit()
+
+    payload.permissions = {str(user_orcid): SubmissionEditorRole.editor.value}
+    response = client.request(
+        method="patch",
+        url=f"/api/metadata_submission/{submission.id}",
+        json=json.loads(payload.json()),
+    )
+    assert response.status_code == 200
+    roles = db.query(SubmissionRole).filter(SubmissionRole.user_orcid == str(user_orcid))
+    assert roles.count() == 1
+    role = roles.first()
+    assert role and role.role == SubmissionEditorRole.editor

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+.scripts
 
 # local env files
 .env.local

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -2,7 +2,7 @@
 import { defineComponent, ref } from '@vue/composition-api';
 import Definitions from '@/definitions';
 import {
-  multiOmicsForm, multiOmicsFormValid, multiOmicsAssociations, templateChoiceDisabled, contextForm,
+  multiOmicsForm, multiOmicsFormValid, multiOmicsAssociations, templateChoiceDisabled, contextForm, canEditSubmissionMetadata,
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
@@ -25,6 +25,7 @@ export default defineComponent({
       contextForm,
       /* functions */
       reValidate,
+      canEditSubmissionMetadata,
     };
   },
 });
@@ -44,6 +45,7 @@ export default defineComponent({
       v-model="multiOmicsFormValid"
       class="my-6 mb-10"
       style="max-width: 1000px;"
+      :disabled="!canEditSubmissionMetadata()"
     >
       <div v-if="contextForm.dataGenerated === true">
         <v-text-field

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -1,8 +1,18 @@
 <script lang="ts">
-import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
+import {
+  defineComponent,
+  onMounted,
+  ref,
+  Ref,
+} from '@vue/composition-api';
 import Definitions from '@/definitions';
-import { studyForm, studyFormValid, permissionTitleToDbValueMap, permissionTitle } from '../store';
+import {
+  studyForm,
+  studyFormValid,
+  permissionTitleToDbValueMap,
+  permissionTitle,
+} from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
@@ -26,9 +36,9 @@ export default defineComponent({
       ];
     }
 
-    const permissionLevelChoices: { title: string, value: string }[] = [];
+    const permissionLevelChoices: Ref<{ title: string, value: string }[]> = ref([]);
     Object.keys(permissionTitleToDbValueMap).forEach((title) => {
-      permissionLevelChoices.push({
+      permissionLevelChoices.value.push({
         title,
         value: permissionTitleToDbValueMap[title as permissionTitle],
       });
@@ -36,7 +46,6 @@ export default defineComponent({
 
     onMounted(() => {
       formRef.value.validate();
-      console.log(NmdcSchema.$defs.CreditEnum.enum);
     });
 
     return {
@@ -212,9 +221,9 @@ export default defineComponent({
             </v-select>
             <v-select
               v-model="contributor.permissionLevel"
-              :items="permissionChoices"
-              :item-title="title"
-              :item-value="value"
+              :items="permissionLevelChoices"
+              item-text="title"
+              item-value="value"
               :style="{ maxWidth: '400px'}"
               label="Edit Permission Level"
               hint="Level of permissions the contributor has for this submission"

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -12,7 +12,7 @@ import {
   studyFormValid,
   permissionTitleToDbValueMap,
   permissionTitle,
-  canEditPermissions,
+  isOwner,
   canEditSubmissionMetadata,
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
@@ -66,7 +66,7 @@ export default defineComponent({
       addContributor,
       requiredRules,
       permissionLevelChoices,
-      canEditPermissions,
+      isOwner,
       canEditSubmissionMetadata,
       orcidRequiredRules,
     };
@@ -131,7 +131,7 @@ export default defineComponent({
       <v-text-field
         v-model="studyForm.piOrcid"
         label="Principal Investigator ORCID"
-        :disabled="!canEditPermissions()"
+        :disabled="!isOwner()"
         outlined
         :hint="Definitions.piOrcid"
         persistent-hint
@@ -235,7 +235,7 @@ export default defineComponent({
               </template>
             </v-select>
             <v-select
-              v-if="canEditPermissions()"
+              v-if="isOwner()"
               v-model="contributor.permissionLevel"
               :items="permissionLevelChoices"
               clearable

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -80,7 +80,7 @@ export default defineComponent({
       v-model="studyFormValid"
       class="my-6"
       style="max-width: 1000px;"
-      :read-only="true"
+      :disabled="!canEditSubmissionMetadata()"
     >
       <v-text-field
         v-model="studyForm.studyName"
@@ -241,6 +241,7 @@ export default defineComponent({
         </v-card>
         <v-btn
           icon
+          :disabled="!canEditSubmissionMetadata()"
           @click="studyForm.contributors.splice(i, 1)"
         >
           <v-icon>mdi-minus-circle</v-icon>
@@ -248,6 +249,7 @@ export default defineComponent({
       </div>
       <v-btn
         depressed
+        :disabled="!canEditSubmissionMetadata()"
         @click="addContributor"
       >
         <v-icon class="pr-1">

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -2,7 +2,7 @@
 import { defineComponent, onMounted, ref } from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 import Definitions from '@/definitions';
-import { studyForm, studyFormValid } from '../store';
+import { studyForm, studyFormValid, permissionTitleToDbValueMap, permissionTitle } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
@@ -15,6 +15,7 @@ export default defineComponent({
         name: '',
         orcid: '',
         roles: [],
+        permissionLevel: null,
       });
     }
 
@@ -25,8 +26,17 @@ export default defineComponent({
       ];
     }
 
+    const permissionLevelChoices: { title: string, value: string }[] = [];
+    Object.keys(permissionTitleToDbValueMap).forEach((title) => {
+      permissionLevelChoices.push({
+        title,
+        value: permissionTitleToDbValueMap[title as permissionTitle],
+      });
+    });
+
     onMounted(() => {
       formRef.value.validate();
+      console.log(NmdcSchema.$defs.CreditEnum.enum);
     });
 
     return {
@@ -37,6 +47,7 @@ export default defineComponent({
       Definitions,
       addContributor,
       requiredRules,
+      permissionLevelChoices,
     };
   },
 });
@@ -179,24 +190,39 @@ export default defineComponent({
               </template>
             </v-text-field>
           </div>
-          <v-select
-            v-model="contributor.roles"
-            :rules="[v => v.length >= 1 || 'At least one role is required']"
-            :items="NmdcSchema.$defs.CreditEnum.enum"
-            label="Roles *"
-            :hint="Definitions.contributorRoles"
-            deletable-chips
-            multiple
-            outlined
-            chips
-            small-chips
-            dense
-            persistent-hint
-          >
-            <template #message="{ message }">
-              <span v-html="message" />
-            </template>
-          </v-select>
+          <div class="d-flex">
+            <v-select
+              v-model="contributor.roles"
+              :rules="[v => v.length >= 1 || 'At least one role is required']"
+              :items="NmdcSchema.$defs.CreditEnum.enum"
+              label="CRediT Roles *"
+              :hint="Definitions.contributorRoles"
+              deletable-chips
+              multiple
+              outlined
+              chips
+              small-chips
+              dense
+              persistent-hint
+              class="mb-2 mr-3"
+            >
+              <template #message="{ message }">
+                <span v-html="message" />
+              </template>
+            </v-select>
+            <v-select
+              v-model="contributor.permissionLevel"
+              :items="permissionChoices"
+              :item-title="title"
+              :item-value="value"
+              :style="{ maxWidth: '400px'}"
+              label="Edit Permission Level"
+              hint="Level of permissions the contributor has for this submission"
+              outlined
+              dense
+              persistent-hint
+            />
+          </div>
         </v-card>
         <v-btn
           icon

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -38,6 +38,12 @@ export default defineComponent({
       ];
     }
 
+    const orcidRequiredRules = (idx: number) => [(v: string) => {
+      if (idx > studyForm.contributors.length) return true;
+      const contributor = studyForm.contributors[idx];
+      return (contributor.permissionLevel && !!v) || 'ORCID iD is required if a permission level is specified';
+    }];
+
     const permissionLevelChoices: Ref<{ title: string, value: string }[]> = ref([]);
     Object.keys(permissionTitleToDbValueMap).forEach((title) => {
       permissionLevelChoices.value.push({
@@ -61,6 +67,7 @@ export default defineComponent({
       permissionLevelChoices,
       canEditPermissions,
       canEditSubmissionMetadata,
+      orcidRequiredRules,
     };
   },
 });
@@ -192,6 +199,7 @@ export default defineComponent({
             />
             <v-text-field
               v-model="contributor.orcid"
+              :rules="orcidRequiredRules(i)"
               :hint="Definitions.contributorOrcid"
               label="ORCID"
               outlined

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -12,6 +12,8 @@ import {
   studyFormValid,
   permissionTitleToDbValueMap,
   permissionTitle,
+  canEditPermissions,
+  canEditSubmissionMetadata,
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
@@ -57,6 +59,8 @@ export default defineComponent({
       addContributor,
       requiredRules,
       permissionLevelChoices,
+      canEditPermissions,
+      canEditSubmissionMetadata,
     };
   },
 });
@@ -76,6 +80,7 @@ export default defineComponent({
       v-model="studyFormValid"
       class="my-6"
       style="max-width: 1000px;"
+      :read-only="true"
     >
       <v-text-field
         v-model="studyForm.studyName"
@@ -220,12 +225,13 @@ export default defineComponent({
               </template>
             </v-select>
             <v-select
+              v-if="canEditPermissions()"
               v-model="contributor.permissionLevel"
               :items="permissionLevelChoices"
               item-text="title"
               item-value="value"
               :style="{ maxWidth: '400px'}"
-              label="Edit Permission Level"
+              label="Permission Level"
               hint="Level of permissions the contributor has for this submission"
               outlined
               dense

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -41,7 +41,8 @@ export default defineComponent({
     const orcidRequiredRules = (idx: number) => [(v: string) => {
       if (idx > studyForm.contributors.length) return true;
       const contributor = studyForm.contributors[idx];
-      return (contributor.permissionLevel && !!v) || 'ORCID iD is required if a permission level is specified';
+      // show error when: permission level exists, but orcid does not
+      return (contributor.permissionLevel && !!v) || !contributor.permissionLevel || 'ORCID iD is required if a permission level is specified';
     }];
 
     const permissionLevelChoices: Ref<{ title: string, value: string }[]> = ref([]);
@@ -130,6 +131,7 @@ export default defineComponent({
       <v-text-field
         v-model="studyForm.piOrcid"
         label="Principal Investigator ORCID"
+        :disabled="!canEditPermissions()"
         outlined
         :hint="Definitions.piOrcid"
         persistent-hint
@@ -236,6 +238,7 @@ export default defineComponent({
               v-if="canEditPermissions()"
               v-model="contributor.permissionLevel"
               :items="permissionLevelChoices"
+              clearable
               item-text="title"
               item-value="value"
               :style="{ maxWidth: '400px'}"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -13,8 +13,7 @@ import {
   contextFormValid,
   AwardTypes,
   addressFormValid,
-  getPermissionLevel,
-  permissionLevelValues,
+  canEditSubmissionMetadata,
 } from '../store';
 import SubmissionContextShippingForm from './SubmissionContextShippingForm.vue';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
@@ -51,9 +50,6 @@ export default defineComponent({
       nextTick(() => formRef.value.validate());
     };
 
-    const permissionLevel = getPermissionLevel();
-    const isReadOnly = permissionLevel ? ['viewer', 'metadata_contributor'].includes(permissionLevel) : true;
-
     watch(
       () => contextForm.award,
       (award) => {
@@ -80,8 +76,7 @@ export default defineComponent({
       otherAwardValidationRules,
       doiRequiredRules,
       revalidate,
-      permissionLevel,
-      isReadOnly,
+      canEditSubmissionMetadata,
     };
   },
 });
@@ -101,6 +96,7 @@ export default defineComponent({
       v-model="contextFormValid"
       style="max-width: 1000px;"
       class="mb-2"
+      :disabled="!canEditSubmissionMetadata()"
     >
       <v-radio-group
         v-model="contextForm.dataGenerated"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -13,6 +13,8 @@ import {
   contextFormValid,
   AwardTypes,
   addressFormValid,
+  getPermissionLevel,
+  permissionLevelValues,
 } from '../store';
 import SubmissionContextShippingForm from './SubmissionContextShippingForm.vue';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
@@ -49,6 +51,9 @@ export default defineComponent({
       nextTick(() => formRef.value.validate());
     };
 
+    const permissionLevel = getPermissionLevel();
+    const isReadOnly = permissionLevel ? ['viewer', 'metadata_contributor'].includes(permissionLevel) : true;
+
     watch(
       () => contextForm.award,
       (award) => {
@@ -75,6 +80,8 @@ export default defineComponent({
       otherAwardValidationRules,
       doiRequiredRules,
       revalidate,
+      permissionLevel,
+      isReadOnly,
     };
   },
 });

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -8,7 +8,12 @@ import {
   watch,
 } from '@vue/composition-api';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
-import { addressForm, addressFormValid, BiosafetyLevels } from '../store';
+import {
+  addressForm,
+  addressFormValid,
+  BiosafetyLevels,
+  canEditSubmissionMetadata,
+} from '../store';
 import { addressToString } from '../store/api';
 import SubmissionContextShippingSummary from './SubmissionContextShippingSummary.vue';
 
@@ -81,6 +86,7 @@ export default defineComponent({
       addressSummary,
       sampleEnumValues,
       shippingConditionsItems,
+      canEditSubmissionMetadata,
       requiredRules,
     };
   },
@@ -117,6 +123,7 @@ export default defineComponent({
         #activator="{ on, attrs }"
       >
         <v-btn
+          :disabled="!canEditSubmissionMetadata()"
           absolute
           top
           right
@@ -139,6 +146,7 @@ export default defineComponent({
             v-model="addressFormValid"
             class="ml-12"
             style="max-width: 1000px"
+            :disabled="!canEditSubmissionMetadata()"
           >
             <v-subheader>
               <span class="text-h6">Shipper</span>

--- a/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
+++ b/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
@@ -1,7 +1,12 @@
 <script lang="ts">
 import { defineComponent, computed } from '@vue/composition-api';
 import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
-import { templateChoiceDisabled, templateList, packageName } from '../store';
+import {
+  templateChoiceDisabled,
+  templateList,
+  packageName,
+  canEditSubmissionMetadata,
+} from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
 
 export default defineComponent({
@@ -17,6 +22,7 @@ export default defineComponent({
       templates: Object.entries(HARMONIZER_TEMPLATES),
       templateListDisplayNames,
       templateChoiceDisabled,
+      canEditSubmissionMetadata,
     };
   },
 });
@@ -34,6 +40,7 @@ export default defineComponent({
     <v-radio-group
       v-model="packageName"
       class="my-6"
+      :disabled="!canEditSubmissionMetadata()"
     >
       <v-radio
         v-for="option in templates.filter((v) => v[1].status === 'published')"

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -21,6 +21,7 @@ import {
   hasChanged,
   tabsValidated,
   submissionStatus,
+  canEditSampleMetadata,
 } from './store';
 import FindReplace from './Components/FindReplace.vue';
 import SubmissionStepper from './Components/SubmissionStepper.vue';
@@ -168,6 +169,9 @@ export default defineComponent({
         await nextTick();
         harmonizerApi.loadData(activeTemplateData.value);
         harmonizerApi.addChangeHook(onDataChange);
+        if (!canEditSampleMetadata()) {
+          harmonizerApi.setTableReadOnly();
+        }
       }
     });
 
@@ -215,7 +219,7 @@ export default defineComponent({
       Object.values(tabsValidated.value).forEach((value) => {
         allTabsValid = allTabsValid && value;
       });
-      return allTabsValid;
+      return allTabsValid && canEditSampleMetadata();
     });
 
     const fields = computed(() => flattenDeep(Object.entries(harmonizerApi.schemaSections.value)
@@ -469,6 +473,7 @@ export default defineComponent({
       validate,
       changeTemplate,
       urlify,
+      canEditSampleMetadata,
     };
   },
 });
@@ -501,6 +506,7 @@ export default defineComponent({
             color="primary"
             class="mr-2"
             hide-details
+            :disabled="!canEditSampleMetadata()"
             @click="showOpenFileDialog"
           >
             1. Import XLSX file
@@ -513,6 +519,7 @@ export default defineComponent({
           v-if="validationErrorGroups.length === 0"
           color="primary"
           outlined
+          :disabled="!canEditSampleMetadata()"
           @click="validate"
         >
           2. Validate
@@ -813,7 +820,10 @@ export default defineComponent({
     </div>
 
     <div class="harmonizer-style-container">
-      <div id="harmonizer-footer-root" />
+      <div
+        v-if="canEditSampleMetadata()"
+        id="harmonizer-footer-root"
+      />
     </div>
 
     <div class="d-flex shrink ma-2">

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -22,6 +22,7 @@ import {
   tabsValidated,
   submissionStatus,
   canEditSampleMetadata,
+  isOwner,
 } from './store';
 import FindReplace from './Components/FindReplace.vue';
 import SubmissionStepper from './Components/SubmissionStepper.vue';
@@ -219,7 +220,7 @@ export default defineComponent({
       Object.values(tabsValidated.value).forEach((value) => {
         allTabsValid = allTabsValid && value;
       });
-      return allTabsValid && canEditSampleMetadata();
+      return allTabsValid && isOwner();
     });
 
     const fields = computed(() => flattenDeep(Object.entries(harmonizerApi.schemaSections.value)

--- a/web/src/views/SubmissionPortal/StepperView.vue
+++ b/web/src/views/SubmissionPortal/StepperView.vue
@@ -68,7 +68,7 @@ export default defineComponent({
         v-if="getSubmissionLockedBy()"
         :orcid-id="getSubmissionLockedBy().orcid"
         :name="getSubmissionLockedBy().name"
-        authenticated="true"
+        :authenticated="true"
       />
       <a href="/submission/home">
         Return to submission list

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -426,6 +426,11 @@ export class HarmonizerApi {
     hot.updateSettings({ columns });
   }
 
+  setTableReadOnly() {
+    this.dh.hot.updateSettings({ readOnly: true });
+    this.dh.hot.render();
+  }
+
   setMaxRows(maxRows: number) {
     this.dh.hot.updateSettings({ maxRows });
   }

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -64,10 +64,11 @@ async function createRecord(record: MetadataSubmission) {
   return resp.data;
 }
 
-async function updateRecord(id: string, record: Partial<MetadataSubmission>, status?: string) {
+async function updateRecord(id: string, record: Partial<MetadataSubmission>, status?: string, permissions?: Record<string, string>) {
   const resp = await client.patch<MetadataSubmissionRecord>(`metadata_submission/${id}`, {
     metadata_submission: record,
     status,
+    permissions,
   });
   return resp.data;
 }

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -49,6 +49,7 @@ interface MetadataSubmissionRecord {
   status: string;
   locked_by: User;
   lock_updated: string;
+  permission_level: string | null;
 }
 
 interface PaginatedResponse<T> {

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -64,7 +64,7 @@ async function createRecord(record: MetadataSubmission) {
   return resp.data;
 }
 
-async function updateRecord(id: string, record: MetadataSubmission, status?: string) {
+async function updateRecord(id: string, record: Partial<MetadataSubmission>, status?: string) {
   const resp = await client.patch<MetadataSubmissionRecord>(`metadata_submission/${id}`, {
     metadata_submission: record,
     status,

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -218,12 +218,10 @@ function getPermissions(): Record<string, permissionLevelValues> {
   }
   studyForm.contributors.forEach((contributor) => {
     const { orcid, permissionLevel } = contributor;
-    console.log(orcid, permissionLevel);
     if (orcid && permissionLevel) {
       permissions[orcid] = permissionLevel;
     }
   });
-  console.log(permissions);
   return permissions;
 }
 

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -245,7 +245,7 @@ async function incrementalSaveRecord(id: string) {
   if (!canEditSubmissionMetadata()) {
     return;
   }
-  const val: api.MetadataSubmission = {
+  const val: Partial<api.MetadataSubmission> = {
     ...payloadObject.value,
   };
   if (hasChanged.value) {

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -23,8 +23,15 @@ enum AwardTypes {
   FICUS = 'FICUS'
 }
 
-type SubmissionStatus = 'In Progress' | 'Submitted- Pending Review' | 'Complete';
+type permissionTitle = 'Viewer' | 'Metadata Contributor' | 'Editor';
+type permissionLevelValues = 'viewer' | 'metadata_contributor' | 'editor';
+const permissionTitleToDbValueMap: Record<permissionTitle, permissionLevelValues> = {
+  Viewer: 'viewer',
+  'Metadata Contributor': 'metadata_contributor',
+  Editor: 'editor',
+};
 
+type SubmissionStatus = 'In Progress' | 'Submitted- Pending Review' | 'Complete';
 const submissionStatus: Record<string, SubmissionStatus> = {
   InProgress: 'In Progress',
   SubmittedPendingReview: 'Submitted- Pending Review',
@@ -41,6 +48,11 @@ const status = ref(submissionStatus.InProgress);
 let _submissionLockedBy: User | null = null;
 function getSubmissionLockedBy(): User | null {
   return _submissionLockedBy;
+}
+
+let _permissionLevel: permissionLevelValues | null = null;
+function getPermissionLevel(): permissionLevelValues | null {
+  return _permissionLevel;
 }
 
 const hasChanged = ref(0);
@@ -84,13 +96,6 @@ const contextForm = reactive(clone(contextFormDefault));
 const contextFormValid = ref(false);
 const addressForm = reactive(clone(addressFormDefault));
 const addressFormValid = ref(false);
-
-type permissionTitle = 'Viewer' | 'Metadata Contributor' | 'Editor';
-const permissionTitleToDbValueMap: Record<permissionTitle, string> = {
-  Viewer: 'viewer',
-  'Metadata Contributor': 'metadata_contributor',
-  Editor: 'editor',
-};
 
 /**
  * Study Form Step
@@ -239,6 +244,7 @@ async function loadRecord(id: string) {
   hasChanged.value = 0;
   status.value = isSubmissionStatus(val.status) ? val.status : submissionStatus.InProgress;
   _submissionLockedBy = val.locked_by;
+  _permissionLevel = (val.permission_level as permissionLevelValues);
 }
 
 watch(payloadObject, () => { hasChanged.value += 1; }, { deep: true });
@@ -260,6 +266,7 @@ export {
   AwardTypes,
   permissionTitle,
   permissionTitleToDbValueMap,
+  permissionLevelValues,
   /* state */
   multiOmicsForm,
   multiOmicsAssociations,
@@ -281,6 +288,7 @@ export {
   status,
   /* functions */
   getSubmissionLockedBy,
+  getPermissionLevel,
   incrementalSaveRecord,
   generateRecord,
   loadRecord,

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -214,11 +214,9 @@ const payloadObject: Ref<api.MetadataSubmission> = computed(() => ({
 function getPermissions(): Record<string, permissionLevelValues> {
   const permissions: Record<string, permissionLevelValues> = {};
   if (studyForm.piOrcid) {
-    console.log('here');
     permissions[studyForm.piOrcid] = 'owner';
   }
   studyForm.contributors.forEach((contributor) => {
-    console.log('contrib');
     const { orcid, permissionLevel } = contributor;
     console.log(orcid, permissionLevel);
     if (orcid && permissionLevel) {

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -24,11 +24,18 @@ enum AwardTypes {
 }
 
 type permissionTitle = 'Viewer' | 'Metadata Contributor' | 'Editor';
-type permissionLevelValues = 'viewer' | 'metadata_contributor' | 'editor';
+type permissionLevelValues = 'viewer' | 'metadata_contributor' | 'editor' | 'owner';
 const permissionTitleToDbValueMap: Record<permissionTitle, permissionLevelValues> = {
   Viewer: 'viewer',
   'Metadata Contributor': 'metadata_contributor',
   Editor: 'editor',
+};
+
+const permissionLevelHierarchy: Record<permissionLevelValues, number> = {
+  owner: 4,
+  editor: 3,
+  metadata_contributor: 2,
+  viewer: 1,
 };
 
 type SubmissionStatus = 'In Progress' | 'Submitted- Pending Review' | 'Complete';
@@ -53,6 +60,21 @@ function getSubmissionLockedBy(): User | null {
 let _permissionLevel: permissionLevelValues | null = null;
 function getPermissionLevel(): permissionLevelValues | null {
   return _permissionLevel;
+}
+
+function canEditPermissions(): boolean {
+  if (!_permissionLevel) return false;
+  return permissionLevelHierarchy[_permissionLevel] === permissionLevelHierarchy.owner;
+}
+
+function canEditSubmissionMetadata(): boolean {
+  if (!_permissionLevel) return false;
+  return permissionLevelHierarchy[_permissionLevel] >= permissionLevelHierarchy.editor;
+}
+
+function canEditSampleMetadta(): boolean {
+  if (!_permissionLevel) return false;
+  return permissionLevelHierarchy[_permissionLevel] >= permissionLevelHierarchy.metadata_contributor;
 }
 
 const hasChanged = ref(0);
@@ -267,6 +289,10 @@ export {
   permissionTitle,
   permissionTitleToDbValueMap,
   permissionLevelValues,
+  permissionLevelHierarchy,
+  canEditPermissions,
+  canEditSampleMetadta,
+  canEditSubmissionMetadata,
   /* state */
   multiOmicsForm,
   multiOmicsAssociations,

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -62,7 +62,7 @@ function getPermissionLevel(): permissionLevelValues | null {
   return _permissionLevel;
 }
 
-function canEditPermissions(): boolean {
+function isOwner(): boolean {
   if (!_permissionLevel) return false;
   return permissionLevelHierarchy[_permissionLevel] === permissionLevelHierarchy.owner;
 }
@@ -262,7 +262,7 @@ async function incrementalSaveRecord(id: string) {
 
   let payload: Partial<api.MetadataSubmission> = {};
   let permissions: Record<string, permissionLevelValues> | undefined;
-  if (canEditPermissions()) {
+  if (isOwner()) {
     payload = payloadObject.value;
     permissions = getPermissions();
   } else if (canEditSubmissionMetadata()) {
@@ -348,7 +348,7 @@ export {
   loadRecord,
   submit,
   mergeSampleData,
-  canEditPermissions,
+  isOwner,
   canEditSampleMetadata,
   canEditSubmissionMetadata,
 };

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -72,7 +72,7 @@ function canEditSubmissionMetadata(): boolean {
   return permissionLevelHierarchy[_permissionLevel] >= permissionLevelHierarchy.editor;
 }
 
-function canEditSampleMetadta(): boolean {
+function canEditSampleMetadata(): boolean {
   if (!_permissionLevel) return false;
   return permissionLevelHierarchy[_permissionLevel] >= permissionLevelHierarchy.metadata_contributor;
 }
@@ -217,7 +217,10 @@ const submitPayload = computed(() => {
 });
 
 function submit(id: string, status: SubmissionStatus = submissionStatus.InProgress) {
-  return api.updateRecord(id, payloadObject.value, status);
+  if (canEditSubmissionMetadata()) {
+    return api.updateRecord(id, payloadObject.value, status);
+  }
+  throw new Error('Unable to submit due to inadequate permission level for this submission.');
 }
 
 function reset() {
@@ -239,6 +242,9 @@ function reset() {
 }
 
 async function incrementalSaveRecord(id: string) {
+  if (!canEditSubmissionMetadata()) {
+    return;
+  }
   const val: api.MetadataSubmission = {
     ...payloadObject.value,
   };
@@ -290,9 +296,6 @@ export {
   permissionTitleToDbValueMap,
   permissionLevelValues,
   permissionLevelHierarchy,
-  canEditPermissions,
-  canEditSampleMetadta,
-  canEditSubmissionMetadata,
   /* state */
   multiOmicsForm,
   multiOmicsAssociations,
@@ -320,4 +323,7 @@ export {
   loadRecord,
   submit,
   mergeSampleData,
+  canEditPermissions,
+  canEditSampleMetadata,
+  canEditSubmissionMetadata,
 };

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -85,6 +85,13 @@ const contextFormValid = ref(false);
 const addressForm = reactive(clone(addressFormDefault));
 const addressFormValid = ref(false);
 
+type permissionTitle = 'Viewer' | 'Metadata Contributor' | 'Editor';
+const permissionTitleToDbValueMap: Record<permissionTitle, string> = {
+  Viewer: 'viewer',
+  'Metadata Contributor': 'metadata_contributor',
+  Editor: 'editor',
+};
+
 /**
  * Study Form Step
  */
@@ -101,6 +108,7 @@ const studyFormDefault = {
     name: string;
     orcid: string;
     roles: string[];
+    permissionLevel: permissionTitle | null;
   }[],
 };
 const studyFormValid = ref(false);
@@ -250,6 +258,8 @@ export {
   submissionStatus,
   BiosafetyLevels,
   AwardTypes,
+  permissionTitle,
+  permissionTitleToDbValueMap,
   /* state */
   multiOmicsForm,
   multiOmicsAssociations,


### PR DESCRIPTION
Close #1077 

Rounds out the initial batch of development to enable per-submission editor permissions.

### Frontend Changes
Based on permission level of the currently logged-in user, submission forms and fields are locked down if appropriate.

- `owner`: this is the only permission level that can submit or edit PI Orcid. Additionally, owners can add a permission level (`viewer`, `editor`, `metadata_contributor`) for contributors on the Study form
- `editor`: can no longer click the Submit button or edit PI Orcid. 
- `metadata_contributor`: all forms except for the data harmonizer table are disabled.
- `viewer`: all forms including the data harmonizer are disabled.

### Backend Changes
 Permission levels are checked for the `PATCH /metadata_submission/{id}` endpoint. Request bodies should not only include data that the logged in user can actually edit. For example, if the user of a request is determined to have `metadata_contributor` permissions, but the request body contains new `studyForm` data, that returns a `403`. If the endpoint determines that the entire request body is in scope for the user, update proceeds as normal, now using the `|` operator to merge objects rather than flat out replacing.

A new pydantic model was created to allow for partial request bodies.

Tests were added.