### PR TITLE
Grow Study fixes

### DIFF
--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -136,11 +136,19 @@ export default defineComponent({
       .map((r) => ({
         ...r,
         name: r.annotations.title || r.name,
+        children: r.children?.map((c) => ({
+          ...c,
+          name: c.annotations.title || c.name,
+        })),
       })));
     const consortiumStudyResults = computed(() => Object.values(consortium.data.results.results)
       .map((r) => ({
         ...r,
         name: r.annotations.title || r.name,
+        children: r.children?.map((c) => ({
+          ...c,
+          name: c.annotations.title || c.name,
+        })),
       })));
 
     const loggedInUser = computed(() => typeof stateRefs.user.value === 'string');


### PR DESCRIPTION
Use annotation title for child studies if available.
Children studies whose parent isn't in the search results should only be included if they don't appear as a child in any other part study present in the search results.
You can check both issues by expanding `River Corridors Science Focus Area`. The correct title for the grow child study is `Creating the GROW...`. Also because grow appears here it should not appear as a top level study in the study results.
