### PR TITLE
Berkeley schema ingest

### DIFF
--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -34,6 +34,8 @@ class WorkflowActivityTypeEnum(Enum):
     metagenome_annotation = "nmdc:MetagenomeAnnotation"
     metaproteomic_analysis = "nmdc:MetaproteomicAnalysis"
     metatranscriptome = "nmdc:MetatranscriptomeAnalysis"
+    metatranscriptome_assembly = "nmdc:MetatranscriptomeAssembly"
+    metatranscriptome_annotation = "nmdc:MetatranscriptomeAnnotation"
     nom_analysis = "nmdc:NomAnalysis"
     raw_data = "nmdc:RawData"
     read_based_analysis = "nmdc:ReadBasedTaxonomyAnalysis"

--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -28,18 +28,16 @@ def get_local_data_url(url: Optional[str]) -> Optional[str]:
 
 
 class WorkflowActivityTypeEnum(Enum):
-    reads_qc = "nmdc:ReadQCAnalysisActivity"
+    mags_analysis = "nmdc:MagsAnalysis"
+    metabolomics_analysis = "nmdc:MetabolomicsAnalysis"
     metagenome_assembly = "nmdc:MetagenomeAssembly"
-    metagenome_annotation = "nmdc:MetagenomeAnnotation"  # TODO name out of date, fix
-    metatranscriptome_assembly = "nmdc:MetatranscriptomeAssembly"
-    metatranscriptome_annotation = "nmdc:MetatranscriptomeAnnotation"  # TODO name out of date, fix
-    metaproteomic_analysis = "nmdc:MetaProteomicAnalysis"
-    mags_analysis = "nmdc:MAGsAnalysisActivity"
-    read_based_analysis = "nmdc:ReadbasedAnalysis"  # TODO name out of date, fix
-    nom_analysis = "nmdc:NomAnalysisActivity"
-    metabolomics_analysis = "nmdc:MetabolomicsAnalysisActivity"
+    metagenome_annotation = "nmdc:MetagenomeAnnotation"
+    metaproteomic_analysis = "nmdc:MetaproteomicAnalysis"
+    metatranscriptome = "nmdc:MetatranscriptomeAnalysis"
+    nom_analysis = "nmdc:NomAnalysis"
     raw_data = "nmdc:RawData"
-    metatranscriptome = "nmdc:metaT"
+    read_based_analysis = "nmdc:ReadBasedTaxonomyAnalysis"
+    reads_qc = "nmdc:ReadQcAnalysis"
 
     @property
     def model(self):

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -142,7 +142,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading metatranscriptome assemblies...")
     pipeline.load(
         db,
-        mongodb["metatranscriptome_assembly_set"].find(),
+        mongodb["workflow_execution_set"].find({"type": "nmdc:MetatranscriptomeAssembly"}),
         pipeline.load_mt_assembly,
         WorkflowActivityTypeEnum.metatranscriptome_assembly.value,
     )
@@ -203,7 +203,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
         logger.info("Loading metatranscriptome annotation...")
         pipeline.load(
             db,
-            mongodb["metatranscriptome_annotation_set"].find(),
+            mongodb["workflow_execution_set"].find({"type": "MetatranscriptomeAnnotation"}),
             pipeline.load_mt_annotation,
             WorkflowActivityTypeEnum.metatranscriptome_annotation.value,
             annotations=mongodb["functional_annotation_agg"],

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -101,10 +101,12 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     )
     db.commit()
 
+    workflow_set = "workflow_execution_set"
+
     logger.info("Loading metabolomics analysis...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:MetabolomicsAnalysis"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.metabolomics_analysis.value}),
         pipeline.load_metabolomics_analysis,
         WorkflowActivityTypeEnum.metabolomics_analysis.value,
     )
@@ -113,7 +115,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading read based analysis...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:ReadBasedTaxonomyAnalysis"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.read_based_analysis.value}),
         pipeline.load_read_based_analysis,
         WorkflowActivityTypeEnum.read_based_analysis.value,
     )
