### PR TITLE
Fix multiple submission editors issues

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -16,11 +16,14 @@ import {
   canEditSubmissionMetadata,
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
+import { api } from '../../../data/api';
 
 export default defineComponent({
   components: { SubmissionDocsLink },
   setup() {
     const formRef = ref();
+
+    const currentUserOrcid = ref('');
 
     function addContributor() {
       studyForm.contributors.push({
@@ -53,8 +56,9 @@ export default defineComponent({
       });
     });
 
-    onMounted(() => {
+    onMounted(async () => {
       formRef.value.validate();
+      currentUserOrcid.value = await api.myOrcid();
     });
 
     return {
@@ -69,6 +73,7 @@ export default defineComponent({
       isOwner,
       canEditSubmissionMetadata,
       orcidRequiredRules,
+      currentUserOrcid,
     };
   },
 });
@@ -203,6 +208,7 @@ export default defineComponent({
               v-model="contributor.orcid"
               :rules="orcidRequiredRules(i)"
               :hint="Definitions.contributorOrcid"
+              :disabled="currentUserOrcid === contributor.orcid"
               label="ORCID"
               outlined
               persistent-hint
@@ -252,7 +258,7 @@ export default defineComponent({
         </v-card>
         <v-btn
           icon
-          :disabled="!canEditSubmissionMetadata()"
+          :disabled="!isOwner() || currentUserOrcid === contributor.orcid"
           @click="studyForm.contributors.splice(i, 1)"
         >
           <v-icon>mdi-minus-circle</v-icon>

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -256,7 +256,7 @@ function reset() {
 }
 
 async function incrementalSaveRecord(id: string) {
-  if (!canEditSubmissionMetadata()) {
+  if (!canEditSampleMetadata()) {
     return;
   }
 


### PR DESCRIPTION
Close #824 

This addresses some feedback about the new permission system for the submission portal. In particular, it:

1. Fixes a bug that prevented users with "metadata contributor" roles from saving submissions.
2. Hardens "editor" permissions by preventing "editor"s from deleting themselves as a contributor for a submission. It also prevents them from changing their own ORCID or deleting other contributors, since this may cause issues if those contributors had permissions themselves.
3. Add form validation to prevent multiple contributors with the same ORCID iD.