### PR TITLE
Update URLs to reflect new workload names on Spin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,11 +80,11 @@ jobs:
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
 
-      - name: Redeploy nmdc:${{ matrix.deployment }}
+      - name: Redeploy nmdc:portal-${{ matrix.deployment }}
         if: ${{ env.IS_PROD_RELEASE == 'true' && env.IS_ORIGINAL_REPO == 'true' }}
         uses: fjogeleit/http-request-action@v1
         with:
-          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc:${{ matrix.deployment }}?action=redeploy
+          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc:portal-${{ matrix.deployment }}?action=redeploy
           method: POST
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}


### PR DESCRIPTION
I recently "renamed" (i.e. replaced with workloads having different names) the targeted workloads on Spin.

![image](https://github.com/microbiomedata/nmdc-server/assets/134325062/8b9094ac-488c-4b48-a3e4-ef3217deab63)

In this branch, I updated the `deploy.yml` GitHub Actions workflow to use those new names.