### PR TITLE
Fix DataHarmonizer scrolling issue

### DIFF
--- a/web/src/components/Presentation/AppHeader.vue
+++ b/web/src/components/Presentation/AppHeader.vue
@@ -3,6 +3,8 @@ import { defineComponent } from '@vue/composition-api';
 import AuthButton from '@/components/Presentation/AuthButton.vue';
 import Menus from '@/menus';
 
+export const APP_HEADER_HEIGHT = 82;
+
 export default defineComponent({
   components: {
     AuthButton,
@@ -10,6 +12,7 @@ export default defineComponent({
   setup() {
     return {
       Menus,
+      APP_HEADER_HEIGHT,
     };
   },
 });
@@ -22,7 +25,7 @@ export default defineComponent({
     color="white"
     clipped-left
     elevation="4"
-    height="82"
+    :height="APP_HEADER_HEIGHT"
   >
     <a
       class="header-logo"
@@ -59,6 +62,7 @@ export default defineComponent({
         content-class="navigation-button-text-animate elevation-4"
         :open-on-hover="true"
         transition="fade-transition"
+        z-index="501"
       >
         <template #activator="{ on, attrs }">
           <v-btn

--- a/web/src/views/SubmissionPortal/Components/SubmissionStepper.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionStepper.vue
@@ -55,7 +55,7 @@ export default defineComponent({
 <template>
   <v-stepper
     :value="step"
-    class="mb-3"
+    class="mb-3 flex-shrink-0"
     outlined
     tile
     dark

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -1027,7 +1027,6 @@ html {
 #harmonizer-root {
   width: 100%;
   height: 100%;
-  overflow: auto;
 
   .secondary-header-cell:hover {
     cursor: pointer;

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -769,9 +769,7 @@ export default defineComponent({
     <div
       class="harmonizer-style-container harmonizer-and-sidebar"
     >
-      <div class="harmonizer-container">
-        <div id="harmonizer-root" />
-      </div>
+      <div id="harmonizer-root" />
 
       <div
         :style="{
@@ -1024,14 +1022,11 @@ html {
   overflow: auto;
 }
 
-.harmonizer-container {
-  flex-grow: 1;
-  overflow: auto;
-}
-
 /* Grid */
 #harmonizer-root {
+  width: 100%;
   height: 100%;
+  overflow: auto;
 
   .secondary-header-cell:hover {
     cursor: pointer;

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -36,6 +36,7 @@ import FindReplace from './Components/FindReplace.vue';
 import SubmissionStepper from './Components/SubmissionStepper.vue';
 import SubmissionDocsLink from './Components/SubmissionDocsLink.vue';
 import SubmissionPermissionBanner from './Components/SubmissionPermissionBanner.vue';
+import { APP_HEADER_HEIGHT } from '@/components/Presentation/AppHeader.vue';
 
 interface ValidationErrors {
   [error: string]: [number, number][],
@@ -456,6 +457,7 @@ export default defineComponent({
     }
 
     return {
+      APP_HEADER_HEIGHT,
       ColorKey,
       HARMONIZER_TEMPLATES,
       columnVisibility,
@@ -504,8 +506,8 @@ export default defineComponent({
 
 <template>
   <div
-    style="overflow-y: hidden; overflow-x: hidden;"
-    class="d-flex flex-column fill-height"
+    :style="{'overflow-y': 'hidden', 'overflow-x': 'hidden', 'height': `calc(100vh - ${APP_HEADER_HEIGHT}px)`}"
+    class="d-flex flex-column"
   >
     <SubmissionStepper />
     <submission-permission-banner
@@ -760,26 +762,22 @@ export default defineComponent({
       </v-tooltip>
     </v-tabs>
 
-    <div>
-      <div v-if="schemaLoading">
-        Loading...
-      </div>
-      <div
-        class="harmonizer-style-container"
-        :style="{
-          'margin-right': sidebarOpen ? '300px' : '0px'
-        }"
-      >
+    <div v-if="schemaLoading">
+      Loading...
+    </div>
+
+    <div
+      class="harmonizer-style-container harmonizer-and-sidebar"
+    >
+      <div class="harmonizer-container">
         <div id="harmonizer-root" />
       </div>
 
       <div
         :style="{
-          'float': 'right',
           'width': sidebarOpen ? '300px' : '0px',
-          'margin-top': '9px',
           'font-size': '14px',
-          'height': 'calc(100vh - 362px)'
+          'position': 'relative',
         }"
       >
         <v-btn
@@ -872,7 +870,7 @@ export default defineComponent({
         id="harmonizer-footer-root"
       />
     </div>
-    <div class="d-flex shrink ma-2">
+    <div class="d-flex ma-2">
       <v-btn
         color="gray"
         depressed
@@ -1017,13 +1015,23 @@ html {
   }
 }
 
+.harmonizer-and-sidebar {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  flex-grow: 1;
+  overflow: auto;
+}
+
+.harmonizer-container {
+  flex-grow: 1;
+  overflow: auto;
+}
+
 /* Grid */
 #harmonizer-root {
-  overflow: hidden;
-  width: 100%;
-  height: calc(100vh - 362px) !important;
-  float: left;
-  margin-top: 8px;
+  height: 100%;
 
   .secondary-header-cell:hover {
     cursor: pointer;
@@ -1090,11 +1098,12 @@ html {
 }
 
 .sidebar-toggle {
-  margin-top: -1px;
-  margin-left: -50px;
   background: white;
   z-index: 500;
   position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateX(-100%);
   border-color: rgb(152, 152, 152);
   border-right-color: rgba(152, 152, 152, 0.0);
 }

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -776,6 +776,7 @@ export default defineComponent({
           'width': sidebarOpen ? '300px' : '0px',
           'font-size': '14px',
           'position': 'relative',
+          'flex-shrink': '0',
         }"
       >
         <v-btn

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -209,9 +209,16 @@ export class HarmonizerApi {
       modalsRoot: document.querySelector('.harmonizer-style-container'),
       fieldSettings: this._getFieldSettings(),
       columnHelpEntries: ['column', 'description', 'guidance', 'examples'],
+      // we use our own custom help sidebar, so turn off DataHarmonizer's built-in one
+      helpSidebar: {
+        enabled: false,
+      },
     });
     this.footer = new Footer(document.querySelector('#harmonizer-footer-root'), this.dh);
     this.dh.useSchema(this.schema, [], templateName);
+    // Let the Handsontable element take up as much space as it wants, it will be visually
+    // constrained by its containing elements
+    this.dh.hot.updateSettings({ height: 'auto', width: 'auto' });
     this._postTemplateChange();
 
     // @ts-ignore

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -216,9 +216,6 @@ export class HarmonizerApi {
     });
     this.footer = new Footer(document.querySelector('#harmonizer-footer-root'), this.dh);
     this.dh.useSchema(this.schema, [], templateName);
-    // Let the Handsontable element take up as much space as it wants, it will be visually
-    // constrained by its containing elements
-    this.dh.hot.updateSettings({ height: 'auto', width: 'auto' });
     this._postTemplateChange();
 
     // @ts-ignore
@@ -320,7 +317,12 @@ export class HarmonizerApi {
         this.selectedColumn.value = column.title;
       }
     }, 200, { leading: true }));
-    this.dh.hot.updateSettings({ search: true, customBorders: true });
+    this.dh.hot.updateSettings({
+      search: true,
+      customBorders: true,
+      height: '100%',
+      width: '100%',
+    });
     this.jumpToRowCol(0, 0);
   }
 


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/issues/issues/701

### Testing instructions

* Create a new submission portal entry or open an existing one that you can edit, just ensure that in Step 4 (Multi-omics Data) the Metagenome checkbox under JGI is selected
* On Step 6 (the DataHarmonizer screen), ensure there are at least ~100 rows are filled out with at least an ID and that they all have "metagenomics" filled out in the "analysis/data type" column
* Click on the "JGI MG" tab
* Verify that you can scroll to the bottom and see all rows

### Details

Previously we set a fixed height directly on the element (`#harmonizer-root`) where the DataHarmonizer instance is mounted. This was a bit janky because the `362px` offset is a bit too brittle to changes in surrounding elements _and_ it doesn't interact well with DataHarmonizer's (sort of odd) choice to have the [height](https://github.com/cidgoh/DataHarmonizer/blob/cc21dc8f7dff3e7fbb9d9cdb2e560ef6f29707fa/lib/DataHarmonizer.js#L504) of its Handsontable instance be `75vh`. So these changes:

* Override DataHarmoinzer's `75vh` choice by telling the Handsontable instance to have a width and height setting of `auto`.
* Make the entire DataHarmonizer screen have a fixed heigh based on the height of the site's `v-app-bar` -- both controlled by the same variable.
* Set various flexbox and overflow settings to let the actual DataHarmonizer container shrink/grow to take up as much space as it can within the bounds of the fixed height element.

This also fixes the minor annoyance that when the red validation result box appears it doesn't push the row with the color key and submit button slightly off the bottom of the page.