### PR TITLE
Update banner to indicate new re-ID-ing date

### DIFF
--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -11,14 +11,14 @@
     >
       Announcement:
     </span>
-    The NMDC will be replacing legacy identifiers with
+    During the week of May 13, 2024, the NMDC will be replacing legacy identifiers with
     <a href="https://microbiomedata.github.io/nmdc-schema/identifiers/#ids-minted-for-use-within-nmdc">
-      NMDC persistent identifiers</a> on May 1, 2024 for studies,
+      NMDC persistent identifiers</a> for studies,
     samples, analysis workflows, and files. Additionally, annotation will be reprocessed for legacy metagenomes
     and metatranscriptomes, along with binning for metagenomes. Legacy metaproteomics datasets will be reprocessed
-    using the new metagenome annotations. For information on mapping between old and new identifiers please refer
+    using the new metagenome annotations. For information on mapping between old and new identifiers, please refer
     to
     <a href="https://microbiomedata.github.io/nmdc-schema/identifiers/#reuse-vs-minting-new-ids">
-      this documentation</a>. If you have questions please contact support@microbiomedata.org.
+      this documentation</a>. If you have questions, please contact support@microbiomedata.org.
   </v-banner>
 </template>


### PR DESCRIPTION
This branch is based upon the most recent release (i.e. the commit tagged `v0.20.0`) instead of being based upon the tip of the `main` branch.