### PR TITLE
Refrain from reporting "0 results" and "0 samples" while loading data

### DIFF
--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -203,7 +203,10 @@ export default defineComponent({
 
 <template>
   <div>
-    <SearchSidebar :results-count="biosample.data.results.count" />
+    <SearchSidebar
+      :results-count="biosample.data.results.count"
+      :is-loading="biosample.loading.value"
+    />
     <v-main>
       <v-progress-linear
         v-show="biosample.loading.value || study.loading.value"
@@ -614,8 +617,13 @@ export default defineComponent({
               <div class="ma-3">
                 <div class="d-flex align-center">
                   <v-card-title class="grow py-0">
-                    {{ biosample.data.results.count }}
-                    {{ biosample.data.results.count === 1 ? 'Sample' : 'Samples' }}
+                    <span v-if="biosample.loading.value">
+                      Samples
+                    </span>
+                    <span v-else>
+                      {{ biosample.data.results.count }}
+                      {{ biosample.data.results.count === 1 ? 'Sample' : 'Samples' }}
+                    </span>
                   </v-card-title>
                   <v-spacer />
                   <div

--- a/web/src/views/Search/SearchSidebar.vue
+++ b/web/src/views/Search/SearchSidebar.vue
@@ -102,6 +102,10 @@ export default defineComponent({
       type: Number,
       default: 0,
     },
+    isLoading: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   setup() {
@@ -198,7 +202,10 @@ export default defineComponent({
     </ConditionChips>
 
     <div class="font-weight-bold text-subtitle-2 primary--text mx-3">
-      Found {{ resultsCount }} results.
+      <span v-if="isLoading">
+        Loading results...
+      </span>
+      <span v-else>Found {{ resultsCount }} results.</span>
     </div>
 
     <v-divider class="my-3" />


### PR DESCRIPTION
#### Old behavior

Previously, while sample data was being loaded, the upper left of the page would say "Found 0 results". Similarly, the top of the "Samples" panel would say "0 Samples".

<img width="1004" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/d581a8ee-78a2-46ad-9bab-94c4c9bc1ed8">

#### New behavior

In this PR, I made it so that, while sample data is being loaded, the message in the upper left says "Loading results..." and the top of the "Samples" panel doesn't report a number.

<img width="1002" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/23f7e7b2-422c-4107-adb4-b58a0cbec757">

#### Side note

> Note: The horizontal misalignment of the "Samples" (or "x Samples") heading with respect to the "Consortia" and "Studies" headings is not part of this PR (neither introduced in this PR nor fixed in this PR).