@@ -122,7 +124,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading metatranscriptome expression analyses...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:MetatranscriptomeAnalysis"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.metatranscriptome.value}),
         pipeline.load_metatranscriptome,
         WorkflowActivityTypeEnum.metatranscriptome.value,
     )
@@ -130,7 +132,9 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading metatranscriptome assemblies...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:MetatranscriptomeAssembly"}),
+        mongodb[workflow_set].find(
+            {"type": WorkflowActivityTypeEnum.metatranscriptome_assembly.value}
+        ),
         pipeline.load_mt_assembly,
         WorkflowActivityTypeEnum.metatranscriptome_assembly.value,
     )
@@ -138,7 +142,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading NOM analysis...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:NomAnalysis"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.nom_analysis.value}),
         pipeline.load_nom_analysis,
         WorkflowActivityTypeEnum.nom_analysis.value,
     )
@@ -147,7 +151,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading MAGs...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:MagsAnalysis"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.mags_analysis.value}),
         pipeline.load_mags,
         WorkflowActivityTypeEnum.mags_analysis.value,
     )
@@ -163,9 +167,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
             # This has historically been fast, but it is only for the progress bar.
             # It can be removed if it becomes slow.
             annotation_activities = list(
-                mongodb["workflow_execution_set"].find(
-                    {"type": "nmdc:MetagenomeAnnotation"}, batch_size=100
-                )
+                mongodb[workflow_set].find({"type": "nmdc:MetagenomeAnnotation"}, batch_size=100)
             )
             # TODO test this and make sure it works as expected
             # this undoes the pagination that existed before
@@ -191,7 +193,9 @@ def load(db: Session, function_limit=None, skip_annotation=False):
         logger.info("Loading metatranscriptome annotation...")
         pipeline.load(
             db,
-            mongodb["workflow_execution_set"].find({"type": "MetatranscriptomeAnnotation"}),
+            mongodb[workflow_set].find(
+                {"type": WorkflowActivityTypeEnum.metatranscriptome_annotation.value}
+            ),
             pipeline.load_mt_annotation,
             WorkflowActivityTypeEnum.metatranscriptome_annotation.value,
             annotations=mongodb["functional_annotation_agg"],
@@ -205,7 +209,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading read qc...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:ReadQcAnalysis"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.reads_qc.value}),
         pipeline.load_reads_qc,
         WorkflowActivityTypeEnum.reads_qc.value,
     )
