### PR TITLE
Use Bearer tokens for authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,8 @@
 # NMDC_MONGO_USER=changeme
 # NMDC_MONGO_PASSWORD=changeme
 
-NMDC_HOST=http://localhost:8080
+NMDC_HOST=http://127.0.0.1:8080
 NMDC_ENVIRONMENT="development"
 
 # Uncomment to enable CORS for local development of the nmdc-field-notes
-# NMDC_CORS_ALLOW_ORIGINS=capacitor://localhost,ionic://localhost,http://localhost,http://localhost:8100
+# NMDC_CORS_ALLOW_ORIGINS=capacitor://localhost,ionic://localhost,http://localhost,http://127.0.0.1:8100

--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@
 # NMDC_DATABASE_URI="postgresql:///nmdc_a"
 # NMDC_TESTING_DATABASE_URI="postgresql:///nmdc_testing"
 
-# OAuth Setup
-# NMDC_CLIENT_ID=changeme
-# NMDC_CLIENT_SECRET=changeme
+# ORCID OAuth Setup
+# NMDC_ORCID_CLIENT_ID=changeme
+# NMDC_ORCID_CLIENT_SECRET=changeme
 
 # MongoDB Ingest Setup
 # NMDC_MONGO_USER=changeme

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@
 # NMDC_MONGO_USER=changeme
 # NMDC_MONGO_PASSWORD=changeme
 
-NMDC_HOST=http://127.0.0.1:8080
 NMDC_ENVIRONMENT="development"
 
 # Uncomment to enable CORS for local development of the nmdc-field-notes

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,8 +23,8 @@ Edit values in `.env` to point to existing postgresql databases. See `nmdc_serve
 1. Set the following configuration in `.env`, and then restart the stack.
 
 ```bash
-NMDC_CLIENT_ID=changeme
-NMDC_CLIENT_SECRET=changeme
+NMDC_ORCID_CLIENT_ID=changeme
+NMDC_ORCID_CLIENT_SECRET=changeme
 ```
 
 # Load production data

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,7 +25,7 @@ Edit values in `.env` to point to existing postgresql databases. See `nmdc_serve
 ```bash
 NMDC_CLIENT_ID=changeme
 NMDC_CLIENT_SECRET=changeme
-NMDC_HOST=http://localhost:8080
+NMDC_HOST=http://127.0.0.1:8080
 ```
 
 # Load production data
