### PR TITLE
Change "Done" to "Submitted"

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -923,7 +923,7 @@ export default defineComponent({
             >
               <span v-if="status === submissionStatus.SubmittedPendingReview || submitCount">
                 <v-icon>mdi-check-circle</v-icon>
-                Done
+                Submitted
               </span>
               <span v-else>
                 3. Submit


### PR DESCRIPTION
This PR changes the wording on the Submit button in the harmonizer view to say "Submitted" after submitting data instead of "Done"