### PR TITLE
Add biosample columns to partial search

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -56,7 +56,7 @@ async def me(user: User = Depends(get_current_user)) -> Optional[User]:
     response_model=List[query.ConditionResultSchema],
 )
 def text_search(terms: str, limit=6, db: Session = Depends(get_db)):
-    # Add 'ilike' filters for study columns users may want to search by
+    # Add 'ilike' filters for study and biosample columns users may want to search by
     study_name_filter = {
         "table": "study",
         "value": terms.lower(),
@@ -75,12 +75,40 @@ def text_search(terms: str, limit=6, db: Session = Depends(get_db)):
         "field": "title",
         "op": "like",
     }
+    biosample_name_filter = {
+        "table": "biosample",
+        "value": terms.lower(),
+        "field": "name",
+        "op": "like",
+    }
+    biosample_description_filter = {
+        "table": "biosample",
+        "value": terms.lower(),
+        "field": "description",
+        "op": "like",
+    }
+    biosample_title_filter = {
+        "table": "biosample",
+        "value": terms.lower(),
+        "field": "title",
+        "op": "like",
+    }
+    biosample_id_filter = {
+        "table": "biosample",
+        "value": terms.lower(),
+        "field": "id",
+        "op": "like",
+    }
     # These two lists are of objects of separate types
     filters = crud.text_search(db, terms, limit)
     plaintext_filters = [
         query.SimpleConditionSchema(**study_name_filter),
         query.SimpleConditionSchema(**study_description_filter),
         query.SimpleConditionSchema(**study_title_filter),
+        query.SimpleConditionSchema(**biosample_name_filter),
+        query.SimpleConditionSchema(**biosample_description_filter),
+        query.SimpleConditionSchema(**biosample_title_filter),
+        query.SimpleConditionSchema(**biosample_id_filter),
     ]
     return [*filters, *plaintext_filters]
 


### PR DESCRIPTION
Closes #1046 
Adds partial search for `id`, `title`, `name` and `description` for biosamples