@@ -68,7 +68,7 @@ This should only need to be done once. When the `db` service starts up again (in
 docker-compose up -d
 ```
 
-View main application at `http://localhost:8080/` and the swagger page at `http://localhost:8080/api/docs`.
+View main application at `http://127.0.0.1:8080/` and the swagger page at `http://127.0.0.1:8080/api/docs`.
 
 
 
@@ -88,7 +88,7 @@ pip install uvicorn tox
 uvicorn nmdc_server.asgi:app --reload
 ```
 
-View swagger page at `http://localhost:8000/api/docs`.
+View swagger page at `http://127.0.0.1:8000/api/docs`.
 
 
 
@@ -136,7 +136,11 @@ yarn
 yarn serve
 ```
 
-**Note**: To authenticate, log into the portal at `http://localhost:8080` first.  Then, the dev environment portal at `http://localhost:8081` will also be authenticated.  This is because oauth with webpack dev server is not possible.
+View main application at `http://127.0.0.1:8081`
+
+## Why not `localhost`?
+
+It is recommended to use `127.0.0.1` instead of `localhost` for local development. This is because `localhost` is **not** allowed as a redirect URI for an ORCID client. The workaround is to register `127.0.0.1` as a redirect URI with ORCID and to use subsequently visit `127.0.0.1` for local testing.
 
 # Testing
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ Edit values in `.env` to point to existing postgresql databases. See `nmdc_serve
 
 1. Create an OrcID account at [orcid.org](https://orcid.org).
 1. Create an Application via the OrcID [developer tools](https://orcid.org/developer-tools) page.
-    - Set the Redirect URIs (the first and only one) to `http://127.0.0.1:8080`
+    - Set the Redirect URIs (the first and only one) to `http://127.0.0.1:8000`
         - Note: OrcID has changed the validation logic for this form field over time.
         - In case you run into validation errors, you may find [this issue](https://github.com/microbiomedata/nmdc-server/issues/1041) helpful.
     - You will use the resulting **Client ID** and **Client Secret** in the next step.
@@ -25,7 +25,6 @@ Edit values in `.env` to point to existing postgresql databases. See `nmdc_serve
 ```bash
 NMDC_CLIENT_ID=changeme
 NMDC_CLIENT_SECRET=changeme
-NMDC_HOST=http://127.0.0.1:8080
 ```
 
 # Load production data

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -23,7 +23,7 @@ def attach_sentry(app: FastAPI):
     )
 
 
-def create_app(env: typing.Mapping[str, str], secure_cookies: bool = True) -> FastAPI:
+def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     app = FastAPI(
         title="NMDC Data and Submission Portal API",
         version=__version__,
@@ -44,8 +44,8 @@ def create_app(env: typing.Mapping[str, str], secure_cookies: bool = True) -> Fa
     attach_sentry(app)
     errors.attach_error_handlers(app)
     app.include_router(api.router, prefix="/api")
-    app.include_router(auth.router, prefix="")
-    app.add_middleware(SessionMiddleware, secret_key=settings.secret_key, https_only=secure_cookies)
+    app.include_router(auth.router, prefix="/auth")
+    app.add_middleware(SessionMiddleware, secret_key=settings.session_secret_key)
 
     if settings.cors_allow_origins:
         app.add_middleware(

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -1,18 +1,21 @@
+from datetime import datetime, timedelta
 from enum import Enum
+from functools import lru_cache
 from typing import Any, Dict, Optional
-from uuid import UUID
 
+import requests
 from authlib.integrations import starlette_client
-from fastapi import APIRouter, Depends, HTTPException, Security, status
-from fastapi.security.oauth2 import OAuth2AuthorizationCodeBearer
-from jose import jwt
+from authlib.jose import jwt
+from authlib.jose.errors import JoseError
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
 
 from nmdc_server import crud, models
-from nmdc_server.config import settings, starlette_config
+from nmdc_server.config import settings
 from nmdc_server.database import get_db
 from nmdc_server.schemas import User
 
@@ -22,74 +25,190 @@ login_required_responses: Dict[Any, Any] = {
     "401": {"description": "Login required"},
     "403": {"description": "Insufficient permissions"},
 }
-oauth2_client = starlette_client.OAuth(starlette_config)
+oauth2_client = starlette_client.OAuth()
 oauth2_client.register(
     name="orcid",
-    client_id=settings.client_id,
-    client_secret=settings.client_secret,
-    server_metadata_url=settings.open_id_config_url,
+    client_id=settings.orcid_client_id,
+    client_secret=settings.orcid_client_secret,
+    server_metadata_url=settings.orcid_openid_config_url,
     client_kwargs={
-        "scope": settings.oauth_scope,
+        "scope": settings.orcid_authorize_scope,
     },
 )
 
-oauth2_scheme = OAuth2AuthorizationCodeBearer(
-    authorizationUrl=settings.oauth_authorization_endpoint,
-    tokenUrl=settings.oauth_token_endpoint,
-    scopes={"authorization": settings.oauth_scope},
-    auto_error=False,
+bearer_scheme = HTTPBearer(auto_error=False)
+
+router = APIRouter()
+
+CREDENTIAL_DECODE_EXCEPTION = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail="Could not validate credentials",
+    headers={"WWW-Authenticate": "Bearer"},
 )
 
+CREDENTIAL_MISSING_EXCEPTION = HTTPException(
+    status_code=status.HTTP_401_UNAUTHORIZED,
+    detail="Login required",
+    headers={"WWW-Authenticate": "Bearer"},
+)
 
-class Token(BaseModel):
-    access_token: UUID
-    token_type: str
-    refresh_token: UUID
-    expires_in: int
-    scope: str
-    name: str
-    orcid: str
-    expires_at: int
+AUTHORIZATION_CODE_INVALID_EXCEPTION = HTTPException(
+    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+    detail="Invalid authorization code",
+)
 
-
-async def get_token(
-    request: Request, access_token: Optional[str] = Security(oauth2_scheme)
-) -> Optional[Token]:
-    token = request.session.get("token")
-    if token:
-        return Token(**token)
-    if access_token:
-        payload = jwt.decode(access_token, settings.secret_key, algorithms=["HS256"])
-        return Token(**payload)
-    return None
+API_JWT_ALGORITHM = "HS256"
+API_JWT_ISSUER = "https://data.microbiomedata.org"
+ORCID_JWT_ISSUER = "https://orcid.org"
 
 
-async def get_current_user(token: Optional[Token] = Depends(get_token)) -> Optional[str]:
-    if token:
-        return token.name
-    return None
+class JwtTypes(str, Enum):
+    Bearer = "Bearer"
+    Refresh = "Refresh"
 
 
-async def get_current_user_orcid(token: Optional[Token] = Depends(get_token)) -> Optional[str]:
-    if token:
-        return token.orcid
-    return None
+class TokenRequest(BaseModel):
+    code: str
+    redirect_uri: str
 
 
-async def login_required(
-    token: Optional[Token] = Depends(get_token), db: Session = Depends(get_db)
-) -> models.User:
-    if token is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Login required",
-            headers={"WWW-Authenticate": "Bearer"},
+class TokenResponse(BaseModel):
+    access_token: bytes
+    refresh_token: Optional[bytes] = None
+    token_type: str = "bearer"
+    expires: int
+
+
+class RefreshRequestBody(BaseModel):
+    refresh_token: str
+
+
+class OidcLoginRequestBody(BaseModel):
+    id_token: str
+
+
+@lru_cache
+def fetch_orcid_jwks():
+    """Fetch the JWKS from the ORCID OpenID Connect configuration."""
+    orcid_openid_config = requests.get(settings.orcid_openid_config_url).json()
+    jwks_uri = orcid_openid_config["jwks_uri"]
+    return requests.get(jwks_uri).json()
+
+
+def encode_token(*, data: dict, expires_delta: timedelta) -> bytes:
+    """Create a JWT with the given data and expiration.
+
+    In addition to the data, the JWT will include our issuer string (iss), the issuing time (iat),
+    and the expiration time (exp). The JWT will be signed with our API's secret key.
+    """
+    header = {"alg": API_JWT_ALGORITHM, "typ": "JWT"}
+
+    payload = data.copy()
+    now = datetime.utcnow()
+    expire = now + expires_delta
+    payload.update(
+        {
+            "iss": API_JWT_ISSUER,
+            "iat": now,
+            "exp": expire,
+        }
+    )
+
+    return jwt.encode(header, payload, settings.api_jwt_secret)
+
+
+def decode_token(token: str) -> dict:
+    """Decode a JWT and validate its claims.
+
+    The token must have been signed with our API's secret key, must include our issuer string, and
+    must not have expired. Once validated, the claims are returned.
+    """
+    claims_options = {
+        "iss": {"essential": True, "value": API_JWT_ISSUER},
+    }
+    claims = jwt.decode(token, settings.api_jwt_secret, claims_options=claims_options)
+    claims.validate()
+    return claims
+
+
+def create_token_response(user: models.User, *, create_refresh_token: bool = True) -> TokenResponse:
+    """Create a token response for the given user.
+
+    This function generates an access token JWT which includes the user's ID as the subject and
+    "Bearer" as the typ. This token will expire in a relatively short time, as defined in the
+    settings (24 hours by default). If create_refresh_token is True, a refresh token will also be
+    generated. It also has the user's ID as the subject, but the typ is "Refresh" and it will expire
+    in a longer time, as defined in the settings (365 days by default).
+    """
+    token_data = {"sub": str(user.id), "typ": JwtTypes.Bearer}
+    expires_delta = timedelta(seconds=settings.api_jwt_expiration)
+    access_token = encode_token(data=token_data, expires_delta=expires_delta)
+    response = TokenResponse(
+        access_token=access_token,
+        expires=expires_delta.total_seconds(),
+    )
+    if create_refresh_token:
+        token_data["typ"] = JwtTypes.Refresh
+        refresh_token = encode_token(
+            data=token_data, expires_delta=timedelta(seconds=settings.api_jwt_refresh_expiration)
         )
-    user_schema = User(name=token.name, orcid=token.orcid)
-    return crud.get_or_create_user(db, user_schema)
+        response.refresh_token = refresh_token
+    return response
 
 
-async def admin_required(user: models.User = Depends(login_required)) -> models.User:
+def get_user_from_token(db: Session, token: str, token_type: JwtTypes) -> models.User:
+    """Get the user associated with the given token.
+
+    This function takes a JWT and first checks to see if it has been manually invalidated. If it has
+    not, the token is decoded and its claims are validated by the decode_token function. Next the
+    typ is checked against the provided value. Then the user ID is extracted from the sub claim and
+    used to retrieve and return the user from the database. If any of these steps fail, an exception
+    is raised.
+    """
+    invalid_token = crud.get_invalidated_token(db, token)
+    if invalid_token:
+        raise CREDENTIAL_DECODE_EXCEPTION
+    try:
+        payload = decode_token(token)
+        if payload.get("typ") != token_type:
+            raise CREDENTIAL_DECODE_EXCEPTION
+        user_id = payload.get("sub")
+        if user_id is None:
+            raise CREDENTIAL_DECODE_EXCEPTION
+    except JoseError:
+        raise CREDENTIAL_DECODE_EXCEPTION
+
+    user = crud.get_user(db, user_id)
+    if user is None:
+        raise CREDENTIAL_DECODE_EXCEPTION
+
+    return user
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> models.User:
+    """Get the current user based on the Bearer credentials."""
+    if credentials is None:
+        raise CREDENTIAL_MISSING_EXCEPTION
+    return get_user_from_token(db, credentials.credentials, JwtTypes.Bearer)
+
+
+def get_current_user_token(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    db: Session = Depends(get_db),
+) -> str:
+    """Get the current user's access token from the Bearer credentials.
+
+    This function is used to get the access token from the Bearer credentials. The token is
+    validated by way of the get_user_from_token function first.
+    """
+    _ = get_current_user(credentials, db)
+    return credentials.credentials
+
+
+def admin_required(user: models.User = Depends(get_current_user)) -> models.User:
     if settings.environment != "production" and settings.environment != "testing":
         return user
     if user.is_admin:
@@ -100,56 +219,139 @@ async def admin_required(user: models.User = Depends(login_required)) -> models.
     )
 
 
-def encode_token(data: dict):
-    encoded_jwt = jwt.encode(data, settings.secret_key, algorithm="HS256")
-    return encoded_jwt
-
-
-router = APIRouter()
-
-
-class LoginBehavior(str, Enum):
-    web = "web"
-    jwt = "jwt"
-    app = "app"
-
-
-# authentication
 @router.get("/login", include_in_schema=False)
-async def login_via_orcid(request: Request, behavior: LoginBehavior = LoginBehavior.web):
-    qs = f"?behavior={behavior}"
+async def login_via_orcid(request: Request, redirect_uri: str, state: Optional[str] = None):
+    """Initiate the login process via ORCID.
+
+    This route is used to initiate the login process via ORCID. It will redirect the user to ORCID's
+    sign in page where they will enter their credentials. The required redirect_uri is **not**
+    the one passed to the ORCID /authorize route. Instead, it is stored in the session and used
+    later to redirect the user at the very end of the login process. We request that ORCID redirect
+    the user back to our /auth/orcid-token route where we complete the ORCID OAuth2 Authorization
+    Code Flow.
+    """
+    allowed_origins = settings.login_redirect_allow_origins.split(",")
+    if not any(redirect_uri.startswith(origin) for origin in allowed_origins):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid redirect_uri",
+        )
     if settings.host:
-        redirect_uri = f"{settings.host.rstrip('/')}/token{qs}"
+        orcid_redirect_uri = f"{settings.host.rstrip('/')}/auth/orcid-token"
     else:
-        redirect_uri = request.url_for("token") + qs
-    return await oauth2_client.orcid.authorize_redirect(request, redirect_uri)
+        orcid_redirect_uri = request.url_for("orcid-token")
+    request.session["redirect_uri"] = redirect_uri
+    if state is not None:
+        request.session["state"] = state
+    return await oauth2_client.orcid.authorize_redirect(request, orcid_redirect_uri)
 
 
-@router.get("/token", name="token", include_in_schema=False)
-async def authorize(
-    request: Request, db: Session = Depends(get_db), behavior: LoginBehavior = LoginBehavior.web
-):
-    token = await oauth2_client.orcid.authorize_access_token(request)
-    user = User(orcid=token["orcid"], name=token["name"])
+@router.get("/orcid-token", name="orcid-token", include_in_schema=False)
+async def orcid_authorize(request: Request, db: Session = Depends(get_db)):
+    """Complete the ORCID OAuth2 Authorization Code Flow and generate our own authorization code.
+
+    This route is used to complete the ORCID OAuth2 Authorization Code Flow. It is provided as the
+    redirect_uri in the ORCID /authorize request. The ORCID API will redirect the user back to this
+    route with an authorization code. We use this code to request an ORCID access token. The ORCID
+    access token response also includes the authenticated user's ORCID iD and name. We use this
+    information to create or update a user in our database. Finally, we generate our own
+    authorization code and redirect the user back to the original redirect_uri (which was provided
+    to the /auth/login route and stored in the session).
+    """
+    token_response = await oauth2_client.orcid.authorize_access_token(request)
+    # TODO: use token_response.access_token to make requests to the ORCID API for more user info?
+    # Or possibly store the access token in the database for later use?
+    user = User(orcid=token_response["orcid"], name=token_response["name"])
     user_model = crud.get_or_create_user(db, user)
     user_model.name = user.name
     db.commit()
-    if behavior == LoginBehavior.web:
-        request.session["token"] = token
-        return RedirectResponse(url="/")
-    if behavior == LoginBehavior.jwt:
-        return encode_token(token)
-    if behavior == LoginBehavior.app:
-        return RedirectResponse(
-            url=f"{settings.field_notes_host}/token?token=" + encode_token(token)
-        )
+    redirect_uri = request.session.pop("redirect_uri")
+    state = request.session.pop("state", None)
+    # TODO: also include code_challenge and code_challenge_method in this request to emulate PKCE?
+    code = crud.create_authorization_code(db, user_model, redirect_uri)
+    url = f"{redirect_uri}?code={code.code}"
+    if state is not None:
+        url += f"&state={state}"
+    return RedirectResponse(url)
 
 
-@router.get(
-    "/logout",
-    tags=["user"],
-    name="Log out of the current session",
+@router.post("/token", response_model=TokenResponse, include_in_schema=False)
+async def token(
+    body: TokenRequest,
+    db: Session = Depends(get_db),
+):
+    """Exchange an nmdc-server authorization code for nmdc-server tokens.
+
+    When a user receives an authorization code from query parameters in the redirect_uri that they
+    provided to the /auth/login route, they can exchange it for an nmdc-server access token using
+    this route. The provided authorization code is looked up in the database. If it is missing,
+    already exchanged, wasn't generated from the same redirect_uri, or is older than 5 minutes, an
+    error is raised. Otherwise, the code is marked as exchanged and new tokens are generated for the
+    user associated with the code.
+    """
+    authorization_code = crud.get_authorization_code(db, body.code)
+    if (
+        authorization_code is None
+        or authorization_code.exchanged
+        or authorization_code.redirect_uri != body.redirect_uri
+        or authorization_code.created < datetime.utcnow() - timedelta(minutes=5)
+    ):
+        raise AUTHORIZATION_CODE_INVALID_EXCEPTION
+    user = authorization_code.user
+    authorization_code.exchanged = True
+    db.commit()
+    return create_token_response(user)
+
+
+@router.post("/oidc-login", response_model=TokenResponse, include_in_schema=False)
+async def oidc_login(body: OidcLoginRequestBody, db: Session = Depends(get_db)):
+    """Exchange an ORCID-issued OpenID Connect token for nmdc-server tokens.
+
+    The endpoint can be used as an alternative to the flow initiated by the /auth/login route. If a
+    client has already obtained an OpenID Connect token from ORCID, they can exchange it for a
+    nmdc-server tokens using this route. The OIDC token is decoded and validated by looking for
+    ORCID as the issuer and the nmdc-server client ID as the audience. If the token is valid, the
+    claims in the token are used to create or update a user in the database. Finally, new tokens are
+    generated for the user.
+    """
+    jwks = fetch_orcid_jwks()
+    claims_options = {
+        "aud": {"essential": True, "value": settings.orcid_client_id},
+        "iss": {"essential": True, "value": ORCID_JWT_ISSUER},
+    }
+    claims = jwt.decode(body.id_token, jwks, claims_options=claims_options)
+    claims.validate()
+    user = User(orcid=claims["sub"], name=f"{claims['given_name']} {claims['family_name']}")
+    user_model = crud.get_or_create_user(db, user)
+    user_model.name = user.name
+    db.commit()
+    return create_token_response(user_model)
+
+
+@router.post(
+    "/refresh",
+    include_in_schema=False,
+    response_model=TokenResponse,
+    response_model_exclude_none=True,
 )
-async def logout(request: Request):
-    request.session.pop("token", None)
-    return RedirectResponse(url="/")
+async def refresh(body: RefreshRequestBody, db: Session = Depends(get_db)):
+    """Exchange a refresh token for a new access token.
+
+    When a user's access token expires, they can submit a refresh token to this route to receive a
+    new access token. The refresh token is first checked to see if it has been manually invalidated.
+    Then the refresh token is decoded and validated by the get_user_from_token function. In this
+    case only a new access token is generated and returned. The user can continue to use the same
+    refresh token to obtain new access tokens until it expires.
+    """
+    invalid_token = crud.get_invalidated_token(db, body.refresh_token)
+    if invalid_token:
+        raise CREDENTIAL_DECODE_EXCEPTION
+    user = get_user_from_token(db, body.refresh_token, JwtTypes.Refresh)
+    return create_token_response(user, create_refresh_token=False)
+
+
+@router.post("/logout", include_in_schema=False)
+async def logout(token: str = Depends(get_current_user_token), db: Session = Depends(get_db)):
+    """Log out the current user by invalidating their access token."""
+    crud.add_invalidated_token(db, token)
+    return {"details": "Logged out successfully"}

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -58,7 +58,6 @@ AUTHORIZATION_CODE_INVALID_EXCEPTION = HTTPException(
 )
 
 API_JWT_ALGORITHM = "HS256"
-API_JWT_ISSUER = "https://data.microbiomedata.org"
 ORCID_JWT_ISSUER = "https://orcid.org"
 
 
@@ -100,7 +99,7 @@ def encode_token(*, data: dict, expires_delta: timedelta) -> bytes:
     expire = now + expires_delta
     payload.update(
         {
-            "iss": API_JWT_ISSUER,
+            "iss": settings.host,
             "iat": now,
             "exp": expire,
         }
@@ -116,7 +115,7 @@ def decode_token(token: str) -> dict:
     must not have expired. Once validated, the claims are returned.
     """
     claims_options = {
-        "iss": {"essential": True, "value": API_JWT_ISSUER},
+        "iss": {"essential": True, "value": settings.host},
     }
     claims = jwt.decode(token, settings.api_jwt_secret, claims_options=claims_options)
     claims.validate()
@@ -228,10 +227,7 @@ async def login_via_orcid(request: Request, redirect_uri: str, state: Optional[s
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid redirect_uri",
         )
-    if settings.host:
-        orcid_redirect_uri = f"{settings.host.rstrip('/')}/auth/orcid-token"
-    else:
-        orcid_redirect_uri = request.url_for("orcid-token")
+    orcid_redirect_uri = f"{settings.host.rstrip('/')}/auth/orcid-token"
     request.session["redirect_uri"] = redirect_uri
     if state is not None:
         request.session["state"] = state

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -285,7 +285,7 @@ async def token(
     When a user receives an authorization code from query parameters in the redirect_uri that they
     provided to the /auth/login route, they can exchange it for an nmdc-server access token using
     this route. The provided authorization code is looked up in the database. If it is missing,
-    already exchanged, wasn't generated from the same redirect_uri, or is older than 5 minutes, an
+    already exchanged, wasn't generated from the same redirect_uri, or is older than 45 seconds, an
     error is raised. Otherwise, the code is marked as exchanged and new tokens are generated for the
     user associated with the code.
     """
@@ -294,7 +294,7 @@ async def token(
         authorization_code is None
         or authorization_code.exchanged
         or authorization_code.redirect_uri != body.redirect_uri
-        or authorization_code.created < datetime.utcnow() - timedelta(minutes=5)
+        or authorization_code.created < datetime.utcnow() - timedelta(seconds=45)
     ):
         raise AUTHORIZATION_CODE_INVALID_EXCEPTION
     user = authorization_code.user

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -87,14 +87,6 @@ class OidcLoginRequestBody(BaseModel):
     id_token: str
 
 
-@lru_cache
-def fetch_orcid_jwks():
-    """Fetch the JWKS from the ORCID OpenID Connect configuration."""
-    orcid_openid_config = requests.get(settings.orcid_openid_config_url).json()
-    jwks_uri = orcid_openid_config["jwks_uri"]
-    return requests.get(jwks_uri).json()
-
-
 def encode_token(*, data: dict, expires_delta: timedelta) -> bytes:
     """Create a JWT with the given data and expiration.
 
@@ -301,6 +293,14 @@ async def token(
     authorization_code.exchanged = True
     db.commit()
     return create_token_response(user)
+
+
+@lru_cache
+def fetch_orcid_jwks():
+    """Fetch the JWKS from the ORCID OpenID Connect configuration."""
+    orcid_openid_config = requests.get(settings.orcid_openid_config_url).json()
+    jwks_uri = orcid_openid_config["jwks_uri"]
+    return requests.get(jwks_uri).json()
 
 
 @router.post("/oidc-login", response_model=TokenResponse, include_in_schema=False)

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -2,7 +2,6 @@ import os
 from typing import Optional
 
 from pydantic import BaseSettings
-from starlette.config import Config
 
 
 class Settings(BaseSettings):
@@ -27,16 +26,18 @@ class Settings(BaseSettings):
     # after the session closes.
     db_pool_max_overflow: int = 3
 
+    # These values control the JWTs issued by nmdc-server as access and refresh tokens
+    api_jwt_secret: str = "generate me"
+    api_jwt_expiration: int = 24 * 60 * 60  # 24 hours
+    api_jwt_refresh_expiration: int = 60 * 60 * 24 * 365  # 365 days
+
     # for orcid oauth
-    secret_key: str = "secret"
-    client_id: str = "oauth client id"
-    client_secret: str = "oauth secret key"
-    open_id_config_url: str = "https://orcid.org/.well-known/openid-configuration"
-    oauth_scope: str = "/authenticate"
-    oauth_authorization_endpoint: str = "https://orcid.org/oauth/authorize"
-    oauth_token_endpoint: str = "https://orcid.org/oauth/token"
+    session_secret_key: str = "secret"
+    orcid_client_id: str = "oauth client id"
+    orcid_client_secret: str = "oauth secret key"
+    orcid_openid_config_url: str = "https://orcid.org/.well-known/openid-configuration"
+    orcid_authorize_scope: str = "/authenticate"
     host: Optional[str] = None  # sets the host name for the oauth2 redirect
-    field_notes_host: str = "https://fieldnotes.microbiomedata.org"
 
     # mongo database used for ingest
     mongo_host: str = "mongo-loadbalancer.nmdc-runtime-dev.development.svc.spin.nersc.org"
@@ -67,6 +68,9 @@ class Settings(BaseSettings):
     # CORS settings necessary for allowing request from Field Notes app
     cors_allow_origins: Optional[str] = None  # comma separated list of allowed origins
 
+    # Comma separated list of allowed origins for post-login redirect
+    login_redirect_allow_origins: str = "http://127.0.0.1:8081"
+
     # Github Issue creation settings. Both are required for automated issue creation.
     github_issue_url: Optional[str] = None
     github_authentication_token: Optional[str] = None
@@ -84,4 +88,3 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-starlette_config = Config(environ=settings.dict())  # for authlib, incompatible with pydantic config

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     orcid_authorize_scope: str = "/authenticate"
 
     # host name for the ORCID oauth2 redirect and our own JWT issuer
-    host: str = 'http://127.0.0.1:8000'
+    host: str = "http://127.0.0.1:8000"
 
     # mongo database used for ingest
     mongo_host: str = "mongo-loadbalancer.nmdc-runtime-dev.development.svc.spin.nersc.org"

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -37,7 +37,9 @@ class Settings(BaseSettings):
     orcid_client_secret: str = "oauth secret key"
     orcid_openid_config_url: str = "https://orcid.org/.well-known/openid-configuration"
     orcid_authorize_scope: str = "/authenticate"
-    host: Optional[str] = None  # sets the host name for the oauth2 redirect
+
+    # host name for the ORCID oauth2 redirect and our own JWT issuer
+    host: str = 'http://127.0.0.1:8000'
 
     # mongo database used for ingest
     mongo_host: str = "mongo-loadbalancer.nmdc-runtime-dev.development.svc.spin.nersc.org"

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -402,7 +402,7 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bulk download not found")
     if bulk_download.expired:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Bulk download expired"
+            status_code=status.HTTP_410_GONE, detail="Bulk download expired"
         )
     content = []
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -401,9 +401,7 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
     if bulk_download is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bulk download not found")
     if bulk_download.expired:
-        raise HTTPException(
-            status_code=status.HTTP_410_GONE, detail="Bulk download expired"
-        )
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Bulk download expired")
     content = []
 
     for file in bulk_download.files:  # type: ignore

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -399,7 +399,11 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
     """Return a download table compatible with mod_zip."""
     bulk_download = db.query(models.BulkDownload).get(id)
     if bulk_download is None:
-        return None
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bulk download not found")
+    if bulk_download.expired:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Bulk download expired"
+        )
     content = []
 
     for file in bulk_download.files:  # type: ignore
@@ -414,7 +418,15 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
         file_size_string = data_object.file_size_bytes if data_object.file_size_bytes else ""
         content.append(f"- {file_size_string} {url} {file.path}")
 
+    bulk_download.expired = True
+    db.commit()
+
     return "\n".join(content) + "\n"
+
+
+def get_user(db: Session, user_id: str) -> Optional[models.User]:
+    """Get a user by ID."""
+    return db.query(models.User).get(user_id)
 
 
 def get_or_create_user(db: Session, user: schemas.User) -> models.User:
@@ -435,6 +447,33 @@ def update_user(db: Session, user: schemas.User) -> Optional[models.User]:
     db_user.is_admin = user.is_admin
     db.commit()
     return db_user
+
+
+def add_invalidated_token(db: Session, token: str) -> None:
+    """Add a token to the invalidated token table."""
+    invalidated = models.InvalidatedToken(token=token)
+    db.add(invalidated)
+    db.commit()
+
+
+def get_invalidated_token(db: Session, token: str) -> Optional[models.InvalidatedToken]:
+    """Get an invalidated token by token."""
+    return db.query(models.InvalidatedToken).get(token)
+
+
+def create_authorization_code(
+    db: Session, user: models.User, redirect_uri: str
+) -> models.AuthorizationCode:
+    """Generate an authorization code tied to a user and redirect URI."""
+    code = models.AuthorizationCode(user_id=user.id, redirect_uri=redirect_uri)
+    db.add(code)
+    db.commit()
+    return code
+
+
+def get_authorization_code(db: Session, code: str) -> Optional[models.AuthorizationCode]:
+    """Get an authorization code by code."""
+    return db.query(models.AuthorizationCode).get(code)
 
 
 def update_submission_lock(db: Session, submission_id: str):
@@ -581,7 +620,9 @@ def can_edit_entire_submission(db: Session, submission_id: str, user_orcid: str)
 
 def get_submissions_for_user(db: Session, user: models.User):
     """Return all submissions that a user has permission to view."""
-    all_submissions = db.query(models.SubmissionMetadata)
+    all_submissions = db.query(models.SubmissionMetadata).order_by(
+        models.SubmissionMetadata.created.desc()
+    )
 
     if user.is_admin:
         return all_submissions

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -115,10 +115,12 @@ DECLARE
         SELECT tablename FROM pg_tables
         WHERE schemaname = 'public'
             and tablename <> 'alembic_version'
+            and tablename <> 'authorization_code'
+            and tablename <> 'bulk_download'
+            and tablename <> 'bulk_download_data_object'
             and tablename <> 'file_download'
             and tablename <> 'ingest_lock'
-            and tablename <> 'bulk_download'
-            and tablename <> 'bulk_download_data_object';
+            and tablename <> 'invalidated_token';
 BEGIN
     FOR stmt IN statements LOOP
         EXECUTE 'TRUNCATE TABLE ' || quote_ident(stmt.tablename) || ' CASCADE;';

--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from typing import Dict, List, Optional
 from uuid import UUID, uuid4
 
-from factory import Factory, Faker, SubFactory, lazy_attribute, post_generation
+from factory import Faker, SubFactory, lazy_attribute, post_generation
 from factory.alchemy import SQLAlchemyModelFactory
 from faker.providers import BaseProvider, date_time, geo, internet, lorem, misc, person, python
 from sqlalchemy.orm.scoping import scoped_session
 
-from nmdc_server import auth, models
+from nmdc_server import models
 from nmdc_server.database import SessionLocal
 from nmdc_server.schemas import AnnotationValue
 
@@ -40,20 +40,6 @@ Faker.add_provider(misc)
 Faker.add_provider(person)
 Faker.add_provider(python)
 Faker.add_provider(EnumProvider)
-
-
-class TokenFactory(Factory):
-    class Meta:
-        model = auth.Token
-
-    access_token: UUID = Faker("uuid")
-    refresh_token: UUID = Faker("uuid")
-    token_type: str = "bearer"
-    expires_in: int = Faker("pyint", min_value=10000, max_value=99999)
-    scope: str = "/authorize"
-    name: str = Faker("name")
-    orcid: str = Faker("pystr")
-    expires_at: int = Faker("pyint", min_value=10000, max_value=99999)
 
 
 class DOIInfoFactory(SQLAlchemyModelFactory):
@@ -347,7 +333,7 @@ class UserFactory(SQLAlchemyModelFactory):
     id: UUID = Faker("uuid")
     name: str = Faker("name")
     orcid: str = Faker("pystr")
-    is_admin: bool = True
+    is_admin: bool = False
 
 
 class MetadataSubmissionFactory(SQLAlchemyModelFactory):

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -74,6 +74,8 @@ def do_ingest(function_limit, skip_annotation):
             merge_download_artifact(ingest_db, prod_db.query(models.User))
             merge_download_artifact(ingest_db, prod_db.query(models.SubmissionMetadata))
             merge_download_artifact(ingest_db, prod_db.query(models.SubmissionRole))
+            merge_download_artifact(ingest_db, prod_db.query(models.AuthorizationCode))
+            merge_download_artifact(ingest_db, prod_db.query(models.InvalidatedToken))
 
             # ingest data
             logger.info(

--- a/nmdc_server/migrations/versions/60fef2166c84_bulk_download_expire.py
+++ b/nmdc_server/migrations/versions/60fef2166c84_bulk_download_expire.py
@@ -1,0 +1,33 @@
+"""Add expired column to bulk_download table
+
+Revision ID: 60fef2166c84
+Revises: 89e8f6a21c8d
+Create Date: 2024-05-03 22:35:35.842031
+
+"""
+
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "60fef2166c84"
+down_revision: Optional[str] = "89e8f6a21c8d"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    # Add new expired column to bulk_download table, false for new records
+    op.add_column(
+        "bulk_download",
+        sa.Column("expired", sa.Boolean(), nullable=False, server_default=sa.sql.False_()),
+    )
+
+    # Consider any existing bulk downloads to be expired
+    op.execute("UPDATE bulk_download SET expired = true")
+
+
+def downgrade():
+    op.drop_column("bulk_download", "expired")

--- a/nmdc_server/migrations/versions/6cdad9ad6543_create_authorization_code.py
+++ b/nmdc_server/migrations/versions/6cdad9ad6543_create_authorization_code.py
@@ -1,0 +1,38 @@
+"""Create authorization_code table
+
+Revision ID: 6cdad9ad6543
+Revises: 60fef2166c84
+Create Date: 2024-05-10 21:36:27.612777
+
+"""
+
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "6cdad9ad6543"
+down_revision: Optional[str] = "60fef2166c84"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.create_table(
+        "authorization_code",
+        sa.Column("code", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created", sa.DateTime(), nullable=False),
+        sa.Column("redirect_uri", sa.String(), nullable=False),
+        sa.Column("exchanged", sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["user_logins.id"], name=op.f("fk_authorization_code_user_id_user_logins")
+        ),
+        sa.PrimaryKeyConstraint("code", name=op.f("pk_authorization_code")),
+    )
+
+
+def downgrade():
+    op.drop_table("authorization_code")

--- a/nmdc_server/migrations/versions/89e8f6a21c8d_invalidated_tokens.py
+++ b/nmdc_server/migrations/versions/89e8f6a21c8d_invalidated_tokens.py
@@ -1,0 +1,30 @@
+"""Add invalidated_token table
+
+Revision ID: 89e8f6a21c8d
+Revises: b4b234bd55cf
+Create Date: 2024-04-19 18:33:18.632583
+
+"""
+
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "89e8f6a21c8d"
+down_revision: Optional[str] = "b4b234bd55cf"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.create_table(
+        "invalidated_token",
+        sa.Column("token", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("token", name=op.f("pk_invalidated_token")),
+    )
+
+
+def downgrade():
+    op.drop_table("invalidated_token")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     # pinned because recent versions throw an error when upgrading through
     # the api at nmdc_server/jobs.py:34
     "alembic==1.5.8",
-    "authlib==0.15.5",
+    "authlib==1.3.0",
     "celery[redis]",
     "click",
     "cryptography",
@@ -31,7 +31,6 @@ dependencies = [
     "pymongo>=4.0.0",
     "python-dateutil",
     "python-dotenv",
-    "python-jose[cryptography]",
     "requests==2.28.1",
     "sentry-sdk[celery,sqlalchemy]",
     "sqlalchemy>=1.4",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,26 +1,33 @@
 from starlette.testclient import TestClient
 
 from nmdc_server import fakes
-from nmdc_server.auth import Token
-from nmdc_server.config import settings
+from nmdc_server.config import Settings
 
 
 def test_login(client: TestClient):
-    resp = client.request(method="get", url="/login", allow_redirects=False)
+    settings = Settings()
+    allowed_redirect_uri = settings.login_redirect_allow_origins.split(",")[0]
+    resp = client.request(
+        method="get",
+        url=f"/auth/login?redirect_uri={allowed_redirect_uri}/whatever",
+        allow_redirects=False,
+    )
 
     assert resp.status_code == 302
-    assert resp.next.url.startswith(settings.oauth_authorization_endpoint)  # type: ignore
+    assert resp.next.url.startswith("https://orcid.org/oauth/authorize")  # type: ignore
 
 
-def test_current_user(client: TestClient, token: Token):
+def test_current_user(client: TestClient, logged_in_user):
     resp = client.get("/api/me")
-    assert resp.json() == token.name
+    body = resp.json()
+    assert body["name"] == logged_in_user.name
 
 
-def test_logout(client: TestClient, token: Token):
-    client.get("/logout")
+def test_logout(client: TestClient, logged_in_user):
+    logout_response = client.post("/auth/logout")
+    logout_response.raise_for_status()
     resp = client.get("/api/me")
-    assert resp.json() == None
+    assert resp.status_code == 401
 
 
 def test_admin_required(client: TestClient):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -115,6 +115,12 @@ def test_generate_bulk_download_filtered(db: Session, client: TestClient, logged
     assert resp.status_code == 200
     assert resp.json()["count"] == 1
 
+    # Verify that the bulk download can be accessed without authentication
     resp = client.get(f"/api/bulk_download/{id_}")
+    del client.headers["Authorization"]
     assert resp.status_code == 200
     assert b"/raw" not in resp.content and b"/metag" in resp.content
+
+    # Verify that the bulk download cannot be accessed a second time
+    resp = client.get(f"/api/bulk_download/{id_}")
+    assert resp.status_code == 410

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -48,7 +48,7 @@ def test_bulk_download_query(db: Session):
     assert qs.aggregate(db) == {"size": raw1.file_size_bytes, "count": 1}
 
 
-def test_generate_bulk_download(db: Session, client: TestClient, token):
+def test_generate_bulk_download(db: Session, client: TestClient, logged_in_user):
     sample = fakes.BiosampleFactory()
     op1 = fakes.OmicsProcessingFactory(biosample_inputs=[sample])
     fakes.OmicsProcessingFactory(biosample_inputs=[sample])
@@ -79,7 +79,7 @@ def test_generate_bulk_download(db: Session, client: TestClient, token):
     assert resp.json()["count"] == 0
 
 
-def test_generate_bulk_download_filtered(db: Session, client: TestClient, token):
+def test_generate_bulk_download_filtered(db: Session, client: TestClient, logged_in_user):
     sample = fakes.BiosampleFactory()
     op1 = fakes.OmicsProcessingFactory(biosample_inputs=[sample])
     fakes.OmicsProcessingFactory(biosample_inputs=[sample])

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -23,7 +23,7 @@ http {
         }
 
         # https://stackoverflow.com/a/52319161
-        location ~ ^/(api|docs|login|logout|token|openapi.json|static) {
+        location ~ ^/(api|docs|auth|openapi.json|static) {
             resolver $DNS_ADDRESS;
             set ${DOLLAR}backend ${BACKEND_URL};
             proxy_pass ${DOLLAR}backend;

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "rimraf -rf ./node_modules/.cache/vue-loader && vue-cli-service serve src/main.ts",
+    "serve": "rimraf -rf ./node_modules/.cache/vue-loader && vue-cli-service serve --host 127.0.0.1 --port 8081 src/main.ts",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, onMounted } from '@vue/composition-api';
+import { defineComponent, onMounted, onUnmounted } from '@vue/composition-api';
 import AppHeader from '@/components/Presentation/AppHeader.vue';
 import { stateRefs, init } from '@/store/';
 import { useRouter } from '@/use/useRouter';
@@ -11,7 +11,16 @@ export default defineComponent({
   setup() {
     const router = useRouter();
 
+    const handleRefreshTokenExpired = () => {
+      stateRefs.user.value = null;
+      if (router) {
+        init(router, false);
+      }
+    };
+
     onMounted(async () => {
+      window.addEventListener('refreshTokenExpired', handleRefreshTokenExpired);
+
       if (!router) {
         return;
       }
@@ -34,6 +43,10 @@ export default defineComponent({
       } finally {
         await init(router);
       }
+    });
+
+    onUnmounted(() => {
+      window.removeEventListener('refreshTokenExpired', handleRefreshTokenExpired);
     });
 
     return {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,12 +1,39 @@
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, onMounted } from '@vue/composition-api';
 import AppHeader from '@/components/Presentation/AppHeader.vue';
-import { stateRefs } from '@/store/';
+import { stateRefs, init } from '@/store/';
+import { useRouter } from '@/use/useRouter';
+import { api, RefreshTokenExchangeError } from '@/data/api';
 
 export default defineComponent({
   name: 'App',
   components: { AppHeader },
   setup() {
+    const router = useRouter();
+
+    onMounted(async () => {
+      if (!router) {
+        return;
+      }
+      if (router.currentRoute.path === '/login') {
+        // init() will be called in the LoginPage component in this case
+        return;
+      }
+      // The first time the app is loaded, there will not yet be an access token configured on
+      // the API client. There *may* be a refresh token in storage, so attempt to exchange it
+      // before calling the init() function.
+      try {
+        await api.exchangeRefreshToken();
+      } catch (error) {
+        if (error instanceof RefreshTokenExchangeError) {
+          // The refresh failed, carry on with a logged-out state
+        } else {
+          throw error;
+        }
+      }
+      await init(router);
+    });
+
     return {
       stateRefs,
     };

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -3,7 +3,7 @@ import { defineComponent, onMounted } from '@vue/composition-api';
 import AppHeader from '@/components/Presentation/AppHeader.vue';
 import { stateRefs, init } from '@/store/';
 import { useRouter } from '@/use/useRouter';
-import { api } from '@/data/api';
+import { api, RefreshTokenExchangeError } from '@/data/api';
 
 export default defineComponent({
   name: 'App',
@@ -27,6 +27,10 @@ export default defineComponent({
       // the app, but we don't want to re-throw the error.
       try {
         await api.exchangeRefreshToken();
+      } catch (error) {
+        if (!(error instanceof RefreshTokenExchangeError)) {
+          throw error;
+        }
       } finally {
         await init(router);
       }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -3,7 +3,7 @@ import { defineComponent, onMounted, onUnmounted } from '@vue/composition-api';
 import AppHeader from '@/components/Presentation/AppHeader.vue';
 import { stateRefs, init } from '@/store/';
 import { useRouter } from '@/use/useRouter';
-import { api, RefreshTokenExchangeError } from '@/data/api';
+import { api, REFRESH_TOKEN_EXPIRED_EVENT, RefreshTokenExchangeError } from '@/data/api';
 
 export default defineComponent({
   name: 'App',
@@ -19,7 +19,7 @@ export default defineComponent({
     };
 
     onMounted(async () => {
-      window.addEventListener('refreshTokenExpired', handleRefreshTokenExpired);
+      window.addEventListener(REFRESH_TOKEN_EXPIRED_EVENT, handleRefreshTokenExpired);
 
       if (!router) {
         return;
@@ -46,7 +46,7 @@ export default defineComponent({
     });
 
     onUnmounted(() => {
-      window.removeEventListener('refreshTokenExpired', handleRefreshTokenExpired);
+      window.removeEventListener(REFRESH_TOKEN_EXPIRED_EVENT, handleRefreshTokenExpired);
     });
 
     return {

--- a/web/src/components/BulkDownload.vue
+++ b/web/src/components/BulkDownload.vue
@@ -6,6 +6,7 @@ import { stateRefs, dataObjectFilter } from '@/store';
 import DownloadDialog from '@/components/DownloadDialog.vue';
 import useBulkDownload from '@/use/useBulkDownload';
 import { humanFileSize } from '@/data/utils';
+import { api } from '@/data/api';
 
 export default defineComponent({
 
@@ -50,6 +51,10 @@ export default defineComponent({
       window.location.assign(val.url);
     }
 
+    function handleLoginClick() {
+      api.initiateOrcidLogin();
+    }
+
     return {
       bulkDownloadSelected: stateRefs.bulkDownloadSelected,
       options,
@@ -58,6 +63,7 @@ export default defineComponent({
       termsDialog,
       createAndDownload,
       humanFileSize,
+      handleLoginClick,
     };
   },
 });
@@ -143,7 +149,7 @@ export default defineComponent({
       <v-chip
         v-else
         class="grow text-subtitle-1 ml-4"
-        href="/login"
+        @click="handleLoginClick"
       >
         Log in to download
       </v-chip>

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -10,6 +10,10 @@ declare module 'axios' {
   }
 }
 
+// The name of a custom event that is dispatched when a refresh token exchange fails
+// Consider moving this to a separate module if we end up having more custom events
+export const REFRESH_TOKEN_EXPIRED_EVENT = 'nmdc:refreshTokenExpired';
+
 const cache = setupCache({
   key: (req) => req.url + JSON.stringify(req.params) + JSON.stringify(req.data),
   maxAge: 15 * 60 * 1000,
@@ -764,7 +768,7 @@ function exchangeRefreshToken(): Promise<TokenResponse> {
       return data;
     } catch (error) {
       window.localStorage.removeItem(REFRESH_TOKEN_KEY);
-      window.dispatchEvent(new CustomEvent('refreshTokenExpired', {
+      window.dispatchEvent(new CustomEvent(REFRESH_TOKEN_EXPIRED_EVENT, {
         detail: { error },
       }));
       throw new RefreshTokenExchangeError(`Refresh request failed: ${error}`);

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -786,6 +786,8 @@ client.interceptors.response.use(undefined, async (error: AxiosError) => {
     const { config } = error;
     config.sent = true;
     const tokenResponse = await exchangeRefreshToken();
+    // Retrying the original request will *not* pick up the new default Authorization header. We
+    // must set it manually here before sending out the retry.
     config.headers = {
       ...config.headers,
       Authorization: `Bearer ${tokenResponse.access_token}`,

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -764,6 +764,9 @@ function exchangeRefreshToken(): Promise<TokenResponse> {
       return data;
     } catch (error) {
       window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+      window.dispatchEvent(new CustomEvent('refreshTokenExpired', {
+        detail: { error },
+      }));
       throw new RefreshTokenExchangeError(`Refresh request failed: ${error}`);
     }
   }

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -1,7 +1,14 @@
 import { merge } from 'lodash';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { setupCache } from 'axios-cache-adapter';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
+
+// The token refresh and retry logic stores an extra bit of state on the request config
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    sent?: boolean;
+  }
+}
 
 const cache = setupCache({
   key: (req) => req.url + JSON.stringify(req.params) + JSON.stringify(req.data),
@@ -10,7 +17,10 @@ const cache = setupCache({
     query: false,
     methods: ['delete'],
     paths: [
+      /me/,
+      /users/,
       /logout/,
+      /bulk_download/,
       /data_object\/.*/,
     ],
   },
@@ -23,6 +33,10 @@ const client = axios.create({
 
 const staticFileClient = axios.create({
   baseURL: '/static',
+});
+
+const authClient = axios.create({
+  baseURL: '/auth',
 });
 
 /* The real entity types */
@@ -340,6 +354,20 @@ export interface User{
     is_admin: boolean;
 }
 
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type: string;
+  expires: number;
+}
+
+export class RefreshTokenExchangeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RefreshTokenExchangeError';
+  }
+}
+
 async function _search<T>(
   table: string,
   {
@@ -612,14 +640,16 @@ async function textSearch(terms: string) {
   return data;
 }
 
-async function me(): Promise<string> {
-  const { data } = await client.get<string>('me');
-  return data;
-}
-
-async function myOrcid(): Promise<string> {
-  const { data } = await client.get<string>('me/orcid');
-  return data;
+async function me(): Promise<User | null> {
+  try {
+    const { data } = await client.get<User>('me');
+    return data;
+  } catch (error) {
+    if (error instanceof RefreshTokenExchangeError) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 async function getAllUsers(params: SearchParams) {
@@ -652,6 +682,119 @@ async function getGoldEcosystemTree() {
   return data;
 }
 
+const REDIRECT_URI = `${window.location.origin}/login`;
+/**
+ * Initiates the ORCID login flow by navigating to the /auth/login endpoint, providing the
+ * redirect_uri as the frontend route (/login) which will handle the authorization code exchange.
+ */
+function initiateOrcidLogin() {
+  window.location.href = `${window.location.origin}/auth/login?redirect_uri=${encodeURIComponent(REDIRECT_URI)}`;
+}
+
+const REFRESH_TOKEN_KEY = 'storage.refreshToken';
+
+/**
+ * Handle a token response by setting the API client's default Authorization header with the access
+ * token and storing the refresh token (if provided) in local storage.
+ *
+ * @param response TokenResponse object
+ */
+function handleTokenResponse(response: TokenResponse) {
+  const { access_token, refresh_token } = response;
+  client.defaults.headers.common.Authorization = `Bearer ${access_token}`;
+  if (refresh_token) {
+    window.localStorage.setItem(REFRESH_TOKEN_KEY, refresh_token);
+  }
+}
+
+/**
+ * Exchange an authorization code for access token and refresh tokens
+ *
+ * @param code Authorization code
+ */
+async function exchangeAuthCode(code: string): Promise<void> {
+  const { data } = await authClient.post('/token', {
+    code,
+    redirect_uri: REDIRECT_URI,
+  });
+  handleTokenResponse(data);
+}
+
+/**
+ * Logout by sending a POST request to the /auth/logout endpoint. This is the only /auth endpoint
+ * which requires an Authorization header. Use the API client's Authorization header, which was set
+ * on login. After the request is sent, remove the default Authorization header from the API client
+ * and remove the refresh token from local storage.
+ */
+async function logout() {
+  try {
+    await authClient.post('/logout', null, {
+      headers: {
+        Authorization: client.defaults.headers.common.Authorization,
+      },
+    });
+  } finally {
+    delete client.defaults.headers.common.Authorization;
+    window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+}
+
+let refreshRequestCache: Promise<TokenResponse> | null = null;
+const REFRESH_REQUEST_MAX_AGE_MS: number = 1000 * 20;
+
+/**
+ * Exchange a refresh token for a new access token. Retrieve the refresh token from local storage.
+ * If one exists, send a POST request to the /auth/refresh endpoint. If the request is successful,
+ * save the returned token. If the request fails, remove the refresh token from local storage
+ * assuming that it either expired or has been invalidated.
+ *
+ * The returned promise is memoized for up to 20 seconds to prevent multiple concurrent refresh
+ * token exchange requests which could happen on page load.
+ */
+function exchangeRefreshToken(): Promise<TokenResponse> {
+  async function _doExchange(): Promise<TokenResponse> {
+    const refreshToken = window.localStorage.getItem(REFRESH_TOKEN_KEY);
+    if (!refreshToken) {
+      throw new RefreshTokenExchangeError('No refresh token found');
+    }
+    delete client.defaults.headers.common.Authorization;
+    try {
+      const { data } = await authClient.post<TokenResponse>('/refresh', { refresh_token: refreshToken });
+      handleTokenResponse(data);
+      return data;
+    } catch (error) {
+      window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+      throw new RefreshTokenExchangeError(`Refresh request failed: ${error}`);
+    }
+  }
+
+  if (refreshRequestCache !== null) {
+    return refreshRequestCache;
+  }
+  refreshRequestCache = _doExchange();
+  setTimeout(() => {
+    refreshRequestCache = null;
+  }, REFRESH_REQUEST_MAX_AGE_MS);
+  return refreshRequestCache;
+}
+
+// Add a response interceptor to the API client which handles 401 errors. If a 401 is received, a
+// refresh token exchange is attempted. If the refresh token exchange is successful, the original
+// request is retried with the new access token. The `sent` flag is used to prevent infinite loops.
+client.interceptors.response.use(undefined, async (error: AxiosError) => {
+  if (error.response?.status === 401 && error.config.sent !== true) {
+    const { config } = error;
+    config.sent = true;
+    const tokenResponse = await exchangeRefreshToken();
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${tokenResponse.access_token}`,
+    };
+    return client.request(config);
+  }
+  throw error;
+});
+
 const api = {
   createBulkDownload,
   getBinnedFacet,
@@ -670,7 +813,6 @@ const api = {
   getSubmissionSchema,
   getGoldEcosystemTree,
   me,
-  myOrcid,
   searchBiosample,
   searchOmicsProcessing,
   searchStudy,
@@ -683,6 +825,10 @@ const api = {
   textSearch,
   getAllUsers,
   updateUser,
+  initiateOrcidLogin,
+  exchangeAuthCode,
+  exchangeRefreshToken,
+  logout,
 };
 
 export {

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -5,7 +5,6 @@ import { init as SentryInit } from '@sentry/vue';
 import AsyncComputed from 'vue-async-computed';
 
 import router from '@/plugins/router';
-import { init } from '@/store';
 import vuetify from '@/plugins/vuetify';
 import { provideRouter } from '@/use/useRouter';
 
@@ -31,8 +30,6 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 Vue.config.productionTip = false;
-
-init(router);
 
 new Vue({
   router,

--- a/web/src/plugins/router.ts
+++ b/web/src/plugins/router.ts
@@ -4,6 +4,8 @@ import VueRouter, { Route } from 'vue-router';
 import Search from '@/views/Search/SearchLayout.vue';
 import SamplePage from '@/views/IndividualResults/SamplePage.vue';
 import StudyPage from '@/views/IndividualResults/StudyPage.vue';
+import UserPage from '@/views/User/UserPage.vue';
+import LoginPage from '@/views/Login/LoginPage.vue';
 
 /* Submission portal */
 import MultiOmicsDataForm from '@/views/SubmissionPortal/Components/MultiOmicsDataForm.vue';
@@ -15,8 +17,6 @@ import TemplateChooser from '@/views/SubmissionPortal/Components/TemplateChooser
 import HarmonizerView from '@/views/SubmissionPortal/HarmonizerView.vue';
 import ValidateSubmit from '@/views/SubmissionPortal/Components/ValidateSubmit.vue';
 import SubmissionList from '@/views/SubmissionPortal/Components/SubmissionList.vue';
-
-import UserPage from '@/views/User/UserPage.vue';
 
 import { unlockSubmission } from '@/views/SubmissionPortal/store/api';
 
@@ -102,6 +102,11 @@ const router = new VueRouter({
       path: '/users',
       name: 'Users',
       component: UserPage,
+    },
+    {
+      path: '/login',
+      name: 'Login',
+      component: LoginPage,
     },
   ],
   scrollBehavior: () => ({ x: 0, y: 0 }),

--- a/web/src/plugins/utils.ts
+++ b/web/src/plugins/utils.ts
@@ -6,42 +6,80 @@ import descriptor from '@/data/protobuf-descriptor.json';
 
 const QueryParams = protobufjs.Root.fromJSON(descriptor).lookupType('nmdc.QueryParams');
 
-function arrayBufferToBase64(buffer: Iterable<number>) {
+/**
+ * Convert an ArrayBuffer to a base6 encoded string using URL-safe characters since the result will
+ * be used in a URL query param.
+ * See: https://www.rfc-editor.org/rfc/rfc4648#section-5
+ * @param buffer
+ */
+function arrayBufferToBase64Urlencoded(buffer: Iterable<number>) {
   let binary = '';
   const bytes = new Uint8Array(buffer);
   const len = bytes.byteLength;
   for (let i = 0; i < len; i += 1) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return window.btoa(binary);
+  const base64 = window.btoa(binary);
+  return base64
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
 }
 
-function stringifyQuery(q: any) {
-  if ('conditions' in q && q.conditions.length) {
-    const clone = cloneDeep(q);
-    clone.conditions.forEach((c: Condition) => {
+/**
+ * Convert a base64 encoded string using URL-safe characters to an ArrayBuffer.
+ * @param base64Urlencoded
+ */
+function base64UrlencodedToArrayBuffer(base64Urlencoded: string) {
+  const base64 = base64Urlencoded
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+  return new Uint8Array(window.atob(base64).split('').map((c) => c.charCodeAt(0)));
+}
+
+/**
+ * If the query contains conditions, encode them as a protobuf message, put the result into the
+ * q parameter, and remove the conditions parameter.
+ */
+function stringifyQuery(params: any) {
+  if ('conditions' in params) {
+    if (params.conditions.length) {
+      const clone = cloneDeep(params);
+      clone.conditions.forEach((c: Condition) => {
+        // eslint-disable-next-line no-param-reassign
+        c.value = JSON.stringify(c.value);
+      });
+      // https://github.com/protobufjs/protobuf.js/issues/1261#issuecomment-667430623
+      const msg = QueryParams.fromObject(clone);
+      const u8a = QueryParams.encode(msg).finish();
       // eslint-disable-next-line no-param-reassign
-      c.value = JSON.stringify(c.value);
-    });
-    // https://github.com/protobufjs/protobuf.js/issues/1261#issuecomment-667430623
-    const msg = QueryParams.fromObject(clone);
-    const u8a = QueryParams.encode(msg).finish();
-    return '?q='.concat(arrayBufferToBase64(u8a));
+      params.q = arrayBufferToBase64Urlencoded(u8a);
+    }
+    // eslint-disable-next-line no-param-reassign
+    delete params.conditions;
   }
-  return '';
+  const queryParamsString = new URLSearchParams(params).toString();
+  return queryParamsString ? `?${queryParamsString}` : '';
 }
 
+/**
+ * If the query contains a q parameter, decode it into the conditions parameter.
+ */
 function parseQuery(q: string) {
-  const b64 = q.length >= 3 ? q.slice(2) : '';
-  const u8a = new Uint8Array(atob(b64).split('').map((c) => c.charCodeAt(0)));
-  const msg = QueryParams.decode(u8a);
-  const obj = QueryParams.toObject(msg, { enums: String });
-  obj.conditions.forEach((c: Condition) => {
-    // @ts-ignore
-    // eslint-disable-next-line no-param-reassign
-    c.value = JSON.parse(c.value);
-  });
-  return obj;
+  const params = new URLSearchParams(q);
+  const parsed = Object.fromEntries(params.entries());
+  if (params.has('q')) {
+    const u8a = base64UrlencodedToArrayBuffer(params.get('q')!);
+    const msg = QueryParams.decode(u8a);
+    const obj = QueryParams.toObject(msg, { enums: String });
+    obj.conditions.forEach((c: Condition) => {
+      // @ts-ignore
+      // eslint-disable-next-line no-param-reassign
+      c.value = JSON.parse(c.value);
+    });
+    parsed.conditions = obj.conditions;
+  }
+  return parsed;
 }
 
 export {

--- a/web/src/views/Login/LoginPage.vue
+++ b/web/src/views/Login/LoginPage.vue
@@ -1,0 +1,62 @@
+<script lang="ts">
+
+import { defineComponent, onMounted, ref } from '@vue/composition-api';
+import { useRouter } from '@/use/useRouter';
+import { api } from '@/data/api';
+import { init } from '@/store';
+
+/**
+ * This component is responsible for handling the authorization code exchange process. It is the
+ * target of the redirect URI after the user has authenticated with ORCID. The code that is passed
+ * in the query string is exchanged for an access token and refresh token. Then the user is
+ * redirected to the home page (via the init() function).
+ */
+export default defineComponent({
+  name: 'LoginPage',
+  setup() {
+    const router = useRouter();
+
+    const error = ref<boolean>(false);
+
+    onMounted(async () => {
+      if (!router) {
+        error.value = true;
+        return;
+      }
+      // If there is no code in the query string, stop here
+      const { query } = router.currentRoute;
+      if (!('code' in query)) {
+        error.value = true;
+        return;
+      }
+      // Attempt to exchange the code for an access token
+      try {
+        await api.exchangeAuthCode(query.code as string);
+      } catch (e) {
+        error.value = true;
+        return;
+      }
+      // If the exchange was successful, call the init() function to load the user's data and
+      // redirect to the home page
+      await init(router);
+    });
+
+    return {
+      error,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-main>
+    <v-container>
+      <div v-if="error === false">
+        Logging in...
+      </div>
+      <div v-else>
+        Something went wrong. <a href="/">Go home</a>.
+      </div>
+    </v-container>
+  </v-main>
+</template>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -154,7 +154,7 @@ export default defineComponent({
         })),
       })));
 
-    const loggedInUser = computed(() => typeof stateRefs.user.value === 'string');
+    const loggedInUser = computed(() => stateRefs.user.value !== null);
 
     const vistab = ref(0);
     const gatedOmicsVisConditions = useClockGate(

--- a/web/src/views/SubmissionPortal/Components/LoginPrompt.vue
+++ b/web/src/views/SubmissionPortal/Components/LoginPrompt.vue
@@ -1,10 +1,14 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
+import { api } from '@/data/api';
 
 export default defineComponent({
   setup() {
+    function handleLoginClick() {
+      api.initiateOrcidLogin();
+    }
     return {
-      loginHref: '/login',
+      handleLoginClick,
     };
   },
 });
@@ -34,10 +38,10 @@ export default defineComponent({
         </v-col>
         <v-col class="flex-grow-0">
           <v-btn
-            :href="loginHref"
             variant="plain"
             elevation="0"
             style="background: transparent"
+            @click="handleLoginClick"
           >
             <img
               width="28px"

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
 import {
+  computed,
   defineComponent,
   onMounted,
   ref,
@@ -15,8 +16,8 @@ import {
   isOwner,
   canEditSubmissionMetadata,
 } from '../store';
+import { stateRefs } from '@/store';
 import SubmissionDocsLink from './SubmissionDocsLink.vue';
-import { api } from '../../../data/api';
 import SubmissionPermissionBanner from './SubmissionPermissionBanner.vue';
 
 export default defineComponent({
@@ -24,7 +25,7 @@ export default defineComponent({
   setup() {
     const formRef = ref();
 
-    const currentUserOrcid = ref('');
+    const currentUserOrcid = computed(() => stateRefs.user.value?.orcid);
 
     const permissionHelpText = ref([
       {
@@ -84,7 +85,6 @@ export default defineComponent({
 
     onMounted(async () => {
       formRef.value.validate();
-      currentUserOrcid.value = await api.myOrcid();
     });
 
     return {

--- a/web/src/views/SubmissionPortal/StepperView.vue
+++ b/web/src/views/SubmissionPortal/StepperView.vue
@@ -27,7 +27,7 @@ export default defineComponent({
       if (!lockedByUser) {
         return true;
       }
-      if (lockedByUser.orcid === stateRefs.orcid.value) {
+      if (lockedByUser.orcid === stateRefs.user.value?.orcid) {
         return true;
       }
       return false;

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -1,10 +1,5 @@
-import axios from 'axios';
-import { SearchParams, User } from '@/data/api';
+import { client, SearchParams, User } from '@/data/api';
 import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
-
-const client = axios.create({
-  baseURL: process.env.VUE_APP_BASE_URL || '/api',
-});
 
 interface NmdcAddress {
   name: string;

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -15,9 +15,8 @@ module.exports = {
       '/static': {
         target: 'http://localhost:8000/',
       },
-      '/DataHarmonizer': {
-        target: 'http://localhost:3333',
-        pathRewrite: { '^/DataHarmonizer': '' },
+      '/auth': {
+        target: 'http://localhost:8000',
       },
     },
   },


### PR DESCRIPTION
~~I'm marking this as a Draft PR for now because I don't want this going out with the [2024.5 Release](https://github.com/microbiomedata/issues/issues/685), but it is fully ready for review and testing.~~

***

Well well well here it is at long last. This is the complete replacement of session cookie-based authentication with Bearer token authentication.

## Why?

Session cookie authentication works well for a backend working with a single frontend where both are served from the same origin. However as a project, we have outgrown that constraint since we now have:

- Internal automated tasks that want to make requests to `nmdc-server` API endpoints that require authorization (e.g. the process that fetches submission data, transforms it, and inserts it into MongoDB)
- The Field Notes app, which extensively uses metadata submission endpoints
- NMDC EDGE is starting to think about how to integrate with the Submission Portal. It's not clear right now exactly how that will shake out, but I think it's safe to assume they will want to make API requests on behalf of a user.

## Backend Overview

In broad strokes these changes implement an "OAuth2-like" flow to provide a user with access and refresh tokens. I won't claim this it fully follows the OAuth2 specification (for example, we don't have a concept of assigning client IDs or client secrets), but it borrows ideas from it. _Within_ our OAuth2-like process we hand off the actual user authentication to ORCID.

From start to finish the process is this:

1. To initiate the authentication process a client navigates to `{nmdc-server}/auth/login` and _must_ provide a `redirect_uri` query parameter.
2. The nmdc-server backend verifies that the provided `redirect_uri` matches an allowed list of origins. This can be configured by the environment. For example, the dev nmdc-server backend might be configured to only allow redirects to `https://data-dev.microbiomedata.org` and `https://fieldnotes.microbiomedata.org`. 
3. After validating the `redirect_uri`, we store it in a session cookie. Yes, session cookies are still part of the process! But they are only an "internal" detail of this process and not used for actual authentication after the process completes.
4. The last step in handling the `{nmdc-server}/auth/login` request is to redirect the client to the ORCID sign-in page. This requires providing ORCID a redirect URI that they can use after the user enters their credentials. We do **not** use the `redirect_uri` provided in step 1 for this. The redirect URI provided to ORCID is always `{nmdc-server}/auth/orcid-token`.
5. Once the user enters their ORCID credentials, ORCID redirects back to `{nmdc-server}/auth/orcid-token` with an authorization code.
6. The request handler for `{nmdc-server}/auth/orcid-token` collects the ORCID authorization code from the query parameters and sends a `POST` request to `{orcid}/oauth/token` with a body that includes (among other required things) the ORCID authorization code.
7. ORCID responds to the `POST` request with a JSON response that includes an ORCID access_token and some basic user information. 
8. The request handler for `{nmdc-server}/auth/orcid-token` uses that response to get or create a User object in the nmdc-server Postgres database based on the user's ORCID iD and name.
9. Then it retrieves the `redirect_uri` stashed away in step 3.
10. Then it generates an nmdc-server authorization code (stored in the Postgres database) which is tied to the user (step 8) and redirect_uri (step 9).
11. The request handler for `{nmdc-server}/auth/orcid-token` completes by responding with a redirect to `redirect_uri` originally provided in step 1, passing the nmdc-server authorization code generated in step 10.
12. The client must now exchange the nmdc-server authorization code for access tokens. It does this by sending a `POST` request to `{nmdc-server}/auth/token` with the nmdc-server authorization code and original `redirect_uri`.
13. The request handler for `{nmdc-server}/auth/token` looks up the provided nmdc-server authorization code in Postgres.
14. Then it validates that it is coming from the same `redirect_uri` that originally generated it and that it hasn't expired (the authorization code is valid for 5 minutes).
15. Then it generates nmdc-server access and refresh tokens for the user associated with the authorization code.
16. The request handler for `{nmdc-server}/auth/token` completes by sending the tokens in a JSON response.

```mermaid
sequenceDiagram
    client->>nmdc-server: 1. Navigate to /auth/login?redirect_uri=CLIENT_REDIRECT_URI
    Note over nmdc-server: 2. Validate CLIENT_REDIRECT_URI in allow list
    Note over nmdc-server: 3. Store CLIENT_REDIRECT_URI in session cookie
    nmdc-server->>ORCID: 4. Redirect to {orcid}/oauth/authorize?client_id=...&redirect_uri={nmdc-server}/auth/orcid-token
    ORCID->>nmdc-server: 5. Redirect to {nmdc-server}/auth/orcid-token?code=ORCID_AUTH_CODE
    nmdc-server->>ORCID: 6. POST {orcid}/oauth/token with ORCID_AUTH_CODE
    ORCID->>nmdc-server: 7. ORCID access_token, ORCID refresh_token, user details
    Note over nmdc-server: 8. Get or create User object from Postgres with user details
    Note over nmdc-server: 9. Retrieve CLIENT_REDIRECT_URI from session cookie
    Note over nmdc-server: 10. Generate nmdc-server authorization code tied to<br/>User and CLIENT_REDIRECT_URI
    nmdc-server->>client: 11. Redirect to CLIENT_REDIRECT_URI?code=NMDC_SERVER_AUTH_CODE
    client->>nmdc-server: 12. POST {nmdc-server}/auth/token with NMDC_SERVER_AUTH_CODE
    Note over nmdc-server: 13. Lookup NMDC_SERVER_AUTH_CODE in Postgres
    Note over nmdc-server: 14. Validate NMDC_SERVER_AUTH_CODE matches original<br/>CLIENT_REDIRECT_URI and hasn't expired
    Note over nmdc-server: 15. Generate nmdc-server access and refresh tokens
    nmdc-server->>client: 16. nmdc-server access_token, nmdc-server refresh_token
```

Steps 4 through 7 constitute what ORCID refers to as ["3 legged OAuth"](https://info.orcid.org/ufaqs/how-does-3-legged-oauth-work/), but it is also commonly referred to generically as the [OAuth Authorization Code Flow](https://www.oauth.com/oauth2-servers/server-side-apps/authorization-code/). 

There is an second, alternative path to obtaining nmdc-server access and refresh tokens for clients that just happen to have an OpenID Connect (OIDC) ID Token issued by ORCID. A client can send a `POST` request with the ID Token to `{nmdc-server}/auth/oidc-login`. The request handler will validate that the ID Token was issued by ORCID to a _known_ audience (we currently accept only our own ORCID client ID, but we could expand that in the future) and that it has not expired. If validation succeeds, the ID token's claims are used to get or create a User object in the `nmdc-server` Postgres database. Then access and refresh tokens are generated for the user and returned in a JSON response.

The nmdc-server frontend will use the first mechanism (`/auth/login` followed by `/auth/token`) because it allows the Authorization Code Flow with ORCID to use our ORCID Member client ID/secret and to request the `/read-limited` scope. This could enable us, in the future, to do something after step 7 with the ORCID access_token that has elevated privileges. 

The alternative OIDC method, on the other hand, could be useful for external clients like NMDC EDGE which also work with ORCID as an authentication provider.

## Frontend overview

Once the client has obtained access and refresh tokens it handles them by:

1. Use the access token to set the default `Authorization` header on API requests
2. Store the refresh token in local storage

The access token has a relatively short expiration time. If a request fails with a 401 Unauthorized status, the client reads the refresh token from storage and sends a `POST /auth/refresh` request with it. If the refresh token is valid, a new access token is generated and sent as a response. The client can then retry the original request with the new access token.

Since the access token is only stored in memory, when the page is fully reloaded there will never be an access token available. Therefore a refresh token exchange is initiated each time the main `App` component is mounted. 

In the event that multiple concurrent API requests fail with a 401 Unauthorized status, the function that handles making the refresh token exchange is memoized for up to 20 seconds so that only one actual refresh request goes to the server.

## Future work

One thing that I know isn't great with these changes is the experience of someone trying to use endpoints via the Swagger interface that require authentication. Clicking the Authorize button in the Swagger interface now simply asks the user to provide a Bearer token, which wouldn't be easy for them to find. My suggestion would be to add a frontend view for logged-in users that allows them to copy their current access and/or refresh token. The access token could be pasted into the Swagger interface. The refresh token could be integrated into longer-standing automated scripts. 

As currently implemented the token exchange in step 12 does relatively minimal checks that the client exchanging the the authorization code is the same client that initiated the process (step 1). It mainly relies on the short expiration time of the authorization code to mitigate leaked authorization codes. One possible enhancement to that step would be to implement something inspired by [PKCE](https://www.oauth.com/oauth2-servers/pkce/) which would be a stronger verification of that the correct client is exchanging the code.

***

I know this is a huge change set, and I'm more than happy to answer any question or to even meet to go over anything in more detail. Just let me know!

cc: @shreddd @eecavanna 