### PR TITLE
Fix for bug where studies would not scroll to return to the top of the page when revisited

### DIFF
--- a/web/src/plugins/router.ts
+++ b/web/src/plugins/router.ts
@@ -104,6 +104,7 @@ const router = new VueRouter({
       component: UserPage,
     },
   ],
+  scrollBehavior: () => ({ x: 0, y: 0 }),
   parseQuery,
   stringifyQuery,
 });


### PR DESCRIPTION
Addressing [this issue](https://github.com/microbiomedata/nmdc-server/issues/771)

We've added a scroll behavior line of code to return to the top of the study page when revisiting that page.