### PR TITLE
Rename `expires` to `expires_in` in TokenResponse

### DIFF
--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -75,7 +75,7 @@ class TokenResponse(BaseModel):
     access_token: bytes
     refresh_token: Optional[bytes] = None
     token_type: str = "bearer"
-    expires: int
+    expires_in: int
 
 
 class RefreshRequestBody(BaseModel):
@@ -136,7 +136,7 @@ def create_token_response(user: models.User, *, create_refresh_token: bool = Tru
     access_token = encode_token(data=token_data, expires_delta=expires_delta)
     response = TokenResponse(
         access_token=access_token,
-        expires=expires_delta.total_seconds(),
+        expires_in=expires_delta.total_seconds(),
     )
     if create_refresh_token:
         token_data["typ"] = JwtTypes.Refresh

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -362,7 +362,7 @@ export interface TokenResponse {
   access_token: string;
   refresh_token?: string;
   token_type: string;
-  expires: number;
+  expires_in: number;
 }
 
 export class RefreshTokenExchangeError extends Error {


### PR DESCRIPTION
This came up in the discussion of an `nmdc-runtime` PR (https://github.com/microbiomedata/nmdc-runtime/pull/572). Even though we're not claiming to be a full OAuth 2.0-compatible authorization server, I had intended to remain close to the standard where possible. I think it was just an oversight that I had used `expires` instead of the [recommended](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) `expires_in` as a field in the `TokenResponse` class. 

Nothing in the front-end actually uses that value, so I think this is a fairly low-risk change. But I'd rather change it now before it hits production for the first time.