### PR TITLE
Submission Permission fixes

### DIFF
--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -5,9 +5,10 @@ import {
   multiOmicsForm, multiOmicsFormValid, multiOmicsAssociations, templateChoiceDisabled, contextForm, canEditSubmissionMetadata,
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
+import SubmissionPermissionBanner from './SubmissionPermissionBanner.vue';
 
 export default defineComponent({
-  components: { SubmissionDocsLink },
+  components: { SubmissionDocsLink, SubmissionPermissionBanner },
   setup() {
     const formRef = ref();
 
@@ -40,6 +41,9 @@ export default defineComponent({
     <div class="text-h5">
       Information about the type of samples being submitted.
     </div>
+    <submission-permission-banner
+      v-if="!canEditSubmissionMetadata()"
+    />
     <v-form
       ref="formRef"
       v-model="multiOmicsFormValid"

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -17,9 +17,10 @@ import {
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
 import { api } from '../../../data/api';
+import SubmissionPermissionBanner from './SubmissionPermissionBanner.vue';
 
 export default defineComponent({
-  components: { SubmissionDocsLink },
+  components: { SubmissionDocsLink, SubmissionPermissionBanner },
   setup() {
     const formRef = ref();
 
@@ -115,6 +116,9 @@ export default defineComponent({
     <div class="text-h5">
       {{ NmdcSchema.$defs.Study.description }}
     </div>
+    <submission-permission-banner
+      v-if="!canEditSubmissionMetadata()"
+    />
     <v-form
       ref="formRef"
       v-model="studyFormValid"

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -167,7 +167,7 @@ export default defineComponent({
       <v-text-field
         v-model="studyForm.piOrcid"
         label="Principal Investigator ORCID"
-        :disabled="!isOwner()"
+        :disabled="!isOwner() || currentUserOrcid === studyForm.piOrcid"
         outlined
         :hint="Definitions.piOrcid"
         persistent-hint

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -25,6 +25,25 @@ export default defineComponent({
 
     const currentUserOrcid = ref('');
 
+    const permissionHelpText = ref([
+      {
+        title: 'Viewer',
+        description: 'Viewers can see all components of a submission, but cannot edit.',
+      },
+      {
+        title: 'Metadata Contributor',
+        description: 'Metadata contributors can view all components of a submission and can only edit the sample metadata information on the last step of the submission process.',
+      },
+      {
+        title: 'Editor',
+        description: 'Editors of a submission have full permission to edit every aspect of the submission with the exception of permission levels.',
+      },
+      {
+        title: 'Owner',
+        description: 'This level of permission is automatically assigned to the submission author and Principal Investigator. These users can edit every aspect of the submission.',
+      },
+    ]);
+
     function addContributor() {
       studyForm.contributors.push({
         name: '',
@@ -81,6 +100,7 @@ export default defineComponent({
       orcidRequiredRule,
       uniqueOrcidRule,
       currentUserOrcid,
+      permissionHelpText,
     };
   },
 });
@@ -260,7 +280,32 @@ export default defineComponent({
               outlined
               dense
               persistent-hint
-            />
+            >
+              <template #prepend-inner>
+                <v-tooltip
+                  bottom
+                  max-width="500px"
+                >
+                  <template #activator="{on, attrs}">
+                    <v-btn
+                      icon
+                      small
+                      v-bind="attrs"
+                      v-on="on"
+                    >
+                      <v-icon>mdi-help-circle</v-icon>
+                    </v-btn>
+                  </template>
+                  <div
+                    v-for="role in permissionHelpText"
+                    :key="role.title"
+                    class="pb-2"
+                  >
+                    <strong>{{ role.title }}: </strong><span>{{ role.description }}</span>
+                  </div>
+                </v-tooltip>
+              </template>
+            </v-select>
           </div>
         </v-card>
         <v-btn

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -17,9 +17,10 @@ import {
 } from '../store';
 import SubmissionContextShippingForm from './SubmissionContextShippingForm.vue';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
+import SubmissionPermissionBanner from './SubmissionPermissionBanner.vue';
 
 export default defineComponent({
-  components: { SubmissionContextShippingForm, SubmissionDocsLink },
+  components: { SubmissionContextShippingForm, SubmissionDocsLink, SubmissionPermissionBanner },
   setup() {
     const formRef = ref();
     const facilityEnum = NmdcSchema.$defs.ProcessingInstitutionEnum.enum.filter(
@@ -91,6 +92,9 @@ export default defineComponent({
     <div class="text-h5">
       Data and sample status
     </div>
+    <submission-permission-banner
+      v-if="!canEditSubmissionMetadata()"
+    />
     <v-form
       ref="formRef"
       v-model="contextFormValid"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -13,7 +13,6 @@ import {
   addressFormValid,
   BiosafetyLevels,
   canEditSubmissionMetadata,
-  validateAddressForm,
 } from '../store';
 import { addressToString } from '../store/api';
 import SubmissionContextShippingSummary from './SubmissionContextShippingSummary.vue';
@@ -72,7 +71,6 @@ export default defineComponent({
       expectedShippingDateString.value = addressForm.expectedShippingDate
         ? reformatDate(addressForm.expectedShippingDate)
         : '';
-      validateAddressForm();
     });
 
     return {
@@ -120,6 +118,7 @@ export default defineComponent({
       v-model="showAddressForm"
       scrollable
       width="1200"
+      eager
     >
       <template
         #activator="{ on, attrs }"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -13,6 +13,7 @@ import {
   addressFormValid,
   BiosafetyLevels,
   canEditSubmissionMetadata,
+  validateAddressForm,
 } from '../store';
 import { addressToString } from '../store/api';
 import SubmissionContextShippingSummary from './SubmissionContextShippingSummary.vue';
@@ -71,6 +72,7 @@ export default defineComponent({
       expectedShippingDateString.value = addressForm.expectedShippingDate
         ? reformatDate(addressForm.expectedShippingDate)
         : '';
+      validateAddressForm();
     });
 
     return {

--- a/web/src/views/SubmissionPortal/Components/SubmissionPermissionBanner.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionPermissionBanner.vue
@@ -1,13 +1,3 @@
-<script lang="ts">
-import { defineComponent } from '@vue/composition-api';
-
-export default defineComponent({
-  setup() {
-    return {};
-  },
-});
-</script>
-
 <template>
   <v-alert
     type="info"

--- a/web/src/views/SubmissionPortal/Components/SubmissionPermissionBanner.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionPermissionBanner.vue
@@ -1,0 +1,17 @@
+<script lang="ts">
+import { defineComponent } from '@vue/composition-api';
+
+export default defineComponent({
+  setup() {
+    return {};
+  },
+});
+</script>
+
+<template>
+  <v-alert
+    type="info"
+  >
+    Your current permission level for this submission does not allow editing of this page. Contact the submission author to request a change in permission level.
+  </v-alert>
+</template>

--- a/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
+++ b/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
@@ -8,9 +8,10 @@ import {
   canEditSubmissionMetadata,
 } from '../store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
+import SubmissionPermissionBanner from './SubmissionPermissionBanner.vue';
 
 export default defineComponent({
-  components: { SubmissionDocsLink },
+  components: { SubmissionDocsLink, SubmissionPermissionBanner },
   setup() {
     const templateListDisplayNames = computed(() => templateList.value
       .map((templateKey) => HARMONIZER_TEMPLATES[templateKey].displayName)
@@ -37,6 +38,9 @@ export default defineComponent({
     <div class="text-h5">
       Choose environment package for your data.
     </div>
+    <submission-permission-banner
+      v-if="!canEditSubmissionMetadata()"
+    />
     <v-radio-group
       v-model="packageName"
       class="my-6"

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -27,6 +27,7 @@ import {
 import FindReplace from './Components/FindReplace.vue';
 import SubmissionStepper from './Components/SubmissionStepper.vue';
 import SubmissionDocsLink from './Components/SubmissionDocsLink.vue';
+import SubmissionPermissionBanner from './Components/SubmissionPermissionBanner.vue';
 
 interface ValidationErrors {
   [error: string]: [number, number][],
@@ -87,7 +88,12 @@ const JGI_MG = 'jgi_mg';
 const JGT_MT = 'jgi_mt';
 
 export default defineComponent({
-  components: { FindReplace, SubmissionStepper, SubmissionDocsLink },
+  components: {
+    FindReplace,
+    SubmissionStepper,
+    SubmissionDocsLink,
+    SubmissionPermissionBanner,
+  },
 
   setup(_, { root }) {
     const harmonizerElement = ref();
@@ -486,6 +492,9 @@ export default defineComponent({
     class="d-flex flex-column fill-height"
   >
     <SubmissionStepper />
+    <submission-permission-banner
+      v-if="!canEditSampleMetadata()"
+    />
     <div class="d-flex flex-column px-2">
       <div class="d-flex align-center">
         <label

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -119,6 +119,27 @@ const contextFormValid = ref(false);
 const addressForm = reactive(clone(addressFormDefault));
 const addressFormValid = ref(false);
 
+function validateAddressForm() {
+  const requiredFieldsShipper = [
+    'name',
+    'email',
+    'line1',
+    'city',
+    'state',
+    'postalCode',
+  ];
+  let shipperValid = requiredFieldsShipper.every((key) => !!(addressForm.shipper as Record<string, any>)[key]);
+  shipperValid = shipperValid && /.+@.+\..+/.test(addressForm.shipper.email);
+  const requiredFields = [
+    'expectedShippingDate',
+    'sample',
+    'experimentalGoals',
+    'biosafetyLevel',
+  ];
+  const formFieldsValid = requiredFields.every((key) => !!(addressForm as Record<string, any>)[key]);
+  addressFormValid.value = formFieldsValid && shipperValid;
+}
+
 /**
  * Study Form Step
  */
@@ -352,4 +373,5 @@ export {
   isOwner,
   canEditSampleMetadata,
   canEditSubmissionMetadata,
+  validateAddressForm,
 };

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -213,15 +213,16 @@ const payloadObject: Ref<api.MetadataSubmission> = computed(() => ({
 
 function getPermissions(): Record<string, permissionLevelValues> {
   const permissions: Record<string, permissionLevelValues> = {};
-  if (studyForm.piOrcid) {
-    permissions[studyForm.piOrcid] = 'owner';
-  }
   studyForm.contributors.forEach((contributor) => {
     const { orcid, permissionLevel } = contributor;
     if (orcid && permissionLevel) {
       permissions[orcid] = permissionLevel;
     }
   });
+  // This should happen last to ensure the PI is an owner
+  if (studyForm.piOrcid) {
+    permissions[studyForm.piOrcid] = 'owner';
+  }
   return permissions;
 }
 

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -119,27 +119,6 @@ const contextFormValid = ref(false);
 const addressForm = reactive(clone(addressFormDefault));
 const addressFormValid = ref(false);
 
-function validateAddressForm() {
-  const requiredFieldsShipper = [
-    'name',
-    'email',
-    'line1',
-    'city',
-    'state',
-    'postalCode',
-  ];
-  let shipperValid = requiredFieldsShipper.every((key) => !!(addressForm.shipper as Record<string, any>)[key]);
-  shipperValid = shipperValid && /.+@.+\..+/.test(addressForm.shipper.email);
-  const requiredFields = [
-    'expectedShippingDate',
-    'sample',
-    'experimentalGoals',
-    'biosafetyLevel',
-  ];
-  const formFieldsValid = requiredFields.every((key) => !!(addressForm as Record<string, any>)[key]);
-  addressFormValid.value = formFieldsValid && shipperValid;
-}
-
 /**
  * Study Form Step
  */
@@ -373,5 +352,4 @@ export {
   isOwner,
   canEditSampleMetadata,
   canEditSubmissionMetadata,
-  validateAddressForm,
 };


### PR DESCRIPTION
Fix #1162 
Fix #939 ~~(temporary/non-ideal fix)~~

This PR addresses additional issues with assigning permissions from the UI and adds some UX enhancements like banners and tooltips.

### List of Changes

#### Don't Override PI Owner Role
If the same ORCID iD was used for the PI ORCID and as a contributor ORCID iD, then the permission level set at the contributor level had priority over the ideal PI level (`owner`). Now, priority is given to the `owner` role when building the request body to update the submission with new permissions.

#### Validate address without rendering form
~~This is a "fix" for #939. The address form now validates by investigating data in addition to through Vuetify's form validation. Vuetify's form validation was insufficient because the address form cannot be validated by it until it is opened. The previous workaround for this was to open the form, which would be validated upon render by Vuetify, and then close the form. Metadata Contributors are unable to do this, and would be stuck at that screen. The only workaround for those users would be to replace `/context` with `/samples` in the URL.~~

~~The reason this fix is not ideal is because it duplicates validation, so changes to validation rules for this form need to be applied in two different places.~~

The address form dialog now uses the [eager prop](https://vuetifyjs.com/en/api/v-dialog/#props-eager), which forces it to render and thus validate when it mounts. (thanks @marySalvi)

#### Add Permission Level Descriptions
A tooltip has been added to the Study form describing each permission level. 
![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/c5514bda-5d0e-4ab1-ab7f-2737413b10ed)

#### Add Banner for read-only views
If a user is presented with a read-only view due to insufficient permissions to edit the current form, a banner now appears informing the user of this.
![image](https://github.com/microbiomedata/nmdc-server/assets/7085625/d9fc32d8-f8b0-46d2-8cbb-4cc70d748518)

#### Prevent PI from changing their own ORCID
If the current user is the PI, don't allow them to edit the PI ORCID field on the study form and remove their permission.