### PR TITLE
Fix berkeley image tag

### DIFF
--- a/.github/workflows/berkeley-image.yml
+++ b/.github/workflows/berkeley-image.yml
@@ -40,7 +40,6 @@ jobs:
             prefix=berkeley
           tags: |
             type=ref,event=branch
-            type=raw,value=berkeley
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Remove redundant use of `berkeley` in tag name.