### PR TITLE
Allow Github issue creation to track all IDs

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -796,20 +796,15 @@ def create_github_issue(submission, user):
         numsamples = max(numsamples, len(sampledata[key]))
 
     # some variable data to supply depending on if data has been generated or not
-    data_ids = []
-    if contextform["dataGenerated"]:
-        data_ids = [
-            "NCBI ID: " + multiomicsform["NCBIBioProjectId"],
-            "GOLD ID: " + multiomicsform["GOLDStudyId"],
-            "Alternative IDs/Names: " + ", ".join(multiomicsform["alternativeNames"]),
-        ]
-
-    else:
-        data_ids = [
-            "JGI IDs: " + multiomicsform["JGIStudyId"],
-            "EMSL IDs: " + multiomicsform["studyNumber"],
-            "Alternative IDs/Names: " + ", ".join(multiomicsform["alternativeNames"]),
-        ]
+    id_dict = {'NCBI ID: ':multiomicsform["NCBIBioProjectId"],
+               'GOLD ID: ':multiomicsform["GOLDStudyId"],
+               'JGI ID: ':multiomicsform["JGIStudyId"],
+               'EMSL ID: ':multiomicsform["studyNumber"],
+               'Alternative IDs: ':", ".join(multiomicsform["alternativeNames"])}
+    valid_ids = []
+    for key,value in id_dict.items():
+        if str(value) != "":
+            valid_ids.append(key + value)
 
     # assemble the body of the API request
     body_lis = [

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -796,13 +796,15 @@ def create_github_issue(submission, user):
         numsamples = max(numsamples, len(sampledata[key]))
 
     # some variable data to supply depending on if data has been generated or not
-    id_dict = {'NCBI ID: ':multiomicsform["NCBIBioProjectId"],
-               'GOLD ID: ':multiomicsform["GOLDStudyId"],
-               'JGI ID: ':multiomicsform["JGIStudyId"],
-               'EMSL ID: ':multiomicsform["studyNumber"],
-               'Alternative IDs: ':", ".join(multiomicsform["alternativeNames"])}
+    id_dict = {
+        "NCBI ID: ": multiomicsform["NCBIBioProjectId"],
+        "GOLD ID: ": multiomicsform["GOLDStudyId"],
+        "JGI ID: ": multiomicsform["JGIStudyId"],
+        "EMSL ID: ": multiomicsform["studyNumber"],
+        "Alternative IDs: ": ", ".join(multiomicsform["alternativeNames"]),
+    }
     valid_ids = []
-    for key,value in id_dict.items():
+    for key, value in id_dict.items():
         if str(value) != "":
             valid_ids.append(key + value)
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -817,7 +817,7 @@ def create_github_issue(submission, user):
         f"Data types: {omicsprocessingtypes}",
         f"Sample type:{sampletype}",
         f"Number of samples:{numsamples}",
-    ] + data_ids
+    ] + valid_ids
     body_string = " \n ".join(body_lis)
     payload_dict = {
         "title": f"NMDC Submission: {submission.id}",


### PR DESCRIPTION
This PR is to update the github issue creation. 
Previously I had misunderstood that the IDs needed would be either JGI/EMSL OR Gold/NCBI but we want to track all of them.

This change checks to see if these ID fields are populated and if they are it adds them to the issue creation.