### PR TITLE
Add submission delete endpoint

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -602,7 +602,7 @@ async def list_submissions(
     user: models.User = Depends(login_required),
     pagination: Pagination = Depends(),
 ):
-    query = db.query(SubmissionMetadata)
+    query = db.query(SubmissionMetadata).order_by(SubmissionMetadata.created.desc())
     try:
         await admin_required(user)
     except HTTPException:

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from starlette.requests import Request
@@ -726,6 +726,37 @@ async def update_submission(
         db.commit()
     crud.update_submission_lock(db, submission.id)
     return submission
+
+
+@router.delete(
+    "/metadata_submission/{id}",
+    tags=["metadata_submission"],
+    responses=login_required_responses,
+)
+async def delete_submission(
+    id: str,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(login_required),
+):
+    submission = db.query(SubmissionMetadata).get(id)
+    if submission is None:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    if not (user.is_admin or user.orcid in submission.owners):
+        raise HTTPException(403, detail="Must have access.")
+
+    has_lock = crud.try_get_submission_lock(db, submission.id, user.id)
+    if not has_lock:
+        raise HTTPException(
+            status_code=400,
+            detail="This submission is currently being edited by a different user.",
+        )
+
+    for role in submission.roles:
+        db.delete(role)
+    db.delete(submission)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.put("/metadata_submission/{id}/unlock")

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -752,7 +752,7 @@ async def delete_submission(
             detail="This submission is currently being edited by a different user.",
         )
 
-    for role in submission.roles:
+    for role in submission.roles:  # type: ignore
         db.delete(role)
     db.delete(submission)
     db.commit()


### PR DESCRIPTION
Fixes #1165 

* Adds a handler for `DELETE /api/metadata_submission/{id}` requests. I figured that only owners (or admins) should be able to delete submissions. I also erred on the side of caution in not allowing the delete if the submission is locked by someone. If you think that could be better let me know. 
* Sort of unrelated, but it would be really helpful to the Field Notes app if the submission list endpoint had a stable sort. I know there have been discussions in the past about full on sorting and filtering of submissions in the portal. But without getting into all that I thought it might be uncontroversial to just sort them by newest by default.