### PR TITLE
Implement endpoint that returns TSV file of submission summaries

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1,6 +1,7 @@
+import csv
 import json
 import logging
-from io import BytesIO
+from io import BytesIO, StringIO
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -621,6 +622,70 @@ async def download_zip_file(
             "Content-Disposition": "attachment; filename=archive.zip",
         },
     )
+
+
+@router.get(
+    "/metadata_submission/report",
+    tags=["metadata_submission"],
+)
+async def get_metadata_submissions_report(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    r"""
+    Download a TSV file containing a high-level report of Submission Portal submissions,
+    including their ID, author info, study info, and PI info.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Your account has insufficient privileges.")
+
+    # Get the submissions from the database.
+    q = crud.get_query_for_all_submissions(db)
+    submissions = q.all()
+
+    # Iterate through the submissions, building the data rows for the report.
+    header_row = [
+        "Submission ID",
+        "Author ORCID",
+        "Author Name",
+        "Study Name",
+        "PI Name",
+        "PI Email",
+    ]
+    data_rows = []
+    for s in submissions:
+        author_name = s.author.name  # note: `s.author` is a `User` instance
+        study_form = (
+            s.metadata_submission["studyForm"] if "studyForm" in s.metadata_submission else {}
+        )
+        study_name = study_form["studyName"] if "studyName" in study_form else ""
+        pi_name = study_form["piName"] if "piName" in study_form else ""
+        pi_email = study_form["piEmail"] if "piEmail" in study_form else ""
+        data_row = [s.id, s.author_orcid, author_name, study_name, pi_name, pi_email]
+        data_rows.append(data_row)
+
+    # Build the report as an in-memory TSV "file" (buffer).
+    # Reference: https://docs.python.org/3/library/csv.html#csv.writer
+    buffer = StringIO()
+    writer = csv.writer(buffer, delimiter="\t")
+    writer.writerow(header_row)
+    writer.writerows(data_rows)
+
+    # Reset the buffer's internal file pointer to the beginning of the buffer, so that,
+    # when we stream the buffer's contents later, all of its contents are included.
+    buffer.seek(0)
+
+    # Stream the buffer's contents to the HTTP client as a downloadable TSV file.
+    # Reference: https://fastapi.tiangolo.com/advanced/custom-response/#using-streamingresponse-with-file-like-objects
+    # Reference: https://mimetype.io/text/tab-separated-values
+    filename = "submissions-report.tsv"
+    response = StreamingResponse(
+        buffer,
+        media_type="text/tab-separated-values",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+    return response
 
 
 @router.get(

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -632,6 +632,19 @@ def get_submissions_for_user(db: Session, user: models.User):
     return permitted_submissions
 
 
+def get_query_for_all_submissions(db: Session):
+    r"""
+    Returns a SQLAlchemy query that can be used to retrieve all submissions.
+
+    Reference: https://fastapi.tiangolo.com/tutorial/sql-databases/#crud-utils
+    Reference: https://docs.sqlalchemy.org/en/14/orm/session_basics.html
+    """
+    all_submissions = db.query(models.SubmissionMetadata).order_by(
+        models.SubmissionMetadata.created.desc()
+    )
+    return all_submissions
+
+
 def get_roles_for_submission(
     db: Session, submission: models.SubmissionMetadata
 ) -> List[models.SubmissionRole]:

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -27,6 +27,24 @@ def test_list_submissions(db: Session, client: TestClient, logged_in_user):
     assert response.json()["results"][0]["id"] == str(submission.id)
 
 
+def test_get_metadata_submissions_report(db: Session, client: TestClient, logged_in_user):
+    submission = fakes.MetadataSubmissionFactory(
+        author=logged_in_user, author_orcid=logged_in_user.orcid
+    )
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=logged_in_user.orcid,
+        role=SubmissionEditorRole.owner,
+    )
+    fakes.SubmissionRoleFactory()
+    fakes.SubmissionRoleFactory()
+    db.commit()
+
+    response = client.request(method="GET", url="/api/metadata_submission/report")
+    assert response.status_code == 200
+
+
 def test_try_edit_locked_submission(db: Session, client: TestClient, logged_in_user):
     # Locked by a random user at utcnow by default
     submission = fakes.MetadataSubmissionFactory(


### PR DESCRIPTION
In this branch, I implemented an API endpoint at `/metadata_submission/report` that responds with a downloadable TSV file containing a high-level report of Submission Portal submissions. I am designing this endpoint with a specific use case in mind: quarterly metrics collection.

At this point, I have implemented the API endpoint and the underlying CRUD function.

The test code in this branch is still preliminary.