### PR TITLE
Redirect users to submission portal if logging in from submission portal

### DIFF
--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -15,7 +15,18 @@ export default defineComponent({
     const router = useRouter();
 
     function handleLogin() {
-      api.initiateOrcidLogin();
+      if (!router) {
+        api.initiateOrcidLogin();
+        return;
+      }
+
+      const submissionState = 'submission';
+      const submissionRegex = new RegExp(submissionState);
+      let state = '';
+      if (submissionRegex.test(router.currentRoute.path)) {
+        state += submissionState;
+      }
+      api.initiateOrcidLogin(state);
     }
 
     async function handleLogout() {

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -691,8 +691,12 @@ const REDIRECT_URI = `${window.location.origin}/login`;
  * Initiates the ORCID login flow by navigating to the /auth/login endpoint, providing the
  * redirect_uri as the frontend route (/login) which will handle the authorization code exchange.
  */
-function initiateOrcidLogin() {
-  window.location.href = `${window.location.origin}/auth/login?redirect_uri=${encodeURIComponent(REDIRECT_URI)}`;
+function initiateOrcidLogin(state: string = '') {
+  let loginUrl = `${window.location.origin}/auth/login?redirect_uri=${encodeURIComponent(REDIRECT_URI)}`;
+  if (state) {
+    loginUrl += `&state=${encodeURIComponent(state)}`;
+  }
+  window.location.href = loginUrl;
 }
 
 const REFRESH_TOKEN_KEY = 'storage.refreshToken';

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -100,7 +100,7 @@ const dataObjectFilter: ComputedRef<DataObjectFilter[]> = computed(() => state
 /**
  * load the current user on app start
  */
-async function init(_router: VueRouter, loadUser = true) {
+async function init(_router: VueRouter, loadUser = true, loginState = '' as string | (string | null)[]) {
   if (loadUser) {
     state.userLoading = true;
     try {
@@ -110,11 +110,21 @@ async function init(_router: VueRouter, loadUser = true) {
     }
   }
   router = _router;
-  // @ts-ignore
-  state.conditions = router.currentRoute.query?.conditions || [];
-  if (state.user) {
-    restoreState();
-  } else {
+  // Handle the login state
+  switch (loginState) {
+    case 'submission':
+      router.push('submission/home');
+      break;
+    default:
+      // Login normally
+      // @ts-ignore
+      state.conditions = router.currentRoute.query?.conditions || [];
+      if (state.user) {
+        restoreState();
+      }
+      break;
+  }
+  if (!state.user) {
     watchEffect(persistState);
   }
 }

--- a/web/src/views/Login/LoginPage.vue
+++ b/web/src/views/Login/LoginPage.vue
@@ -23,12 +23,14 @@ export default defineComponent({
         error.value = true;
         return;
       }
+
       // If there is no code in the query string, stop here
       const { query } = router.currentRoute;
       if (!('code' in query)) {
         error.value = true;
         return;
       }
+
       // Attempt to exchange the code for an access token
       try {
         await api.exchangeAuthCode(query.code as string);
@@ -36,9 +38,11 @@ export default defineComponent({
         error.value = true;
         return;
       }
+
       // If the exchange was successful, call the init() function to load the user's data and
-      // redirect to the home page
-      await init(router);
+      // redirect to the home page. The init() function can handle the state URL query param
+      // that has been persisted through the login process.
+      await init(router, true, query.state);
     });
 
     return {

--- a/web/src/views/SubmissionPortal/Components/LoginPrompt.vue
+++ b/web/src/views/SubmissionPortal/Components/LoginPrompt.vue
@@ -5,7 +5,7 @@ import { api } from '@/data/api';
 export default defineComponent({
   setup() {
     function handleLoginClick() {
-      api.initiateOrcidLogin();
+      api.initiateOrcidLogin('submission');
     }
     return {
       handleLoginClick,


### PR DESCRIPTION
Fix microbiomedata/user_research#19

### Changes
Enable passing a state parameter to `initiateOrcidLogin()`, which is encoded in the login request and persisted by the server during the login process.

This handles two workflows where the user would need to be redirected:

1. When clicking the normal login button (the one in the app bar) while navigated to any route containing `submission`
2. When clicking the "login" button that appears on the submission homepage

In those 2 cases, the string `submission` is passed to `initiateOrcidLogin()`.

When we return from the server during the login process, we can expect a `state` query parameter if we sent one up at the start of login. The `init` function now takes this as an optional parameter and handles it accordingly. The only value for `state` that is handled differently as part of these changes is `submission`, in which case the `submission/home` route is pushed to the Vue router.

### To test
Make sure logging in from the submission home screen redirects you back to the submision home screen. Test for regressions by making sure that the filter state is persisted during normal (data portal) login.