### PR TITLE
Fix spelling error and hyperlink formatting

### DIFF
--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -8,14 +8,12 @@
   >
     <span class="title">Announcement: </span>The NMDC will be replacing legacy identifiers with
     <a href="https://microbiomedata.github.io/nmdc-schema/identifiers/#ids-minted-for-use-within-nmdc">
-      NMDC persistent identifiers
-    </a> on April 22, 2024 for studies,
+      NMDC persistent identifiers</a> on April 22, 2024 for studies,
     samples, analysis workflows, and files. Additionally, annotation will be reprocessed for legacy metagenomes
     and metatranscriptomes, along with binning for metagenomes. Legacy metaproteomics datasets will be reprocessed
     using the new metagenome annotations. For information on mapping between old and new identifiers please refer
     to
     <a href="https://microbiomedata.github.io/nmdc-schema/identifiers/#reuse-vs-minting-new-ids">
-      this documentation
-    </a>. If you have questions please contact support@microbiomedata.org.
+      this documentation</a>. If you have questions please contact support@microbiomedata.org.
   </v-banner>
 </template>

--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -6,7 +6,13 @@
     icon="mdi-information"
     class="ma-4"
   >
-    <span class="title">Announcement: </span>The NMDC will be replacing legacy identifiers with
+    <span
+      class="title"
+      style="line-height: inherit"
+    >
+      Announcement:
+    </span>
+    The NMDC will be replacing legacy identifiers with
     <a href="https://microbiomedata.github.io/nmdc-schema/identifiers/#ids-minted-for-use-within-nmdc">
       NMDC persistent identifiers</a> on April 22, 2024 for studies,
     samples, analysis workflows, and files. Additionally, annotation will be reprocessed for legacy metagenomes

--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -6,7 +6,7 @@
     icon="mdi-information"
     class="ma-4"
   >
-    <span class="title">Anouncement: </span>The NMDC will be replacing legacy identifiers with
+    <span class="title">Announcement: </span>The NMDC will be replacing legacy identifiers with
     <a href="https://microbiomedata.github.io/nmdc-schema/identifiers/#ids-minted-for-use-within-nmdc">
       NMDC persistent identifiers
     </a> on April 22, 2024 for studies,


### PR DESCRIPTION
This PR branch includes three changes:
- A spelling error is fixed:
  ```diff
  - Anouncement
  + Announcement
  ```
- Hyperlinks are no longer followed by an underlined space
- Makes the line height consistent throughout the banner (previously, first line differed)

Before:

<img width="567" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/8a002bee-0d97-412f-a0c9-e699d3a8b8ca">

After:

<img width="567" alt="image" src="https://github.com/microbiomedata/nmdc-server/assets/134325062/2f6ac2de-bcf1-4e70-9556-1ae1bc7a8abc">
