### PR TITLE
Filter out irrelevant omics_processing results

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -192,11 +192,13 @@ async def search_biosample(
     results = pagination.response(
         crud.search_biosample(db, query.conditions, data_object_filter), insert_selected
     )
-    biosample_ids = [b.id for b in results["results"]]
+    biosample_ids = [b.id for b in results["results"]]  # type: ignore
     omics_results = crud.search_omics_processing_for_biosamples(db, query.conditions, biosample_ids)
     omics_ids = set([str(o.id) for o in omics_results.all()])
     for biosample in results["results"]:
-        biosample.omics_processing = [op for op in biosample.omics_processing if op.id in omics_ids]
+        biosample.omics_processing = [  # type: ignore
+            op for op in biosample.omics_processing if op.id in omics_ids  # type: ignore
+        ]
     return results
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -189,9 +189,15 @@ async def search_biosample(
                     da.selected = schemas.DataObject.is_selected(workflow, da, data_object_filter)
         return biosample
 
-    return pagination.response(
+    results = pagination.response(
         crud.search_biosample(db, query.conditions, data_object_filter), insert_selected
     )
+    biosample_ids = [b.id for b in results["results"]]
+    omics_results = crud.search_omics_processing_for_biosamples(db, query.conditions, biosample_ids)
+    omics_ids = set([str(o.id) for o in omics_results.all()])
+    for biosample in results["results"]:
+        biosample.omics_processing = [op for op in biosample.omics_processing if op.id in omics_ids]
+    return results
 
 
 @router.post(

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -29,6 +29,7 @@ from nmdc_server.models import (
     User,
 )
 from nmdc_server.pagination import Pagination
+from nmdc_server.table import Table
 
 router = APIRouter()
 
@@ -192,13 +193,21 @@ async def search_biosample(
     results = pagination.response(
         crud.search_biosample(db, query.conditions, data_object_filter), insert_selected
     )
-    biosample_ids = [b.id for b in results["results"]]  # type: ignore
-    omics_results = crud.search_omics_processing_for_biosamples(db, query.conditions, biosample_ids)
-    omics_ids = set([str(o.id) for o in omics_results.all()])
-    for biosample in results["results"]:
-        biosample.omics_processing = [  # type: ignore
-            op for op in biosample.omics_processing if op.id in omics_ids  # type: ignore
+    if any(
+        [
+            condition.table == Table.omics_processing or condition.table == Table.gene_function
+            for condition in query.conditions
         ]
+    ):
+        biosample_ids = [b.id for b in results["results"]]  # type: ignore
+        omics_results = crud.search_omics_processing_for_biosamples(
+            db, query.conditions, biosample_ids
+        )
+        omics_ids = set([str(o.id) for o in omics_results.all()])
+        for biosample in results["results"]:
+            biosample.omics_processing = [  # type: ignore
+                op for op in biosample.omics_processing if op.id in omics_ids  # type: ignore
+            ]
     return results
 
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -183,6 +183,10 @@ def search_omics_processing(db: Session, conditions: List[query.ConditionSchema]
     return query.OmicsProcessingQuerySchema(conditions=conditions).execute(db)
 
 
+def search_omics_processing_for_biosamples(db: Session, conditions: List[query.ConditionSchema], biosample_ids: List[UUID]) -> Query:
+    return query.OmicsProcessingQuerySchema(conditions=conditions).omics_processing_for_biosample_ids(db, biosample_ids)
+
+
 def facet_omics_processing(
     db: Session, attribute: str, conditions: List[query.ConditionSchema]
 ) -> query.FacetResponse:

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -183,8 +183,12 @@ def search_omics_processing(db: Session, conditions: List[query.ConditionSchema]
     return query.OmicsProcessingQuerySchema(conditions=conditions).execute(db)
 
 
-def search_omics_processing_for_biosamples(db: Session, conditions: List[query.ConditionSchema], biosample_ids: List[UUID]) -> Query:
-    return query.OmicsProcessingQuerySchema(conditions=conditions).omics_processing_for_biosample_ids(db, biosample_ids)
+def search_omics_processing_for_biosamples(
+    db: Session, conditions: List[query.ConditionSchema], biosample_ids: List[UUID]
+) -> Query:
+    return query.OmicsProcessingQuerySchema(
+        conditions=conditions
+    ).omics_processing_for_biosample_ids(db, biosample_ids)
 
 
 def facet_omics_processing(

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -707,6 +707,17 @@ class OmicsProcessingQuerySchema(BaseQuerySchema):
     def table(self) -> Table:
         return Table.omics_processing
 
+    def omics_processing_for_biosample_ids(self, db: Session, biosample_ids):
+        # Do the normal query with the conditions
+        query = self.execute(db)
+        # Join to association table to get biosample IDs
+        query_by_sample_ids = (
+            query.join(models.biosample_input_association)
+            # Filter to only include bisoample ids in the given list
+            .filter(models.biosample_input_association.c.biosample_id.in_(biosample_ids))
+        )
+        return query_by_sample_ids
+
 
 class BiosampleQuerySchema(BaseQuerySchema):
     data_object_filter: List[DataObjectFilter] = []


### PR DESCRIPTION
Fix #1176 

Adds some post-query logic the to `/biosample/search` endpoint that filters out `OmicsProcessing` records from the results.

The logic incurs the overhead of an additional database query, in order to determine which omics processing records are valid given the current filter conditions. Then each result populated from the [lazy loading](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#lazy-loading) is checked against the filtered list.

We only add this penalty if the search conditions contain at least one filter for the `omics_processing` or `gene_function` tables. Other filters apply at the study and biosample level, and would not apply to omics processing records. Below is some data on the performance impact when applying a KEGG filter for various page sizes.

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Page Size | f1 | f2 | f3 | f_avg | r1 | r2 | r3 | r_avg | % of total response time
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
15 | 0.081 | 0.072 | 0.074 | 0.07566666667 | 3.52 | 3.43 | 3.13 | 3.36 | 2.417465389
25 | 0.087 | 0.092 | 0.085 | 0.088 | 6.1 | 5.91 | 6.63 | 6.213333333 | 1.327300151
50 | 0.061 | 0.06 | 0.068 | 0.063 | 11.93 | 12.3 | 11.5 | 11.91 | 0.547826087

fn = time spent in the new logic for the nth test
rn = time spent in the entire API endpoint function for the nth test
f_avg = average time spent in the new logic
r_avg = average time spent overall for the response 

As expected, when applying a KEGG filter, we do incur some performance penalty. Interestingly (or maybe not), the penalty decreases (as a percentage of total response time) as the page size increases. This is likely due to the fact that serialization of biosamples is very expensive and slow.
