### PR TITLE
Fix column order in XLSX export

### DIFF
--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -453,36 +453,42 @@ export class HarmonizerApi {
     this.dh.hot.render();
   }
 
-  getSlot(slotName: string) {
+  getSlot(slotName: string, className: string) {
+    // If this slot has been fully materialized into the class's attributes, return that
+    const classAttributes = this.schema.classes?.[className]?.attributes;
+    if (classAttributes && slotName in classAttributes) {
+      return classAttributes[slotName];
+    }
+    // Otherwise return the top-level slot definition
     return this.schema.slots[slotName];
   }
 
-  getSlotRank(slotName: string) {
-    const slot = this.getSlot(slotName);
+  getSlotRank(slotName: string, className: string) {
+    const slot = this.getSlot(slotName, className);
     if (!slot) {
       return 9999;
     }
     return slot.rank;
   }
 
-  getSlotGroupRank(slotName: string) {
-    const slot = this.getSlot(slotName);
+  getSlotGroupRank(slotName: string, className: string) {
+    const slot = this.getSlot(slotName, className);
     if (!slot || !slot.slot_group) {
       return 9999;
     }
-    return this.getSlotRank(slot.slot_group);
+    return this.getSlotRank(slot.slot_group, className);
   }
 
   getOrderedAttributeNames(className: string): string[] {
     return Object.keys(this.schema.classes[className].attributes).sort(
       (a, b) => {
-        const aSlotGroupRank = this.getSlotGroupRank(a);
-        const bSlotGroupRank = this.getSlotGroupRank(b);
+        const aSlotGroupRank = this.getSlotGroupRank(a, className);
+        const bSlotGroupRank = this.getSlotGroupRank(b, className);
         if (aSlotGroupRank !== bSlotGroupRank) {
           return aSlotGroupRank - bSlotGroupRank;
         }
-        const aSlotRank = this.getSlotRank(a);
-        const bSlotRank = this.getSlotRank(b);
+        const aSlotRank = this.getSlotRank(a, className);
+        const bSlotRank = this.getSlotRank(b, className);
         return aSlotRank - bSlotRank;
       },
     );


### PR DESCRIPTION
Fixes #1205 

Despite what I initially guessed in the issue, this was actually a consequence of a recent change to the submission schema. Previously there was some confusion in the submission schema around [materializing](https://linkml.io/linkml/schemas/derived-models.html#materializing-a-derived-model) slot definitions into class `attributes` vs into the top-level slot definitions. That has been fixed, but this code where slots get sorted was originally written in a way to _expect_ that buggy submission schema behavior. These changes fix that by first looking for a slot definition in the context of a class before falling back to looking at top-level definitions. 