### PR TITLE
Add nmdc-server CLI subcommand for loading local database with production data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,5 @@ __pycache__/
 .idea/
 .venv
 vetur.config.js
-*.sql
 **.local**
 build/**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: postgres:13
     volumes:
       - app-db-data:/var/lib/postgresql/data/pgdata
+      - ./scripts/docker/init.sql:/docker-entrypoint-initdb.d/init.sql
     env_file:
       - .docker-env
     environment:
@@ -20,6 +21,8 @@ services:
       - "-c"
       # Our MGA ingest makes some *very* large transactions
       - "max_wal_size=2GB"
+    ports:
+      - "5432:5432"
 
   worker:
     image: ghcr.io/microbiomedata/nmdc-server/worker:main

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,19 +1,18 @@
 # Development Setup
-## __Docker__
 
-* install docker and docker-compose
+## Docker
 
-### Configuration
+Install docker and docker-compose.
+
+## Configuration
 
 ```bash
 cp .env.example .env
 ```
 
-Edit values in `.env` to point to existing postgresql databases.
+Edit values in `.env` to point to existing postgresql databases. See `nmdc_server/config.py` for all configuration variables.  Variable names in `.env` should be all uppercase and prefixed with `NMDC_`.
 
-### OAuth setup
-
-See `nmdc_server/config` for configuration.  Env variable names begin with `NMDC_`.
+## OAuth setup
 
 1. Create an OrcID account at [orcid.org](https://orcid.org).
 1. Create an Application via the OrcID [developer tools](https://orcid.org/developer-tools) page.
@@ -29,7 +28,33 @@ NMDC_CLIENT_SECRET=changeme
 NMDC_HOST=http://localhost:8080
 ```
 
-### Running the server
+# Load production data
+
+The `nmdc-server` CLI has a `load-db` subcommand which populates your local database using a nightly production backup. These backups are stored on NERSC. You must have NERSC credentials to use this subcommand.
+
+First use NERSC's `sshproxy` [tool](https://docs.nersc.gov/connect/mfa/#sshproxy) to generate an ssh key.
+
+```bash
+sshproxy.sh -u <nersc_username>
+```
+
+Then run the `load-db` subcommand from a `backend` container, mounting the ssh key.
+
+```bash
+docker compose run \
+  --rm \
+  -v ~/.ssh/nersc:/tmp/nersc \
+  backend \
+  nmdc-server load-db -u <nersc_username>
+```
+
+To see all CLI options run:
+
+```bash
+nmdc-server load-db --help
+```
+
+# Running the server
 
 ```bash
 docker-compose up -d
@@ -39,7 +64,7 @@ View main application at `http://localhost:8080/` and the swagger page at `http:
 
 
 
-## __Outside Docker__
+## Outside Docker
 
 ```bash
 # Start only the service dependencies.
@@ -61,7 +86,7 @@ View swagger page at `http://localhost:8000/api/docs`.
 
 # Running ingest
 
-You need an active SSH tunnel connection to nersc attached to the compose network.  After running docker-compose up, run this container.
+You need an active SSH tunnel connection to NERSC attached to the compose network.  After running docker-compose up, run this container.
 
 If you haven't already, [set up MFA on your NERSC account](https://docs.nersc.gov/connect/mfa/) (it's required for SSHing in).
 
@@ -111,7 +136,7 @@ yarn serve
 tox
 ```
 
-## Generating new migrations
+# Generating new migrations
 
 ```bash
 # Autogenerate a migration diff from the current HEAD
@@ -130,23 +155,6 @@ docker-compose run backend psql -c "create database nmdc_a;" -d postgres
 docker-compose run backend alembic -c nmdc_server/alembic.ini upgrade head
 # Autogenerate a migration diff from the current HEAD
 docker-compose run backend alembic -c nmdc_server/alembic.ini revision --autogenerate
-```
-
-# Postgres import and export
-
-You can find existing database exports in Notion.
-
-```bash
-# export, and
-docker-compose run backend bash -c 'pg_dump nmdc_a > /app/nmdc_server/nmdc_a.sql'
-
-# import -- starting from an EMPTY database with DB running
-docker-compose down -v
-docker-compose up -d db
-docker-compose run backend psql -c "create database nmdc_a;" -d postgres
-cp downloads/nmdc_a.sql nmdc_server/nmdc_a.sql
-docker-compose run backend bash -c 'psql nmdc_a < /app/nmdc_server/nmdc_a.sql'
-docker-compose run backend nmdc-server migrate # stamp the migration db
 ```
 
 # Developing with the shell

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,6 +54,14 @@ To see all CLI options run:
 nmdc-server load-db --help
 ```
 
+**Note**: if you already have a local database set up, the first time you attempt to load from a production backup you may see an error about a missing `nmdc_data_reader` role. If you see this error, run the following command to remove existing docker volumes:
+
+```bash
+docker compose down -v
+```
+
+This should only need to be done once. When the `db` service starts up again (including via running the `load-db` command), the necessary roles and databases will be created automatically.
+
 # Running the server
 
 ```bash

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -238,12 +238,13 @@ def load_db(key_file, user, host, list_backups, backup_file):
 
         backup_file = dumps[-1]
 
-    click.echo(f"Downloading {backup_file}...")
-    subprocess.run(
-        ["scp", "-i", key_file, f"{user}@{host}:{pgdump_dir}/{backup_file}", "."],
-        check=True,
-        encoding="utf-8",
-    )
+    if not (Path(os.getcwd()) / backup_file).exists():
+        click.echo(f"Downloading {backup_file}...")
+        subprocess.run(
+            ["scp", "-i", key_file, f"{user}@{host}:{pgdump_dir}/{backup_file}", "."],
+            check=True,
+            encoding="utf-8",
+        )
 
     click.echo(f"Restoring from {backup_file}...")
     settings = Settings()

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -189,8 +189,10 @@ def shell(print_sql: bool, script: Optional[Path]):
 @click.option(
     "-f",
     "--backup-file",
-    help=("Filename in NERSC's backup directory to load. "
-          "If not provided, the latest backup will be loaded."),
+    help=(
+        "Filename in NERSC's backup directory to load. "
+        "If not provided, the latest backup will be loaded."
+    ),
 )
 @click.option(
     "-k",

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -1,4 +1,7 @@
 import logging
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -177,3 +180,88 @@ def shell(print_sql: bool, script: Optional[Path]):
         c.InteractiveShellApp.file_to_run = script
 
     start_ipython(argv=[], config=c)
+
+
+@cli.command()
+@click.option("-u", "--user", help="NERSC username", default=os.getenv("USER"), show_default=True)
+@click.option("-h", "--host", help="NERSC host", default="dtn01.nersc.gov", show_default=True)
+@click.option("--list-backups", is_flag=True, help="Only list available backup filenames")
+@click.option(
+    "-f",
+    "--backup-file",
+    help="Filename in NERSC's backup directory to load. If not provided, the latest backup will be loaded.",
+)
+@click.option(
+    "-k",
+    "--key-file",
+    default="/tmp/nersc",
+    show_default=True,
+    help="Path to NERSC SSH key file within Docker container. Use if not using standard mounting.",
+)
+def load_db(key_file, user, host, list_backups, backup_file):
+    """Load a local database from a production backup on NERSC."""
+    pgdump_dir = "/global/cfs/cdirs/m3408/pgdump"
+
+    if list_backups or not backup_file:
+        click.echo("Finding latest production backups...")
+        proc = subprocess.run(
+            [
+                "ssh",
+                "-i",
+                key_file,
+                "-o",
+                "StrictHostKeyChecking=no",
+                f"{user}@{host}",
+                f'find {pgdump_dir} -type f -iname "*pg_main-prod*.dump" -printf "%f\n"',
+            ],
+            capture_output=True,
+            encoding="utf-8",
+        )
+        if proc.returncode != 0:
+            click.echo("Error finding backups:")
+            print(proc.stderr)
+            sys.exit(1)
+
+        dumps = sorted(proc.stdout.splitlines())
+        if list_backups:
+            click.echo("Available backups:")
+            for dump in dumps:
+                click.echo(dump)
+            return
+
+        if not dumps:
+            click.echo("No backups found")
+            sys.exit(1)
+
+        backup_file = dumps[-1]
+
+    click.echo(f"Downloading {backup_file}...")
+    subprocess.run(
+        ["scp", "-i", key_file, f"{user}@{host}:{pgdump_dir}/{backup_file}", "."],
+        check=True,
+        encoding="utf-8",
+    )
+
+    click.echo(f"Restoring from {backup_file}...")
+    settings = Settings()
+    # Use `Popen.communicate()` instead of `run()` to avoid buffering output
+    proc = subprocess.Popen(
+        [
+            "pg_restore",
+            "--dbname",
+            settings.current_db_uri,
+            "--clean",
+            "--if-exists",
+            "--verbose",
+            "--single-transaction",
+            backup_file,
+        ],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        encoding="utf-8",
+    )
+    proc.communicate()
+    if proc.returncode != 0:
+        sys.exit(1)
+
+    click.secho(f"\nSuccessfully loaded {settings.current_db_uri}", fg="green")

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -189,7 +189,8 @@ def shell(print_sql: bool, script: Optional[Path]):
 @click.option(
     "-f",
     "--backup-file",
-    help="Filename in NERSC's backup directory to load. If not provided, the latest backup will be loaded.",
+    help=("Filename in NERSC's backup directory to load. "
+          "If not provided, the latest backup will be loaded."),
 )
 @click.option(
     "-k",
@@ -245,7 +246,7 @@ def load_db(key_file, user, host, list_backups, backup_file):
     click.echo(f"Restoring from {backup_file}...")
     settings = Settings()
     # Use `Popen.communicate()` instead of `run()` to avoid buffering output
-    proc = subprocess.Popen(
+    open_proc = subprocess.Popen(
         [
             "pg_restore",
             "--dbname",
@@ -260,8 +261,8 @@ def load_db(key_file, user, host, list_backups, backup_file):
         stderr=sys.stderr,
         encoding="utf-8",
     )
-    proc.communicate()
-    if proc.returncode != 0:
+    open_proc.communicate()
+    if open_proc.returncode != 0:
         sys.exit(1)
 
     click.secho(f"\nSuccessfully loaded {settings.current_db_uri}", fg="green")

--- a/prestart.sh
+++ b/prestart.sh
@@ -1,17 +1,15 @@
 #!/bin/sh
 set -e
 
+# This script is run before the server application starts by the tiangolo/uvicorn-gunicorn
+# image. See: https://github.com/tiangolo/uvicorn-gunicorn-docker#custom-appprestartsh
+
 export PGUSER PGPASSWORD PGDATABASE PGHOST POSTGRES_URI
 
+# Wait for the database to be ready
 while ! PGDATABASE=postgres psql --quiet -c "select * from user" ; do
     sleep 1;
 done
 
-echo 'Creating and migrating database'
-# in spin the database already exists
-PGDATABASE=postgres psql -c "create database nmdc_a;" || true
-
-
-PGDATABASE=postgres psql -c "create database nmdc_b;" || true
-
+# Apply pending alembic migrations
 nmdc-server migrate

--- a/prestart.sh
+++ b/prestart.sh
@@ -11,5 +11,12 @@ while ! PGDATABASE=postgres psql --quiet -c "select * from user" ; do
     sleep 1;
 done
 
+echo 'Creating and migrating database'
+# in spin the database already exists
+PGDATABASE=postgres psql -c "create database nmdc_a;" || true
+
+
+PGDATABASE=postgres psql -c "create database nmdc_b;" || true
+
 # Apply pending alembic migrations
 nmdc-server migrate

--- a/scripts/docker/init.sql
+++ b/scripts/docker/init.sql
@@ -1,0 +1,4 @@
+create role nmdc_data_reader;
+
+create database nmdc_a;
+create database nmdc_b;


### PR DESCRIPTION
Fixes #1228 

### Summary

* The main addition is the new `click` subcommand named `load-db` in `nmdc_server/cli.py`. This subcommand is designed to 1) get a list of available backups on NERSC in the `/global/cfs/cdirs/m3408/pgdump` directory, 2) make a local copy of the latest one (or a specified one), 3) run `pg_restore` on the _local_ database using the copied backup.
* I wanted to make sure that this workflow worked:
  1. Completely destroy entire local Postgres database (or perhaps this is the first time ever running `nmdc-server`)
  2. Run the new `load-db` command to populate the database
  3. Run `docker compose up` to start the whole stack

  The issue I ran into was that the `nmdc_a` and `nmdc_b` databases are currently being created in the script (`prestart.sh`) that runs just before the web server application starts. This means that they would not be created yet at step 2 above. Additionally, restoring from the production backup requires the `nmdc_data_reader` role to be present; currently that has to be created manually. 

  In these changes both issues are resolved by adding `scripts/docker/init.sql` and mounting it into the `/docker-entrypoint-initdb.d` directory of the Postgres container. (See also: https://github.com/docker-library/docs/tree/master/postgres#initialization-scripts). This ensures that the database is properly initialized, even when started for the first time outside of the rest of the stack. 
* I updated `docs/development.md` to document the new subcommand and remove the old outdated information.