### PR TITLE
Make certain JGI columns always read-only in DataHarmonizer

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -64,6 +64,21 @@ const TYPE_FIELD = ANALYSIS_TYPE;
 // TODO: should this be derived from schema?
 const COMMON_COLUMNS = [SAMP_NAME, SOURCE_MAT_ID, ANALYSIS_TYPE];
 
+const ALWAYS_READ_ONLY_COLUMNS = [
+  'dna_seq_project',
+  'rna_seq_project',
+  'dna_samp_id',
+  'rna_samp_id',
+  'rna_seq_project_pi',
+  'dna_seq_project_pi',
+  'dna_project_contact',
+  'rna_project_contact',
+  'proposal_rna',
+  'proposal_dna',
+  'rna_seq_project_name',
+  'dna_seq_project_name',
+];
+
 // TODO: can this be imported from elsewhere?
 const EMSL = 'emsl';
 const JGI_MG = 'jgi_mg';
@@ -96,9 +111,10 @@ export default defineComponent({
 
     watch(activeTemplate, () => {
       harmonizerApi.loadData(activeTemplateData.value);
+      harmonizerApi.setColumnsReadOnly(ALWAYS_READ_ONLY_COLUMNS);
       // if we're not on the first tab, the common columns should be read-only
       if (activeTemplateKey.value !== templateList.value[0]) {
-        harmonizerApi.setColumnsReadOnly([0, 1, 2]);
+        harmonizerApi.setColumnsReadOnly(COMMON_COLUMNS);
         harmonizerApi.setMaxRows(activeTemplateData.value.length);
       }
     });
@@ -1018,5 +1034,9 @@ html {
 
 .sidebar-toggle-close {
   transform: rotate(180deg);
+}
+
+.htDimmed {
+  cursor: not-allowed;
 }
 </style>

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -414,15 +414,16 @@ export class HarmonizerApi {
     this._postTemplateChange();
   }
 
-  setColumnsReadOnly(columns: number[]) {
+  setColumnsReadOnly(slotNames: string[]) {
     const { hot } = this.dh;
-    const rowCount = hot.countRows();
-    columns.forEach((col) => {
-      for (let row = 0; row < rowCount; row += 1) {
-        hot.setCellMeta(row, col, 'readOnly', true);
+    const { columns } = hot.getSettings();
+    const fields = this.dh.getFields();
+    for (let col = 0; col < fields.length; col += 1) {
+      if (slotNames.includes(fields[col].name)) {
+        columns[col].readOnly = true;
       }
-    });
-    hot.render();
+    }
+    hot.updateSettings({ columns });
   }
 
   setMaxRows(maxRows: number) {


### PR DESCRIPTION
Re: https://github.com/microbiomedata/issues/issues/412 (will close once it has been tested on dev)

These changes make a set of JGI-related columns read-only in DataHarmonizer. This does _not_ prevent the columns from being populated by importing an XLSX file. This is a feature, not a bug.

To test:
* Go to any submission with a JGI MG and/or JGI MT tab
* Enter data in the first tab to ensure that some rows will display in the JGI tab(s)
* On the JGI tab(s) ensure that the indicated columns cannot be edited