### PR TITLE
Remove extraneous data update call when changing tabs

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -448,8 +448,6 @@ export default defineComponent({
         return;
       }
 
-      onDataChange();
-
       await validate();
 
       // When changing templates we may need to populate the common columns
@@ -781,7 +779,7 @@ export default defineComponent({
             <v-tab>
               <v-badge
                 :content="validationTotalCounts[templateKey] || '!'"
-                :value="validationTotalCounts[templateKey] > 0 || !tabsValidated[templateKey] || status !== submissionStatus.InProgress"
+                :value="validationTotalCounts[templateKey] > 0 || !tabsValidated[templateKey]"
                 :color="validationTotalCounts[templateKey] > 0 ? 'error' : 'warning'"
               >
                 {{ HARMONIZER_TEMPLATES[templateKey].displayName }}

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -276,6 +276,7 @@ async function incrementalSaveRecord(id: string): Promise<number | void> {
 
   if (hasChanged.value) {
     const response = await api.updateRecord(id, payload, undefined, permissions);
+    hasChanged.value = 0;
     return response.httpStatus;
   }
   hasChanged.value = 0;


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/issues/issues/736

Two small updates related to recent "show save indicator" work here.

1. In the recent work, the `onDataChange` function became async. However its invocation in `changeTemplate` was not awaited before invoking the `validate` function. Both `onDataChange` and `validate` modify the `tabsValidated` object. Once `onDataChnage` became async its changes to `tabsValidated` got applied _after_ (and therefore clobbering) the changes applied in `validate`. Instead of awaiting the call to `onDataChange`, however, the fix here is actually to just remove it entirely. I believe all the necessary state updates when changing tabs are handled sufficiently by `validate`. The call to `onDataChange` may have at one time been necessary but not anymore.
2. In debugging I noticed that the `hasChanged` ref value was no longer being reset after a successful API call because of the early return of the response status code. I don't know if that was causing any problems other than potentially unnecessary API requests going out, but it seemed straightforward to fix.

As a side note, it seems like some of the "save indicator" work in `HarmonizerView.vue` tracking loading and error state partially replicates what's already in the [`useRequest`](https://github.com/microbiomedata/nmdc-server/blob/main/web/src/use/useRequest.ts) utility. Maybe at some we can circle back and consolidate that.