### PR TITLE
Show depth as range or with units, if possible

### DIFF
--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -43,7 +43,6 @@ const buildStrFromDepthAnnotation = (depthAnnotation: JSONValue, format: Format)
         break;
       }
       default: {
-        console.error('Invalid format specifier.');
         break;
       }
     }

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -110,10 +110,10 @@ export default defineComponent({
             if (typeof rangeStr === 'string') {
               result = rangeStr;
             } else {
-              // Check whether the raw depth is non-null and the depth annotation contains a unit;
+              // Check whether the raw depth is numeric (i.e. not null) and the depth annotation contains a unit;
               // and, if so, use a concatenation of the two as the result.
               const unitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Mode.Unit);
-              if (rawDepth !== null && typeof unitStr === 'string') {
+              if (typeof rawDepth === 'number' && typeof unitStr === 'string') {
                 result = `${rawDepth} ${unitStr}`;
               }
             }

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -17,7 +17,7 @@ export enum Format {
 const buildStrFromDepthAnnotation = (depthAnnotation: JSONValue, format: Format): string | undefined => {
   let str: string | undefined;
 
-  // Regardless of the specified mode, check whether the depth annotation is a "non-null, non-array" object.
+  // Regardless of the specified format, check whether the depth annotation is a "non-null, non-array" object.
   if (typeof depthAnnotation === 'object' && depthAnnotation !== null && !Array.isArray(depthAnnotation)) {
     // Extract data according to the specified format.
     switch (format) {

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -104,21 +104,22 @@ export default defineComponent({
 
         // Check whether there is a depth annotation.
         if ('depth' in props.item.annotations) {
+          const depthAnnotation = props.item.annotations.depth as JSONValue;
           // Check whether the depth annotation describes a range with a unit;
           // and, if so, use that as the result.
-          const rangeWithUnitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Format.RangeWithUnit);
+          const rangeWithUnitStr = buildStrFromDepthAnnotation(depthAnnotation, Format.RangeWithUnit);
           if (typeof rangeWithUnitStr === 'string') {
             result = rangeWithUnitStr;
           } else {
             // Check whether the depth annotation describes a range;
             // and, if so, use that as the result.
-            const rangeStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Format.Range);
+            const rangeStr = buildStrFromDepthAnnotation(depthAnnotation, Format.Range);
             if (typeof rangeStr === 'string') {
               result = rangeStr;
             } else {
               // Check whether the top-level depth value is numeric (not null) and the depth annotation contains a unit;
               // and, if so, use a concatenation of the two as the result.
-              const unitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Format.Unit);
+              const unitStr = buildStrFromDepthAnnotation(depthAnnotation, Format.Unit);
               if (typeof topLevelDepth === 'number' && typeof unitStr === 'string') {
                 result = `${topLevelDepth} ${unitStr}`;
               }

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -1,64 +1,8 @@
 <script lang="ts">
 import { defineComponent, PropType } from '@vue/composition-api';
 import { getField } from '@/encoding';
-import { fieldDisplayName, valueDisplayName } from '@/util';
-import { BaseSearchResult, BiosampleSearchResult, JSONValue } from '@/data/api';
-
-export enum Format {
-  RangeWithUnit = 'RangeWithUnit',
-  Range = 'Range',
-  Unit = 'Unit',
-}
-
-/**
- * Helper function that returns a string representation of the depth in the specified format, if the specified
- * depth annotation contains adequate information to do so. Otherwise, the function returns `undefined`.
- */
-const buildStrFromDepthAnnotation = (depthAnnotation: JSONValue, format: Format): string | undefined => {
-  let str: string | undefined;
-
-  // Regardless of the specified format, check whether the depth annotation is a "non-null, non-array" object.
-  if (typeof depthAnnotation === 'object' && depthAnnotation !== null && !Array.isArray(depthAnnotation)) {
-    // Extract data according to the specified format.
-    switch (format) {
-      case Format.RangeWithUnit: {
-        const { has_minimum_numeric_value, has_maximum_numeric_value, has_unit } = depthAnnotation;
-        if (typeof has_minimum_numeric_value === 'number' && typeof has_maximum_numeric_value === 'number' && typeof has_unit === 'string') {
-          str = `${has_minimum_numeric_value} - ${has_maximum_numeric_value} ${has_unit}`;
-        }
-        break;
-      }
-      case Format.Range: {
-        const { has_minimum_numeric_value, has_maximum_numeric_value } = depthAnnotation;
-        if (typeof has_minimum_numeric_value === 'number' && typeof has_maximum_numeric_value === 'number') {
-          str = `${has_minimum_numeric_value} - ${has_maximum_numeric_value}`;
-        }
-        break;
-      }
-      case Format.Unit: {
-        const { has_unit } = depthAnnotation;
-        if (typeof has_unit === 'string') {
-          str = has_unit;
-        }
-        break;
-      }
-      default: {
-        break;
-      }
-    }
-  }
-
-  return str;
-};
-
-/**
- * Helper function that checks whether the specified depth annotation describes a range.
- */
-export const doesDepthAnnotationDescribeRange = (depthAnnotation: JSONValue): boolean => {
-  const rangeWithUnit = buildStrFromDepthAnnotation(depthAnnotation, Format.RangeWithUnit);
-  const range = buildStrFromDepthAnnotation(depthAnnotation, Format.Range);
-  return typeof rangeWithUnit === 'string' || typeof range === 'string';
-};
+import { fieldDisplayName, formatBiosampleDepth, valueDisplayName } from '@/util';
+import { BaseSearchResult, BiosampleSearchResult } from '@/data/api';
 
 export default defineComponent({
   props: {
@@ -96,38 +40,10 @@ export default defineComponent({
 
   setup(props) {
     function getValue(field: string) {
+      // For the "depth" field, format it as a string or `null`.
+      // Note: I assert some types here to work around the inaccurate type definitions in `api.ts`.
       if (field === 'depth') {
-        const topLevelDepth = props.item.depth;
-
-        // Use the top-level depth value as the fallback result.
-        let result = topLevelDepth;
-
-        // Check whether there is a depth annotation.
-        if ('depth' in props.item.annotations) {
-          const depthAnnotation = props.item.annotations.depth as JSONValue;
-          // Check whether the depth annotation describes a range with a unit;
-          // and, if so, use that as the result.
-          const rangeWithUnitStr = buildStrFromDepthAnnotation(depthAnnotation, Format.RangeWithUnit);
-          if (typeof rangeWithUnitStr === 'string') {
-            result = rangeWithUnitStr;
-          } else {
-            // Check whether the depth annotation describes a range;
-            // and, if so, use that as the result.
-            const rangeStr = buildStrFromDepthAnnotation(depthAnnotation, Format.Range);
-            if (typeof rangeStr === 'string') {
-              result = rangeStr;
-            } else {
-              // Check whether the top-level depth value is numeric (not null) and the depth annotation contains a unit;
-              // and, if so, use a concatenation of the two as the result.
-              const unitStr = buildStrFromDepthAnnotation(depthAnnotation, Format.Unit);
-              if (typeof topLevelDepth === 'number' && typeof unitStr === 'string') {
-                result = `${topLevelDepth} ${unitStr}`;
-              }
-            }
-          }
-        }
-
-        return result;
+        return formatBiosampleDepth(props.item.annotations.depth as object | null, props.item.depth as number | null);
       }
       if (field === 'geo_loc_name') {
         return props.item.annotations.geo_loc_name;

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -43,7 +43,7 @@ export default defineComponent({
       // For the "depth" field, format it as a string or `null`.
       // Note: I assert some types here to work around the inaccurate type definitions in `api.ts`.
       if (field === 'depth') {
-        return formatBiosampleDepth(props.item.annotations.depth as object | null, props.item.depth as number | null);
+        return formatBiosampleDepth(props.item.annotations?.depth as object | null, props.item.depth as number | null);
       }
       if (field === 'geo_loc_name') {
         return props.item.annotations.geo_loc_name;

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -6,6 +6,7 @@ import { BaseSearchResult, BiosampleSearchResult, JSONValue } from '@/data/api';
 
 enum Mode {
   RangeWithUnit = 'RangeWithUnit',
+  Range = 'Range',
   Unit = 'Unit',
 }
 
@@ -27,6 +28,13 @@ const buildStrFromDepthAnnotation = (depthAnnotation: JSONValue, mode: Mode): st
         const { has_minimum_numeric_value, has_maximum_numeric_value, has_unit } = depthAnnotation;
         if (typeof has_minimum_numeric_value === 'number' && typeof has_maximum_numeric_value === 'number' && typeof has_unit === 'string') {
           str = `${has_minimum_numeric_value} - ${has_maximum_numeric_value} ${has_unit}`;
+        }
+        break;
+      }
+      case Mode.Range: {
+        const { has_minimum_numeric_value, has_maximum_numeric_value } = depthAnnotation;
+        if (typeof has_minimum_numeric_value === 'number' && typeof has_maximum_numeric_value === 'number') {
+          str = `${has_minimum_numeric_value} - ${has_maximum_numeric_value}`;
         }
         break;
       }
@@ -90,17 +98,24 @@ export default defineComponent({
 
         // Check whether there is a depth annotation.
         if ('depth' in props.item.annotations) {
-          // Check whether the depth annotation describes a range;
+          // Check whether the depth annotation describes a range with a unit;
           // and, if so, use that as the result.
           const rangeWithUnitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Mode.RangeWithUnit);
           if (typeof rangeWithUnitStr === 'string') {
             result = rangeWithUnitStr;
           } else {
-            // Check whether the raw depth is non-null and the depth annotation contains a unit;
-            // and, if so, use a concatenation of the two as the result.
-            const unitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Mode.Unit);
-            if (rawDepth !== null && typeof unitStr === 'string') {
-              result = `${rawDepth} ${unitStr}`;
+            // Check whether the depth annotation describes a range;
+            // and, if so, use that as the result.
+            const rangeStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Mode.Range);
+            if (typeof rangeStr === 'string') {
+              result = rangeStr;
+            } else {
+              // Check whether the raw depth is non-null and the depth annotation contains a unit;
+              // and, if so, use a concatenation of the two as the result.
+              const unitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Mode.Unit);
+              if (rawDepth !== null && typeof unitStr === 'string') {
+                result = `${rawDepth} ${unitStr}`;
+              }
             }
           }
         }

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -52,7 +52,7 @@ const buildStrFromDepthAnnotation = (depthAnnotation: JSONValue, format: Format)
 };
 
 /**
- * Helper function that checks whether the specified depth annotation "adequately" describes a range.
+ * Helper function that checks whether the specified depth annotation describes a range.
  */
 export const doesDepthAnnotationDescribeRange = (depthAnnotation: JSONValue): boolean => {
   const rangeWithUnit = buildStrFromDepthAnnotation(depthAnnotation, Format.RangeWithUnit);
@@ -97,10 +97,10 @@ export default defineComponent({
   setup(props) {
     function getValue(field: string) {
       if (field === 'depth') {
-        const rawDepth = props.item.depth;
+        const topLevelDepth = props.item.depth;
 
-        // Use the raw depth as the fallback result.
-        let result = rawDepth;
+        // Use the top-level depth value as the fallback result.
+        let result = topLevelDepth;
 
         // Check whether there is a depth annotation.
         if ('depth' in props.item.annotations) {
@@ -116,11 +116,11 @@ export default defineComponent({
             if (typeof rangeStr === 'string') {
               result = rangeStr;
             } else {
-              // Check whether the raw depth is numeric (i.e. not null) and the depth annotation contains a unit;
+              // Check whether the top-level depth value is numeric (not null) and the depth annotation contains a unit;
               // and, if so, use a concatenation of the two as the result.
               const unitStr = buildStrFromDepthAnnotation(props.item.annotations.depth, Format.Unit);
-              if (typeof rawDepth === 'number' && typeof unitStr === 'string') {
-                result = `${rawDepth} ${unitStr}`;
+              if (typeof topLevelDepth === 'number' && typeof unitStr === 'string') {
+                result = `${topLevelDepth} ${unitStr}`;
               }
             }
           }

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -4,7 +4,7 @@ import { isObject } from 'lodash';
 
 import { BaseSearchResult, BiosampleSearchResult } from '@/data/api';
 import { getField } from '@/encoding';
-import AttributeItem from './AttributeItem.vue';
+import AttributeItem, { doesDepthAnnotationDescribeRange } from './AttributeItem.vue';
 
 export default defineComponent({
   components: { AttributeItem },
@@ -41,6 +41,15 @@ export default defineComponent({
         if (includeFields.has(field)) {
           return true;
         }
+
+        // For the "depth" field, we only include it if either:
+        // (a) the top-level depth value is a number (even if it's 0); or
+        // (b) the depth annotation describes a range (with or without units).
+        if (field === 'depth') {
+          const isTopLevelDepthNumeric = typeof props.item.depth === 'number';
+          return isTopLevelDepthNumeric || doesDepthAnnotationDescribeRange(props.item.annotations.depth);
+        }
+
         const value = props.item[field];
         return !isObject(value) && value && (!getField(field) || !getField(field).hideAttr);
       });

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -4,7 +4,8 @@ import { isObject } from 'lodash';
 
 import { BaseSearchResult, BiosampleSearchResult } from '@/data/api';
 import { getField } from '@/encoding';
-import AttributeItem, { doesDepthAnnotationDescribeRange } from './AttributeItem.vue';
+import AttributeItem from './AttributeItem.vue';
+import { formatBiosampleDepth } from '@/util';
 
 export default defineComponent({
   components: { AttributeItem },
@@ -42,12 +43,11 @@ export default defineComponent({
           return true;
         }
 
-        // For the "depth" field, we only include it if either:
-        // (a) the top-level depth value is a number (even if it's 0); or
-        // (b) the depth annotation describes a range (with or without units).
+        // For the "depth" field, we only include it if it is something we can format as a string.
+        // Note: I assert some types here to work around the inaccurate type definitions in `api.ts`.
         if (field === 'depth') {
-          const isTopLevelDepthNumeric = typeof props.item.depth === 'number';
-          return isTopLevelDepthNumeric || doesDepthAnnotationDescribeRange(props.item.annotations.depth);
+          const formattedDepth = formatBiosampleDepth(props.item.annotations.depth as object | null, props.item.depth as number | null);
+          return formattedDepth !== null;
         }
 
         const value = props.item[field];

--- a/web/src/components/Presentation/AttributeList.vue
+++ b/web/src/components/Presentation/AttributeList.vue
@@ -46,7 +46,7 @@ export default defineComponent({
         // For the "depth" field, we only include it if it is something we can format as a string.
         // Note: I assert some types here to work around the inaccurate type definitions in `api.ts`.
         if (field === 'depth') {
-          const formattedDepth = formatBiosampleDepth(props.item.annotations.depth as object | null, props.item.depth as number | null);
+          const formattedDepth = formatBiosampleDepth(props.item.annotations?.depth as object | null, props.item.depth as number | null);
           return formattedDepth !== null;
         }
 

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -39,15 +39,6 @@ export type entityType = 'biosample'
  */
 export type entitySchemaType = keyof typeof NmdcSchema.$defs;
 
-/**
- * Define a TypeScript type alias that accounts for all possible JSON values.
- *
- * References:
- * - https://www.json.org/json-en.html
- * - https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#more-recursive-type-aliases
- */
-export type JSONValue = string | number | boolean | null | { [k: string]: JSONValue } | Array<JSONValue>;
-
 export interface BaseSearchResult {
   id: string;
   name: string;

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -39,12 +39,21 @@ export type entityType = 'biosample'
  */
 export type entitySchemaType = keyof typeof NmdcSchema.$defs;
 
+/**
+ * Define a TypeScript type alias that accounts for all possible JSON values.
+ *
+ * References:
+ * - https://www.json.org/json-en.html
+ * - https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#more-recursive-type-aliases
+ */
+export type JSONValue = string | number | boolean | null | { [k: string]: JSONValue } | Array<JSONValue>;
+
 export interface BaseSearchResult {
   id: string;
   name: string;
   description: string;
   alternate_identifiers: string[];
-  annotations: Record<string, string | string[]>;
+  annotations: Record<string, JSONValue>;
   [key: string]: unknown; // possibly other things.
 }
 

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -53,7 +53,7 @@ export interface BaseSearchResult {
   name: string;
   description: string;
   alternate_identifiers: string[];
-  annotations: Record<string, JSONValue>;
+  annotations: Record<string, string | string[]>;
   [key: string]: unknown; // possibly other things.
 }
 

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -169,7 +169,7 @@ export function saveAs(filename, text) {
  * @param depth {number | null} Value of the biosample's top-level `depth` property
  * @return {string | null} Either a string describing the depth of the biosample, or `null`
  */
-export const formatBiosampleDepth = (depthAnnotation, depth) => {
+export function formatBiosampleDepth(depthAnnotation, depth) {
   let formattedStr = depth; // fallback value
   if (depthAnnotation !== null) {
     const {
@@ -187,4 +187,4 @@ export const formatBiosampleDepth = (depthAnnotation, depth) => {
     }
   }
   return formattedStr;
-};
+}

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -143,17 +143,19 @@ export function saveAs(filename, text) {
 }
 
 /**
- * Returns a string describing the depth of the biosample in the most preferred format possible (see formats below);
- * or returns `null` (if it cannot describe a depth in any of the preferred formats).
+ * Returns a string describing the depth of a biosample, or returns null.
  *
- * Formats, from most to least preferred (preferred by whom? see https://github.com/microbiomedata/nmdc-server/issues/756):
+ * If the biosample's depth annotation contains enough information for this function to format the depth into a string
+ * having one of the formats listed below, the function formats it that way. Otherwise, the function returns whatever
+ * the biosample's top-level `depth` property contains, which could be `null` (per `nmdc_server/ingest/biosample.py`).
+ *
+ * Formats:
  * 1. Range with unit (e.g. "1 - 2 meters")
  * 2. Range without unit (e.g. "1 - 2")
  * 3. Number with unit (e.g. "1 meter")
- * 4. Whatever the biosample's top-level `depth` property contains (see `nmdc_server/ingest/biosample.py`)
  *
- * Note: I check values' types instead of their truthiness because I consider 0 to be a valid depth magnitude,
- *       while JavaScript considers it to be falsy.
+ * Note: I check values' types instead of their truthiness here because I consider `0` to be a valid depth magnitude,
+ *       while JavaScript considers it to be falsy (per https://developer.mozilla.org/en-US/docs/Glossary/Falsy).
  *
  * References:
  * - https://jsdoc.app/tags-param#parameters-with-properties

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -161,7 +161,7 @@ export function saveAs(filename, text) {
  * - https://jsdoc.app/tags-param#parameters-with-properties
  * - https://microbiomedata.github.io/nmdc-schema/QuantityValue/
  *
- * @param depthAnnotation {object?} Value of the biosample's `annotations.depth` property
+ * @param depthAnnotation {object | null} Value of the biosample's `annotations.depth` property
  * @param depthAnnotation.has_minimum_numeric_value {number?} Lower magnitude of the quantity's range
  * @param depthAnnotation.has_maximum_numeric_value {number?} Upper magnitude of the quantity's range
  * @param depthAnnotation.has_numeric_value {number?} Magnitude of the quantity
@@ -171,7 +171,7 @@ export function saveAs(filename, text) {
  */
 export const formatBiosampleDepth = (depthAnnotation, depth) => {
   let formattedStr = depth; // fallback value
-  if (depthAnnotation !== undefined) {
+  if (depthAnnotation !== null) {
     const {
       has_minimum_numeric_value: minMagnitude,
       has_maximum_numeric_value: maxMagnitude,

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -160,8 +160,8 @@ export function saveAs(filename, text) {
  * - https://microbiomedata.github.io/nmdc-schema/QuantityValue/
  *
  * @param depthAnnotation {object?} Value of the biosample's `annotations.depth` property
- * @param depthAnnotation.has_maximum_numeric_value {number?} Upper magnitude of the quantity's range
  * @param depthAnnotation.has_minimum_numeric_value {number?} Lower magnitude of the quantity's range
+ * @param depthAnnotation.has_maximum_numeric_value {number?} Upper magnitude of the quantity's range
  * @param depthAnnotation.has_numeric_value {number?} Magnitude of the quantity
  * @param depthAnnotation.has_unit {string?} Unit of the quantity
  * @param depth {number | null} Value of the biosample's top-level `depth` property
@@ -171,14 +171,14 @@ export const formatBiosampleDepth = (depthAnnotation, depth) => {
   let formattedStr = depth; // fallback value
   if (depthAnnotation !== undefined) {
     const {
-      has_maximum_numeric_value: maxMagnitude,
       has_minimum_numeric_value: minMagnitude,
+      has_maximum_numeric_value: maxMagnitude,
       has_numeric_value: magnitude,
       has_unit: unit,
     } = depthAnnotation;
-    if (typeof maxMagnitude === 'number' && typeof minMagnitude === 'number' && typeof unit === 'string') {
+    if (typeof minMagnitude === 'number' && typeof maxMagnitude === 'number' && typeof unit === 'string') {
       formattedStr = `${minMagnitude} - ${maxMagnitude} ${unit}`; // range with unit
-    } else if (typeof maxMagnitude === 'number' && typeof minMagnitude === 'number') {
+    } else if (typeof minMagnitude === 'number' && typeof maxMagnitude === 'number') {
       formattedStr = `${minMagnitude} - ${maxMagnitude}`; // range without unit
     } else if (typeof magnitude === 'number' && typeof unit === 'string') {
       formattedStr = `${magnitude} ${unit}`; // number with unit


### PR DESCRIPTION
### Summary of changes

On the biosample details page, the depth is now displayed according to the following rules:
1. If the depth annotation contains a minimum, a maximum, and a unit → display `{min} - {max} {unit}`
1. If the depth annotation contains a minimum and a maximum (but no unit) → display `{min} - {max}`
1. If the depth annotation contains a magnitude and a unit → display `{depth} {unit}`
1. Otherwise → display whatever is in the top-level `depth` property

#### Scenario 1:

<img width="1511" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/7f877499-0fd7-425a-8c2e-8a28620d7553">

> Local URL: http://localhost:8081/details/sample/gold:Gb0110680

#### Scenario 2:

<img width="1304" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/787b7640-d322-4cf5-a485-3a1707d710be">

> Local URL: http://localhost:8081/details/sample/nmdc:bsm-11-q5nxet10

#### Scenario 3:

<img width="1266" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/c878e8e6-6b54-4338-bd46-d3376f4850ab">

> Local URL: http://localhost:8081/details/sample/gold:Gb0115859

#### Scenario 4:

<img width="1265" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/baf0f756-cf6c-4f3e-84c6-b2062b26e57b">

> Local URL: http://localhost:8081/details/sample/igsn:IEWFS000I

<details>
  <summary>Developer notes for myself (click to show/hide)</summary>

Here's an example of a SQL query I used to find biosamples meeting certain criteria:

```sql
SELECT id
FROM biosample
WHERE
    depth > 0
    AND annotations->'depth'->>'has_unit' IS NULL
    AND annotations->'depth'->>'has_maximum_numeric_value' IS NULL
    AND annotations->'depth'->>'has_minimum_numeric_value' IS NULL;
```

</details>