### PR TITLE
Add `Newsletters` link to navigation menu (to match website)

### DIFF
--- a/web/src/menus.ts
+++ b/web/src/menus.ts
@@ -108,6 +108,10 @@ const Menus = [
         href: 'https://microbiomedata.org/events/',
       },
       {
+        label: 'Newsletters',
+        href: 'https://microbiomedata.org/newsletters/',
+      },
+      {
         label: 'Annual Reports',
         href: 'https://microbiomedata.org/annual_report/',
       },


### PR DESCRIPTION
In this branch, I added an item to the "News & Impact" menu in the navigation bar, that points to a web page containing an archive of NMDC Newsletter editions. The same menu item was added to the website earlier today, causing the Data Portal's navigation menu and the website's navigation menu to fall out of sync. This PR brings them back into sync.