### PR TITLE
Fix navigation link URLs in "Resources" section

### DIFF
--- a/web/src/menus.ts
+++ b/web/src/menus.ts
@@ -1,3 +1,6 @@
+// Note: Each object in each `items` array represents a link in a dropdown menu.
+//       When defining a link for client-side routing, use the `to` property.
+//       When defining a link for server-side routing, use the `href` property.
 const Menus = [
   {
     label: 'About Us',
@@ -51,23 +54,23 @@ const Menus = [
     items: [
       {
         label: 'Data Standards',
-        to: 'https://microbiomedata.org/data-standards/',
+        href: 'https://microbiomedata.org/data-standards/',
       },
       {
         label: 'Bioinformatics Workflows',
-        to: 'https://microbiomedata.org/workflows/',
+        href: 'https://microbiomedata.org/workflows/',
       },
       {
         label: 'GitHub',
-        to: 'https://github.com/microbiomedata',
+        href: 'https://github.com/microbiomedata',
       },
       {
         label: 'Documentation',
-        to: 'https://microbiomedata.org/documentation/',
+        href: 'https://microbiomedata.org/documentation/',
       },
       {
         label: 'Data Management',
-        to: 'https://microbiomedata.org/data-management/',
+        href: 'https://microbiomedata.org/data-management/',
       },
     ],
   },


### PR DESCRIPTION
In this branch, I switched from using the `to` property (which appears to me to have been designed for client-side routing only) to the `href` property (which appears to me to have been designed for server-side routing only). I also added some documentation about that difference in an attempt to make it less likely that someone make the same mistake in the future.

Fixes https://github.com/microbiomedata/nmdc-server/issues/1195