### PR TITLE
Don't check empty ORCID iDs for uniqueness

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -69,7 +69,7 @@ export default defineComponent({
     };
 
     const uniqueOrcidRule = (idx: number) => (v: string) => {
-      if (idx > studyForm.contributors.length) return true;
+      if (idx > studyForm.contributors.length || !v) return true;
       const existingOrcids = new Set(studyForm.contributors.filter((contributor, contributorListIndex) => idx !== contributorListIndex).map((contributor) => contributor.orcid));
       return !existingOrcids.has(v) || 'ORCID iDs must be unique';
     };


### PR DESCRIPTION
Fix #1202
Fix microbiomedata/issues/issues/573

Previously if 2 contributors were added to the Study form of a submission and no ORCID iD was provided for either, the form wouldn't validate since those 2 contributors had the same ORCID. Now, empty ORCID fields are not checked for uniqueness.

To reproduce in prod:
1. Create a new submission. 
2. On the study form, add 2 contributors and fill in the name and Credit Role fields for each. 
3. Observe that you cannot go to the next page. Clicking into one of the blank ORCID fields will reveal the validation error

To test these changes (locally or in dev once this PR is merged):

1. Create a new submission. 
2. On the study form, add 2 contributors and fill in the name and Credit Role fields for each. 
3. Make sure you can navigate to the next page using the UI