@@ -215,7 +219,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
         logger.info("Loading metaproteomic analysis...")
         pipeline.load(
             db,
-            mongodb["workflow_execution_set"].find(
+            mongodb[workflow_set].find(
                 {"type": "nmdc:MetaproteomicsAnalysis"},
                 no_cursor_timeout=True,
             ),
@@ -233,7 +237,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading metagenome assembly...")
     pipeline.load(
         db,
-        mongodb["workflow_execution_set"].find({"type": "nmdc:MetagenomeAssembly"}),
+        mongodb[workflow_set].find({"type": WorkflowActivityTypeEnum.metagenome_assembly.value}),
         pipeline.load_mg_assembly,
         WorkflowActivityTypeEnum.metagenome_assembly.value,
     )

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Iterator
 import click
 from pymongo import MongoClient
 from pymongo.collection import Collection
-from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 
 from nmdc_server import models

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -90,7 +90,6 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     biosample.load(
         db,
         cursor,
-        omics_processing=mongodb["omics_processing_set"],
     )
     db.commit()
 

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -228,7 +228,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
         pipeline.load(
             db,
             mongodb["workflow_execution_set"].find(
-                {"type": "nmdc:MetaproteomicAnalysis"},
+                {"type": "nmdc:MetaproteomicsAnalysis"},
                 no_cursor_timeout=True,
             ),
             pipeline.load_mp_analysis,

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -96,7 +96,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     logger.info("Loading omics processing...")
     omics_processing.load(
         db,
-        mongodb["omics_processing_set"].find(),
+        mongodb["data_generation_set"].find(),
         mongodb,
     )
     db.commit()

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -102,17 +102,6 @@ def load(db: Session, function_limit=None, skip_annotation=False):
     )
     db.commit()
 
-    """
-    nmdc:ReadQcAnalysis
-    nmdc:MagsAnalysis
-    nmdc:MetabolomicsAnalysis
-    nmdc:MetagenomeSequencing
-    nmdc:ReadBasedTaxonomyAnalysis
-    nmdc:MetagenomeAssembly
-    nmdc:MetagenomeAnnotation
-    nmdc:NomAnalysis
-    """
-
     logger.info("Loading metabolomics analysis...")
     pipeline.load(
         db,

--- a/nmdc_server/ingest/biosample.py
+++ b/nmdc_server/ingest/biosample.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any, Dict
 
 from pydantic import root_validator, validator
-from pymongo.collection import Collection
 from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 

--- a/nmdc_server/ingest/biosample.py
+++ b/nmdc_server/ingest/biosample.py
@@ -107,12 +107,12 @@ def load_biosample(db: Session, obj: Dict[str, Any]):
     if env_medium:
         obj["env_medium_id"] = env_medium.id
 
-    part_of = obj.pop("associated_studies", None)
-    if part_of is None:
+    associated_studies = obj.pop("associated_studies", None)
+    if associated_studies is None:
         logger.error(f"Could not determine study for biosample {obj['id']}")
         return
 
-    obj["study_id"] = part_of[0]
+    obj["study_id"] = associated_studies[0]
     depth_obj = obj.get("depth", {})
     obj["depth"] = extract_quantity(depth_obj, "biosample", "depth")
 

--- a/nmdc_server/ingest/biosample.py
+++ b/nmdc_server/ingest/biosample.py
@@ -108,9 +108,10 @@ def load_biosample(db: Session, obj: Dict[str, Any], omics_processing: Collectio
     if env_medium:
         obj["env_medium_id"] = env_medium.id
 
-    omics_processing_record = omics_processing.find_one({"has_input": obj["id"]})
-    part_of = obj.pop("part_of", None)
+    part_of = obj.pop("associated_studies", None)
     if part_of is None:
+        # omics_processing_record = omics_processing.find_one({"has_input": obj["id"]})
+        omics_processing_record = None
         if omics_processing_record is None:
             logger.error(f"Could not determine study for biosample {obj['id']}")
             return

--- a/nmdc_server/ingest/biosample.py
+++ b/nmdc_server/ingest/biosample.py
@@ -92,7 +92,7 @@ class Biosample(BiosampleCreate):
                     return raw_value
 
 
-def load_biosample(db: Session, obj: Dict[str, Any], omics_processing: Collection):
+def load_biosample(db: Session, obj: Dict[str, Any]):
     logger = get_logger(__name__)
     env_broad_scale_id = obj.pop("env_broad_scale", {}).get("term", {}).get("id", "")
     env_broad_scale = db.query(models.EnvoTerm).get(env_broad_scale_id.replace("_", ":"))
@@ -110,12 +110,8 @@ def load_biosample(db: Session, obj: Dict[str, Any], omics_processing: Collectio
 
     part_of = obj.pop("associated_studies", None)
     if part_of is None:
-        # omics_processing_record = omics_processing.find_one({"has_input": obj["id"]})
-        omics_processing_record = None
-        if omics_processing_record is None:
-            logger.error(f"Could not determine study for biosample {obj['id']}")
-            return
-        part_of = omics_processing_record["part_of"]
+        logger.error(f"Could not determine study for biosample {obj['id']}")
+        return
 
     obj["study_id"] = part_of[0]
     depth_obj = obj.get("depth", {})
@@ -144,11 +140,11 @@ def load_biosample(db: Session, obj: Dict[str, Any], omics_processing: Collectio
     db.add(models.Biosample(**biosample.dict()))
 
 
-def load(db: Session, cursor: Cursor, omics_processing: Collection):
+def load(db: Session, cursor: Cursor):
     logger = get_logger(__name__)
     for obj in cursor:
         try:
-            load_biosample(db, obj, omics_processing)
+            load_biosample(db, obj)
         except Exception as err:
             logger.error(f"Error parsing biosample: {err}")
             logger.error(json.dumps(obj, indent=2, default=str))

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -23,7 +23,9 @@ date_fmt = re.compile(r"\d\d-[A-Z]+-\d\d \d\d\.\d\d\.\d\d\.\d+ [AP]M")
 omics_types = {
     "metagenome": "Metagenome",
     "metabolome": "Metabolomics",
+    "metabolomics": "Metabolomics",
     "metaproteome": "Proteomics",
+    "proteomics": "Proteomics",
     "metatranscriptome": "Metatranscriptome",
     "organic matter characterization": "Organic Matter Characterization",
     "nom": "Organic Matter Characterization",

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -20,28 +20,13 @@ from nmdc_server.schemas import OmicsProcessingCreate
 date_fmt = re.compile(r"\d\d-[A-Z]+-\d\d \d\d\.\d\d\.\d\d\.\d+ [AP]M")
 
 
-process_types = [
-    "pooling",
-    "extraction",
-    "library_preparation",
-]
-
-
-collections = {
-    "biosample": "biosample_set",
-    "processed_sample": "processed_sample_set",
-    "extraction": "extraction_set",
-    "library_preparation": "library_preparation_set",
-    "pooling": "pooling_set",
-}
-
-
 omics_types = {
     "metagenome": "Metagenome",
-    "metabolomics": "Metabolomics",
-    "proteomics": "Proteomics",
+    "metabolome": "Metabolomics",
+    "metaproteome": "Proteomics",
     "metatranscriptome": "Metatranscriptome",
     "organic matter characterization": "Organic Matter Characterization",
+    "nom": "Organic Matter Characterization",
 }
 
 
@@ -65,17 +50,11 @@ def is_biosample(object_id, biosample_collection):
 
 def find_parent_process(output_id: str, mongodb: Database) -> Optional[dict[str, Any]]:
     """Given a ProcessedSample ID, find the process (e.g. Extraction) that created it."""
-    output_found = False
-    collections_left = True
-    while not output_found and collections_left:
-        for name in process_types:
-            collection: Collection = mongodb[collections[name]]
-            query = collection.find({"has_output": output_id}, no_cursor_timeout=True)
-            result_list = list(query)
-            if len(result_list):
-                output_found = True
-                return result_list[0]
-        collections_left = False
+    material_processing_collection: Collection = mongodb["material_processing_set"]
+    query = material_processing_collection.find({"has_output": output_id}, no_cursor_timeout=True)
+    result_list = list(query)
+    if len(result_list):
+        return result_list[0]
     return None
 
 
@@ -117,10 +96,6 @@ def load_omics_processing(db: Session, obj: Dict[str, Any], mongodb: Database, l
     biosample_input_ids: set[str] = set()
     for input_id in input_ids:
         biosample_input_ids.union(get_biosample_input_ids(input_id, mongodb, biosample_input_ids))
-    if len(biosample_input_ids) > 1:
-        logger.error("Processed sample input detected")
-        logger.error(obj["id"])
-        logger.error(biosample_input_ids)
 
     obj["biosample_inputs"] = []
     biosample_input_objects = []
@@ -133,9 +108,9 @@ def load_omics_processing(db: Session, obj: Dict[str, Any], mongodb: Database, l
             biosample_input_objects.append(biosample_object)
 
     data_objects = obj.pop("has_output", [])
-    obj["study_id"] = obj.pop("part_of", [None])[0]
-    raw_omics_type: str = obj["omics_type"]["has_raw_value"]
-    obj["omics_type"]["has_raw_value"] = omics_types[raw_omics_type.lower()]
+    obj["study_id"] = obj.pop("associated_studies", [None])[0]
+    obj["analyte_category"] = omics_types[obj["analyte_category"].lower()]
+    obj["omics_type"] = omics_types[obj["analyte_category"].lower()]
 
     omics_processing = models.OmicsProcessing(**OmicsProcessing(**obj).dict())
     for biosample_object in biosample_input_objects:

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -114,6 +114,13 @@ def load_omics_processing(db: Session, obj: Dict[str, Any], mongodb: Database, l
     obj["analyte_category"] = omics_types[obj["analyte_category"].lower()]
     obj["omics_type"] = omics_types[obj["analyte_category"].lower()]
 
+    # Get instrument name
+    instrument_id = obj.pop("instrument_used", [])
+    if instrument_id:
+        instrument = mongodb["instrument_set"].find_one({"id": instrument_id[0]})
+        if instrument:
+            obj["instrument_name"] = instrument["name"]
+
     omics_processing = models.OmicsProcessing(**OmicsProcessing(**obj).dict())
     for biosample_object in biosample_input_objects:
         # mypy thinks that omics_processing.biosample_inputs is of type Biosample

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -77,7 +77,12 @@ def load(db: Session, cursor: Cursor):
                 doi["doi_value"] = transform_doi(doi.pop("doi_value"))
 
             for doi in dois:
-                upsert_doi(db, **doi)
+                upsert_doi(
+                    db,
+                    doi_value=doi["doi_value"],
+                    doi_category=doi["doi_category"],
+                    doi_provider=doi.get("doi_provider", ""),
+                )
 
         new_study = create_study(db, Study(**obj))
         if dois:

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -566,7 +566,7 @@ class MAGsAnalysis(PipelineStep):
 
 class NOMAnalysisBase(PipelineStepBase):
     type: str = WorkflowActivityTypeEnum.nom_analysis.value
-    used: str
+    used: str = ""
 
 
 class NOMAnalysis(PipelineStep):
@@ -591,7 +591,7 @@ class Metatranscriptome(PipelineStep):
 
 class MetabolomicsAnalysisBase(PipelineStepBase):
     type: str = WorkflowActivityTypeEnum.metabolomics_analysis.value
-    used: str
+    used: str = ""
     has_calibration: str
 
 


### PR DESCRIPTION
Fix #1291 

### Breaking changes
This breaks the ingest process for any version of `nmdc-schema` version `<11.0.0`. For deployments of the NMDC Data Portal using this code base and ingest, ingest must be pointed at a database that conforms to the "[Berkeley Schema](https://github.com/microbiomedata/berkeley-schema-fy24)"

### Changes
This set of changes updates ingest to be able to accept data from a source mongo database running version `>=11.0.0` of the NMDC Schema (Berkeley). It does not attempt to update the data portal in any other way. From and end-user perspective, the changes here should have no impact. Users should see the same data, presented in the same way as data ingested from an older version of the mongo database. It does not attempt to rename endpoints, files, classes, functions, or variables to be up to date with the new schema either (e.g. the term "omics processing" will still exist in our code). 

Some specific changes include:

- Update link from Biosample and Data Generation to Study (`part_of` -> `associated_studies`)
- Processes that used to exist across several collections now exist in a single collection, so associating a Data Generation record with multiple Biosample inputs has been simplified
- Similarly, workflow activities have been squashed into a single collection. Now, when building our tables for these workflow executions, we query a single collection, filtering on the `type` field.
- Instead of being able to extract the instrument name from an Omics Processing record itself, we have to take the `instrument_id` field from a Data Generation object and do a lookup in the `instrument_set` collection.
- The workflow enum has been updated. This should greatly reduce the amount of warnings logged during ingest.