### PR TITLE
Add debounce to fetch results when conditions change

### DIFF
--- a/web/src/use/usePaginatedResults.ts
+++ b/web/src/use/usePaginatedResults.ts
@@ -41,22 +41,24 @@ export default function usePaginatedResult<T>(
     });
   }
 
+  const debouncedFetchResults = debounce(fetchResults, 500);
+
   watch([
     toRef(data, 'limit'),
     toRef(data, 'offset'),
-  ], fetchResults);
+  ], debouncedFetchResults);
 
-  watch([conditions], debounce(() => {
+  watch([conditions], () => {
     const doFetch = data.offset === 0;
     data.offset = 0;
     data.limit = limit;
-    if (doFetch) fetchResults();
-  }, 500));
+    if (doFetch) debouncedFetchResults();
+  });
 
   if (dataObjectFilter !== undefined) {
-    watch(dataObjectFilter, fetchResults, { deep: true });
+    watch(dataObjectFilter, debouncedFetchResults, { deep: true });
   }
-  fetchResults();
+  debouncedFetchResults();
   // ENDTODO
 
   function setPage(newPage: number) {

--- a/web/src/use/usePaginatedResults.ts
+++ b/web/src/use/usePaginatedResults.ts
@@ -1,6 +1,7 @@
 import {
   watch, Ref, computed, toRef, shallowReactive,
 } from '@vue/composition-api';
+import { debounce } from 'lodash';
 import {
   SearchParams, Condition, DataObjectFilter, SearchResponse,
 } from '@/data/api';
@@ -44,12 +45,13 @@ export default function usePaginatedResult<T>(
     toRef(data, 'limit'),
     toRef(data, 'offset'),
   ], fetchResults);
-  watch([conditions], () => {
+
+  watch([conditions], debounce(() => {
     const doFetch = data.offset === 0;
     data.offset = 0;
     data.limit = limit;
     if (doFetch) fetchResults();
-  });
+  }, 500));
 
   if (dataObjectFilter !== undefined) {
     watch(dataObjectFilter, fetchResults, { deep: true });


### PR DESCRIPTION
Closes #1034 
Adding a debouce to `fetchResults` when conditions change ensures that the desired query when copying a url is fired second and eliminates the race condition. 
