### PR TITLE
Add user info page

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -8,6 +8,8 @@ jobs:
     defaults:
       run:
         working-directory: web
+    env:
+      NODE_OPTIONS: --openssl-legacy-provider
     name: Client Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -11,10 +11,10 @@ jobs:
     name: Client Tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
         node-version: 'lts/*'
     - run: yarn install --frozen-lockfile --network-timeout 300000
@@ -35,9 +35,9 @@ jobs:
         postgresql db: 'nmdc'
         postgresql user: 'nmdc'
         postgresql password: 'nmdc'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Create environment

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: 'recursive'
     - uses: actions/setup-node@v1
       with:
-        node-version: '14.x'
+        node-version: 'lts/*'
     - run: yarn install --frozen-lockfile --network-timeout 300000
     - run: yarn lint
     - run: yarn build

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -26,6 +26,11 @@ def attach_sentry(app: FastAPI):
 def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     app = FastAPI(
         title="NMDC Data and Submission Portal API",
+        description="""
+To use authenticated endpoints, you must first obtain an Access Token by following the instructions in the Developer 
+Tools section <a href="/user">here</a>. Once you have an Access Token, click the "Authorize" button on this page. In the
+popup, paste the token in the "Value" field and click "Authorize".
+""",
         version=__version__,
         docs_url="/api/docs",
         openapi_url="/api/openapi.json",

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -27,9 +27,10 @@ def create_app(env: typing.Mapping[str, str]) -> FastAPI:
     app = FastAPI(
         title="NMDC Data and Submission Portal API",
         description="""
-To use authenticated endpoints, you must first obtain an Access Token by following the instructions in the Developer 
-Tools section <a href="/user">here</a>. Once you have an Access Token, click the "Authorize" button on this page. In the
-popup, paste the token in the "Value" field and click "Authorize".
+To use authenticated endpoints, you must first obtain an Access Token by following the
+instructions in the Developer Tools section <a href="/user">here</a>. Once you have an Access
+Token, click the "Authorize" button on this page. In the popup, paste the token in the "Value"
+field and click "Authorize".
 """,
         version=__version__,
         docs_url="/api/docs",

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -23,6 +23,9 @@ module.exports = {
     'vuejs-accessibility/anchor-has-content': 'off',
     'vuejs-accessibility/click-events-have-key-events': 'off',
     'vue/no-v-html': 'off',
+    // See: https://github.com/vuejs/eslint-plugin-vue/issues/365
+    // The issue is supposed to be resolved, but eslint complains without the ignore
+    'vue/html-indent': ['warn', 2, { ignores: ['VElement[name=pre].children'] }],
     camelcase: 0,
     // we should always disable console logs and debugging in production
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "data-harmonizer": "1.6.5",
     "filesize": "^8.0.6",
     "jquery": "3.5.1",
+    "jwt-decode": "^4.0.0",
     "leaflet": "^1.7.1",
     "leaflet.markercluster": "^1.5.3",
     "linkify-it": "^4.0.1",

--- a/web/src/components/Presentation/AuthButton.vue
+++ b/web/src/components/Presentation/AuthButton.vue
@@ -76,7 +76,7 @@ export default defineComponent({
         :plain="nav"
         :small="nav"
         :ripple="!nav"
-        :href="me.orcid ? `https://orcid.org/${me.orcid}` : ''"
+        :to="{ name: 'User' }"
       >
         <v-icon left>
           mdi-account-circle

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -701,6 +701,18 @@ function initiateOrcidLogin(state: string = '') {
 
 const REFRESH_TOKEN_KEY = 'storage.refreshToken';
 
+function getRefreshToken() {
+  return window.localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+function setRefreshToken(token: string) {
+  return window.localStorage.setItem(REFRESH_TOKEN_KEY, token);
+}
+
+function clearRefreshToken() {
+  return window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
 /**
  * Handle a token response by setting the API client's default Authorization header with the access
  * token and storing the refresh token (if provided) in local storage.
@@ -711,7 +723,7 @@ function handleTokenResponse(response: TokenResponse) {
   const { access_token, refresh_token } = response;
   client.defaults.headers.common.Authorization = `Bearer ${access_token}`;
   if (refresh_token) {
-    window.localStorage.setItem(REFRESH_TOKEN_KEY, refresh_token);
+    setRefreshToken(refresh_token);
   }
 }
 
@@ -743,7 +755,7 @@ async function logout() {
     });
   } finally {
     delete client.defaults.headers.common.Authorization;
-    window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+    clearRefreshToken();
   }
 }
 
@@ -761,7 +773,7 @@ const REFRESH_REQUEST_MAX_AGE_MS: number = 1000 * 20;
  */
 function exchangeRefreshToken(): Promise<TokenResponse> {
   async function _doExchange(): Promise<TokenResponse> {
-    const refreshToken = window.localStorage.getItem(REFRESH_TOKEN_KEY);
+    const refreshToken = getRefreshToken();
     if (!refreshToken) {
       throw new RefreshTokenExchangeError('No refresh token found');
     }
@@ -771,7 +783,7 @@ function exchangeRefreshToken(): Promise<TokenResponse> {
       handleTokenResponse(data);
       return data;
     } catch (error) {
-      window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+      clearRefreshToken();
       window.dispatchEvent(new CustomEvent(REFRESH_TOKEN_EXPIRED_EVENT, {
         detail: { error },
       }));
@@ -842,6 +854,7 @@ const api = {
   exchangeAuthCode,
   exchangeRefreshToken,
   logout,
+  getRefreshToken,
 };
 
 export {

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -2,6 +2,7 @@ import { merge } from 'lodash';
 import axios, { AxiosError } from 'axios';
 import { setupCache } from 'axios-cache-adapter';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc.schema.json';
+import { clearRefreshToken, getRefreshToken, setRefreshToken } from '@/store/localStorage';
 
 // The token refresh and retry logic stores an extra bit of state on the request config
 declare module 'axios' {
@@ -699,20 +700,6 @@ function initiateOrcidLogin(state: string = '') {
   window.location.href = loginUrl;
 }
 
-const REFRESH_TOKEN_KEY = 'storage.refreshToken';
-
-function getRefreshToken() {
-  return window.localStorage.getItem(REFRESH_TOKEN_KEY);
-}
-
-function setRefreshToken(token: string) {
-  return window.localStorage.setItem(REFRESH_TOKEN_KEY, token);
-}
-
-function clearRefreshToken() {
-  return window.localStorage.removeItem(REFRESH_TOKEN_KEY);
-}
-
 /**
  * Handle a token response by setting the API client's default Authorization header with the access
  * token and storing the refresh token (if provided) in local storage.
@@ -854,7 +841,6 @@ const api = {
   exchangeAuthCode,
   exchangeRefreshToken,
   logout,
-  getRefreshToken,
 };
 
 export {

--- a/web/src/plugins/router.ts
+++ b/web/src/plugins/router.ts
@@ -5,6 +5,7 @@ import Search from '@/views/Search/SearchLayout.vue';
 import SamplePage from '@/views/IndividualResults/SamplePage.vue';
 import StudyPage from '@/views/IndividualResults/StudyPage.vue';
 import UserPage from '@/views/User/UserPage.vue';
+import UserDetailPage from '@/views/User/UserDetailPage.vue';
 import LoginPage from '@/views/Login/LoginPage.vue';
 
 /* Submission portal */
@@ -102,6 +103,11 @@ const router = new VueRouter({
       path: '/users',
       name: 'Users',
       component: UserPage,
+    },
+    {
+      path: '/user',
+      name: 'User',
+      component: UserDetailPage,
     },
     {
       path: '/login',

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -8,6 +8,7 @@ import { removeCondition as utilsRemoveCond } from '@/data/utils';
 import {
   api, Condition, DataObjectFilter, EnvoNode, EnvoTree, User,
 } from '@/data/api';
+import { clearQueryState, getQueryState, setQueryState } from '@/store/localStorage';
 
 // TODO: Remove in version 3;
 Vue.use(CompositionApi);
@@ -25,7 +26,6 @@ const unreactive = {
   nodeMapId: {} as Record<string, EnvoNode>,
   nodeMapLabel: {} as Record<string, EnvoNode>,
 };
-const queryStateKey = 'storage.queryState';
 
 /**
  * Persist state into localstorage
@@ -33,10 +33,10 @@ const queryStateKey = 'storage.queryState';
 function persistState() {
   /* If the user is browsing anonymously, stash their state in case they log in */
   if (!state.user) {
-    window.localStorage.setItem(queryStateKey, JSON.stringify({
+    setQueryState({
       conditions: state.conditions,
       bulkDownloadSelected: state.bulkDownloadSelected,
-    }));
+    });
   }
 }
 
@@ -75,12 +75,12 @@ function setUniqueCondition(
  * Restore state from localStorage and clear
  */
 function restoreState() {
-  const previousState = window.localStorage.getItem(queryStateKey);
+  const previousState = getQueryState();
   if (previousState) {
-    const { conditions, bulkDownloadSelected } = JSON.parse(previousState);
+    const { conditions, bulkDownloadSelected } = previousState;
     setConditions(conditions);
     state.bulkDownloadSelected = bulkDownloadSelected;
-    window.localStorage.removeItem(queryStateKey);
+    clearQueryState();
   }
 }
 

--- a/web/src/store/localStorage.ts
+++ b/web/src/store/localStorage.ts
@@ -1,0 +1,36 @@
+const QUERY_STATE_KEY = 'storage.queryState';
+const REFRESH_TOKEN_KEY = 'storage.refreshToken';
+
+function getQueryState() {
+  const state = window.localStorage.getItem(QUERY_STATE_KEY);
+  return state ? JSON.parse(state) : null;
+}
+
+function setQueryState(state: any) {
+  return window.localStorage.setItem(QUERY_STATE_KEY, JSON.stringify(state));
+}
+
+function clearQueryState() {
+  return window.localStorage.removeItem(QUERY_STATE_KEY);
+}
+
+function getRefreshToken() {
+  return window.localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+function setRefreshToken(token: string) {
+  return window.localStorage.setItem(REFRESH_TOKEN_KEY, token);
+}
+
+function clearRefreshToken() {
+  return window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+export {
+  getQueryState,
+  setQueryState,
+  clearQueryState,
+  getRefreshToken,
+  setRefreshToken,
+  clearRefreshToken,
+};

--- a/web/src/views/User/UserDetailPage.vue
+++ b/web/src/views/User/UserDetailPage.vue
@@ -3,16 +3,16 @@ import { defineComponent, ref } from '@vue/composition-api';
 import moment from 'moment';
 import { jwtDecode } from 'jwt-decode';
 import AppBanner from '@/components/AppBanner.vue';
-import { api } from '@/data/api';
 import OrcidId from '@/components/Presentation/OrcidId.vue';
 import { stateRefs } from '@/store';
+import { getRefreshToken } from '@/store/localStorage';
 
 export default defineComponent({
   name: 'UserDetailPage',
   components: { OrcidId, AppBanner },
 
   setup() {
-    const refreshToken = api.getRefreshToken();
+    const refreshToken = getRefreshToken();
     let refreshTokenExpirationDate;
     if (refreshToken != null) {
       const decodedToken = jwtDecode(refreshToken);

--- a/web/src/views/User/UserDetailPage.vue
+++ b/web/src/views/User/UserDetailPage.vue
@@ -1,0 +1,195 @@
+<script lang="ts">
+import { defineComponent, ref } from '@vue/composition-api';
+import moment from 'moment';
+import { jwtDecode } from 'jwt-decode';
+import AppBanner from '@/components/AppBanner.vue';
+import { api } from '@/data/api';
+import OrcidId from '@/components/Presentation/OrcidId.vue';
+import { stateRefs } from '@/store';
+
+export default defineComponent({
+  name: 'UserDetailPage',
+  components: { OrcidId, AppBanner },
+
+  setup() {
+    const refreshToken = api.getRefreshToken();
+    let tokenExpiration;
+    if (refreshToken != null) {
+      const decodedToken = jwtDecode(refreshToken);
+      if (decodedToken.exp != null) {
+        tokenExpiration = moment.unix(decodedToken.exp).format('YYYY-MM-DD HH:mm:ss');
+      }
+    }
+    const showToken = ref(false);
+    const showCopyRefreshTokenSnackbar = ref(false);
+
+    const copyRefreshTokenToClipboard = async () => {
+      if (refreshToken != null) {
+        await navigator.clipboard.writeText(refreshToken);
+        showCopyRefreshTokenSnackbar.value = true;
+      }
+    };
+
+    const toggleTokenVisibility = () => {
+      showToken.value = !showToken.value;
+    };
+
+    const handleRefreshTokenInputClick = (event: MouseEvent) => {
+      event.preventDefault();
+      if (showToken.value) {
+        (event.target as HTMLInputElement).select();
+      }
+    };
+
+    return {
+      user: stateRefs.user,
+      userLoading: stateRefs.userLoading,
+      // loading,
+      // error,
+      base: window.location.origin,
+      refreshToken,
+      tokenExpiration,
+      showCopyRefreshTokenSnackbar,
+      showToken,
+      toggleTokenVisibility,
+      handleRefreshTokenInputClick,
+      copyRefreshTokenToClipboard,
+    };
+  },
+});
+</script>
+
+<template>
+  <v-main>
+    <AppBanner v-if="false" />
+    <v-container>
+      <div v-if="userLoading">
+        Loading...
+      </div>
+      <div v-else-if="user">
+        <div class="mb-8">
+          <div class="py-2">
+            <span class="text-h4">{{ user.name }}</span>
+            <v-chip
+              v-if="user.is_admin"
+              class="mx-2"
+              style="vertical-align: baseline"
+              color="primary"
+            >
+              <v-icon
+                left
+              >
+                mdi-shield-account
+              </v-icon>
+              Admin
+            </v-chip>
+          </div>
+          <orcid-id
+            :orcid-id="user.orcid"
+            :authenticated="false"
+            :width="24"
+          />
+        </div>
+
+        <div class="mb-8">
+          <div class="text-h5 py-2">
+            Developer Tools
+          </div>
+          <p>
+            To access authenticated endpoints in the <a href="/api/docs">NMDC Data and Submission Portal API</a> you
+            must provide an <b>Access Token</b> in the <code>Authorization</code> header of the request. An
+            <b>Access Token</b> is valid for 24 hours and can be obtained by providing your <b>Refresh Token</b> to the
+            <code>/auth/refresh</code> endpoint. Your <b>Refresh Token</b> and its expiration date can be found below.
+            <b>Treat this Refresh Token as securely as you would treat a password!</b>
+          </p>
+
+          <v-row>
+            <v-col
+              cols="auto"
+            >
+              <v-text-field
+                label="Refresh Token"
+                readonly
+                filled
+                :type="showToken ? 'text' : 'password'"
+                :value="refreshToken"
+                @click="handleRefreshTokenInputClick"
+              >
+                <template #append>
+                  <v-icon
+                    right
+                    @click="toggleTokenVisibility"
+                  >
+                    {{ showToken ? 'mdi-eye' : 'mdi-eye-off' }}
+                  </v-icon>
+                  <v-icon
+                    right
+                    @click="copyRefreshTokenToClipboard"
+                  >
+                    mdi-content-copy
+                  </v-icon>
+                </template>
+              </v-text-field>
+            </v-col>
+            <v-col
+              cols="auto"
+            >
+              <v-text-field
+                label="Expiration Date"
+                readonly
+                filled
+                type="text"
+                :value="tokenExpiration"
+              />
+            </v-col>
+          </v-row>
+
+          <div class="text-h6 py-2">
+            Example
+          </div>
+          <ol class="mb-4">
+            <li>
+              In your project, store your Refresh Token in a variable named <code>REFRESH_TOKEN</code>.
+            </li>
+            <li>
+              Exchange your Refresh Token for an Access Token which will be valid for 24 hours.
+              <pre>
+curl \
+  -H "content-type: application/json" \
+  -d "{ \"refresh_token\": \"$REFRESH_TOKEN\"}" \
+  {{ base }}/auth/refresh
+              </pre>
+            </li>
+            <li>
+              Store the value returned in the <code>access_token</code> in your program and use it when making
+              authenticated API requests.
+              <pre>
+curl \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  {{ base }}/api/me
+              </pre>
+            </li>
+            <li>
+              If your program runs for more than 24 hours. Step 2 will need to be repeated once the Access Token
+              expires.
+            </li>
+            <li>
+              When your Refresh Token expires (one year after your last login), visit this page again to get a new one.
+            </li>
+          </ol>
+        </div>
+      </div>
+      <div v-else>
+        You must log in to view this page.
+      </div>
+
+      <v-snackbar
+        v-model="showCopyRefreshTokenSnackbar"
+        timeout="3000"
+      >
+        Refresh Token Copied to Clipboard
+      </v-snackbar>
+    </v-container>
+  </v-main>
+</template>

--- a/web/src/views/User/UserDetailPage.vue
+++ b/web/src/views/User/UserDetailPage.vue
@@ -151,7 +151,7 @@ export default defineComponent({
             </li>
             <li>
               Exchange your Refresh Token for an Access Token which will be valid for 24 hours.
-              <pre>
+              <pre class="grey lighten-4 my-2 pa-2">
 curl \
   -H "content-type: application/json" \
   -d "{ \"refresh_token\": \"$REFRESH_TOKEN\"}" \
@@ -160,12 +160,11 @@ curl \
             <li>
               Store the value returned in the <code>access_token</code> in your program and use it when making
               authenticated API requests.
-              <pre>
+              <pre class="grey lighten-4 my-2 pa-2">
 curl \
   -H "content-type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  {{ origin }}/api/me
-              </pre>
+  {{ origin }}/api/me</pre>
             </li>
             <li>
               If your program runs for more than 24 hours. Step 2 will need to be repeated once the Access Token

--- a/web/src/views/User/UserDetailPage.vue
+++ b/web/src/views/User/UserDetailPage.vue
@@ -13,30 +13,30 @@ export default defineComponent({
 
   setup() {
     const refreshToken = api.getRefreshToken();
-    let tokenExpiration;
+    let refreshTokenExpirationDate;
     if (refreshToken != null) {
       const decodedToken = jwtDecode(refreshToken);
       if (decodedToken.exp != null) {
-        tokenExpiration = moment.unix(decodedToken.exp).format('YYYY-MM-DD HH:mm:ss');
+        refreshTokenExpirationDate = moment.unix(decodedToken.exp).format('YYYY-MM-DD HH:mm:ss');
       }
     }
-    const showToken = ref(false);
-    const showCopyRefreshTokenSnackbar = ref(false);
+    const isTokenVisible = ref(false);
+    const isCopyRefreshTokenSnackbarVisible = ref(false);
 
-    const copyRefreshTokenToClipboard = async () => {
+    const handleRefreshTokenCopyButtonClick = async () => {
       if (refreshToken != null) {
         await navigator.clipboard.writeText(refreshToken);
-        showCopyRefreshTokenSnackbar.value = true;
+        isCopyRefreshTokenSnackbarVisible.value = true;
       }
     };
 
-    const toggleTokenVisibility = () => {
-      showToken.value = !showToken.value;
+    const handleRefreshTokenVisibilityButtonClick = () => {
+      isTokenVisible.value = !isTokenVisible.value;
     };
 
     const handleRefreshTokenInputClick = (event: MouseEvent) => {
       event.preventDefault();
-      if (showToken.value) {
+      if (isTokenVisible.value) {
         (event.target as HTMLInputElement).select();
       }
     };
@@ -44,16 +44,14 @@ export default defineComponent({
     return {
       user: stateRefs.user,
       userLoading: stateRefs.userLoading,
-      // loading,
-      // error,
-      base: window.location.origin,
+      origin: window.location.origin,
       refreshToken,
-      tokenExpiration,
-      showCopyRefreshTokenSnackbar,
-      showToken,
-      toggleTokenVisibility,
+      refreshTokenExpirationDate,
+      isCopyRefreshTokenSnackbarVisible,
+      isTokenVisible,
+      handleRefreshTokenVisibilityButtonClick,
       handleRefreshTokenInputClick,
-      copyRefreshTokenToClipboard,
+      handleRefreshTokenCopyButtonClick,
     };
   },
 });
@@ -111,20 +109,20 @@ export default defineComponent({
                 label="Refresh Token"
                 readonly
                 filled
-                :type="showToken ? 'text' : 'password'"
+                :type="isTokenVisible ? 'text' : 'password'"
                 :value="refreshToken"
                 @click="handleRefreshTokenInputClick"
               >
                 <template #append>
                   <v-icon
                     right
-                    @click="toggleTokenVisibility"
+                    @click="handleRefreshTokenVisibilityButtonClick"
                   >
-                    {{ showToken ? 'mdi-eye' : 'mdi-eye-off' }}
+                    {{ isTokenVisible ? 'mdi-eye' : 'mdi-eye-off' }}
                   </v-icon>
                   <v-icon
                     right
-                    @click="copyRefreshTokenToClipboard"
+                    @click="handleRefreshTokenCopyButtonClick"
                   >
                     mdi-content-copy
                   </v-icon>
@@ -139,7 +137,7 @@ export default defineComponent({
                 readonly
                 filled
                 type="text"
-                :value="tokenExpiration"
+                :value="refreshTokenExpirationDate"
               />
             </v-col>
           </v-row>
@@ -157,8 +155,7 @@ export default defineComponent({
 curl \
   -H "content-type: application/json" \
   -d "{ \"refresh_token\": \"$REFRESH_TOKEN\"}" \
-  {{ base }}/auth/refresh
-              </pre>
+  {{ origin }}/auth/refresh</pre>
             </li>
             <li>
               Store the value returned in the <code>access_token</code> in your program and use it when making
@@ -167,7 +164,7 @@ curl \
 curl \
   -H "content-type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  {{ base }}/api/me
+  {{ origin }}/api/me
               </pre>
             </li>
             <li>
@@ -185,7 +182,7 @@ curl \
       </div>
 
       <v-snackbar
-        v-model="showCopyRefreshTokenSnackbar"
+        v-model="isCopyRefreshTokenSnackbarVisible"
         timeout="3000"
       >
         Refresh Token Copied to Clipboard

--- a/web/src/views/User/UserDetailPage.vue
+++ b/web/src/views/User/UserDetailPage.vue
@@ -12,6 +12,8 @@ export default defineComponent({
   components: { OrcidId, AppBanner },
 
   setup() {
+    const refreshTokenInput = ref();
+
     const refreshToken = getRefreshToken();
     let refreshTokenExpirationDate;
     if (refreshToken != null) {
@@ -30,14 +32,14 @@ export default defineComponent({
       }
     };
 
-    const handleRefreshTokenVisibilityButtonClick = () => {
+    const handleRefreshTokenVisibilityButtonClick = async () => {
       isTokenVisible.value = !isTokenVisible.value;
-    };
-
-    const handleRefreshTokenInputClick = (event: MouseEvent) => {
-      event.preventDefault();
       if (isTokenVisible.value) {
-        (event.target as HTMLInputElement).select();
+        // Wait for the type of the input to change before selecting the text.
+        // For some reason, nextTick isn't enough in this case.
+        setTimeout(() => {
+          refreshTokenInput.value.$refs.input.select();
+        }, 50);
       }
     };
 
@@ -47,10 +49,10 @@ export default defineComponent({
       origin: window.location.origin,
       refreshToken,
       refreshTokenExpirationDate,
+      refreshTokenInput,
       isCopyRefreshTokenSnackbarVisible,
       isTokenVisible,
       handleRefreshTokenVisibilityButtonClick,
-      handleRefreshTokenInputClick,
       handleRefreshTokenCopyButtonClick,
     };
   },
@@ -106,26 +108,47 @@ export default defineComponent({
               cols="auto"
             >
               <v-text-field
+                ref="refreshTokenInput"
                 label="Refresh Token"
                 readonly
                 filled
                 :type="isTokenVisible ? 'text' : 'password'"
                 :value="refreshToken"
-                @click="handleRefreshTokenInputClick"
               >
                 <template #append>
-                  <v-icon
-                    right
-                    @click="handleRefreshTokenVisibilityButtonClick"
+                  <v-tooltip
+                    bottom
+                    open-delay="600"
                   >
-                    {{ isTokenVisible ? 'mdi-eye' : 'mdi-eye-off' }}
-                  </v-icon>
-                  <v-icon
-                    right
-                    @click="handleRefreshTokenCopyButtonClick"
+                    <template #activator="{ on, attrs }">
+                      <v-icon
+                        right
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="handleRefreshTokenVisibilityButtonClick"
+                      >
+                        {{ isTokenVisible ? 'mdi-eye' : 'mdi-eye-off' }}
+                      </v-icon>
+                    </template>
+                    <span v-if="isTokenVisible">Hide Token</span>
+                    <span v-else>Show Token</span>
+                  </v-tooltip>
+                  <v-tooltip
+                    bottom
+                    open-delay="600"
                   >
-                    mdi-content-copy
-                  </v-icon>
+                    <template #activator="{ on, attrs }">
+                      <v-icon
+                        right
+                        v-bind="attrs"
+                        v-on="on"
+                        @click="handleRefreshTokenCopyButtonClick"
+                      >
+                        mdi-content-copy
+                      </v-icon>
+                    </template>
+                    <span>Copy Token</span>
+                  </v-tooltip>
                 </template>
               </v-text-field>
             </v-col>

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6948,6 +6948,11 @@ jsprim@^1.2.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"


### PR DESCRIPTION
Fixes #1277 

### Summary

These changes add a new page served on `/user` that provides information about the currently logged-in user. For now this page is mainly to facilitate providing information about making authenticated API requests, but it could potentially be expanded in the future.

### Details

* The top of the new page displays the user's name and ORCID iD (linked to their ORCID profile). If they are an admin that is indicated next to their name.
* The new page's Developer Tools section allows a logged-in user to view and/or copy their existing Refresh Token and provides general instructions on how to use it in their application.
* The Swagger UI's header now has instructions for obtaining and using an Access Token
* The site header's auth button now links to the new User page instead of ORCID
* To show the Refresh Token's expiration time, the JWT needs to be decoded. I added `jwt-decode` as a new dependency to handle that. That package requires Node >= 18. This meant that I needed to update the Client Tests job in the main testing workflow to use a newer version of Node instead of 14. I have it set to use the latest LTS version, which is inline with what the frontend Dockerfile uses. The necessary `NODE_OPTIONS` environment variable was also added.