### PR TITLE
Don't use ** to convert row to dict

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -634,7 +634,11 @@ async def get_submission(
         elif user.orcid in submission.viewers:
             permission_level = models.SubmissionEditorRole.viewer.value
         return schemas_submission.SubmissionMetadataSchema(
-            **submission.__dict__,
+            status=submission.status,
+            id=submission.id,
+            metadata_submission=submission.metadata_submission,
+            author_orcid=submission.author_orcid,
+            created=submission.created,
             author=schemas.User(**submission.author.__dict__),
             locked_by=schemas.User(**submission.locked_by.__dict__),
             permission_level=permission_level,

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -73,6 +73,7 @@ def do_ingest(function_limit, skip_annotation):
             # Copy persistent data that does not depend on ingest FK
             merge_download_artifact(ingest_db, prod_db.query(models.User))
             merge_download_artifact(ingest_db, prod_db.query(models.SubmissionMetadata))
+            merge_download_artifact(ingest_db, prod_db.query(models.SubmissionRole))
 
             # ingest data
             logger.info(


### PR DESCRIPTION
Partial Fix #1150 

Fix #1148 

Using `**` to pass `kwargs` proved to be unreliable, resulting in an inability to open submissions on the submission portal.

While testing, I noticed a bug that would wipe out submission roles on migration. In order to stop this, `SubmissionRole` is now carried over in the same way that `UserLogin`s and `SubmissionMetadata`s are. In order to fully fix that issue, I would propose re-running the migration.