### PR TITLE
Add `Field Notes Mobile App` link to navigation menu

### DIFF
--- a/web/src/menus.ts
+++ b/web/src/menus.ts
@@ -47,6 +47,10 @@ const Menus = [
         label: 'NMDC EDGE',
         href: 'https://nmdc-edge.org',
       },
+      {
+        label: 'Field Notes Mobile App',
+        href: 'https://microbiomedata.org/field-notes/',
+      },
     ],
   },
   {


### PR DESCRIPTION
In this branch, I added an item to the "Productions" menu in the navigation bar, that points to a web page about the upcoming NMDC Field Notes mobile app. The same menu item was added to the website earlier today, causing the Data Portal's navigation menu and the website's navigation menu to fall out of sync. This PR brings them back into sync.