### PR TITLE
Show save progress

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -164,14 +164,20 @@ export default defineComponent({
       ])),
     ));
 
-    const onDataChange = () => {
+    const isSaving = ref();
+    const saveSuccess = ref();
+    const onBeforeChange = () => {
+      isSaving.value = true;
+    };
+    const onDataChange = async () => {
       hasChanged.value += 1;
       const data = harmonizerApi.exportJson();
       mergeSampleData(activeTemplate.value.sampleDataSlot, data);
-      incrementalSaveRecord(root.$route.params.id);
+      const httpStatus = await incrementalSaveRecord(root.$route.params.id);
       tabsValidated.value[activeTemplateKey.value] = false;
+      saveSuccess.value = httpStatus === 200;
+      isSaving.value = false;
     };
-
     const { request: schemaRequest, loading: schemaLoading } = useRequest();
     onMounted(async () => {
       const [schema, goldEcosystemTree] = await schemaRequest(() => Promise.all([
@@ -183,6 +189,7 @@ export default defineComponent({
         await harmonizerApi.init(r, schema, activeTemplate.value.schemaClass, goldEcosystemTree);
         await nextTick();
         harmonizerApi.loadData(activeTemplateData.value);
+        harmonizerApi.addBeforeChangeHook(onBeforeChange);
         harmonizerApi.addChangeHook(onDataChange);
         if (!canEditSampleMetadata()) {
           harmonizerApi.setTableReadOnly();
@@ -470,6 +477,8 @@ export default defineComponent({
       packageName,
       fields,
       highlightedValidationError,
+      isSaving,
+      saveSuccess,
       sidebarOpen,
       validationItems,
       validationActiveCategory,
@@ -615,6 +624,35 @@ export default defineComponent({
           </v-btn>
         </v-card>
         <submission-docs-link anchor="sample-metadata" />
+        <span
+          v-if="isSaving"
+          class="text-center"
+        >
+          <v-progress-circular
+            color="primary"
+            :width="1"
+            size="20"
+            value="70"
+          />
+          Saving progress
+        </span>
+        <span v-if="saveSuccess && !isSaving">
+          <v-icon
+
+            color="green"
+          >
+            mdi-check
+          </v-icon>
+          Changes saved successfully
+        </span>
+        <span v-else-if="saveSuccess === false">
+          <v-icon
+            color="red"
+          >
+            mdi-close
+          </v-icon>
+          Failed to save changes
+        </span>
         <v-spacer />
         <v-autocomplete
           v-model="jumpToModel"

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -406,6 +406,19 @@ export class HarmonizerApi {
     return this.dh.invalid_cells;
   }
 
+  addBeforeChangeHook(callback: Function) {
+    if (!this.ready.value) {
+      return;
+    }
+    // calls function on any non-programmatic change of the data
+    this.dh.hot.addHook('beforeChange', (changes: any[], source: string | null) => {
+      if (source === 'loadData') {
+        return;
+      }
+      callback();
+    });
+  }
+
   addChangeHook(callback: Function) {
     if (!this.ready.value) {
       return;

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -70,7 +70,7 @@ async function updateRecord(id: string, record: Partial<MetadataSubmission>, sta
     status,
     permissions,
   });
-  return resp.data;
+  return { data: resp.data, httpStatus: resp.status };
 }
 
 async function listRecords(params: SearchParams) {

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -275,7 +275,9 @@ async function incrementalSaveRecord(id: string) {
   }
 
   if (hasChanged.value) {
-    await api.updateRecord(id, payload, undefined, permissions);
+    const response = await api.updateRecord(id, payload, undefined, permissions);
+    // eslint-disable-next-line consistent-return
+    return response.httpStatus;
   }
   hasChanged.value = 0;
 }


### PR DESCRIPTION
closes https://github.com/microbiomedata/user_research/issues/18

This adds a `beforeChangeHook` the fires when a user enters new data, initiating a spinning progress component. When a 200 is returned from the patch a green check mark appears with text indicating successful save. If the patch does not return a 200 a red 'x' is shown with corresponding text.