### PR TITLE
Use more descriptive section name for envo terms

### DIFF
--- a/web/src/components/FacetedSearch.vue
+++ b/web/src/components/FacetedSearch.vue
@@ -10,7 +10,7 @@ const groupOrders = [
   'function',
   'sample',
   'gold ecosystems',
-  'envo',
+  'mixs environmental triad',
   'omics processing',
 ];
 

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -291,26 +291,26 @@ const fields: Record<string, FieldsData> = {
     hideFacet: true,
   },
   /* END GOLD ecosystem type */
-  /* ENVO terms */
+  /* MIxS Environmental Triad terms */
   env_broad_scale: {
     name: 'Broad-scale Environmental Context',
-    group: 'ENVO',
+    group: 'MIxS Environmental Triad',
     sortKey: 1,
   },
   env_local_scale: {
     name: 'Local Environmental Context',
-    group: 'ENVO',
+    group: 'MIxS Environmental Triad',
     sortKey: 2,
   },
   env_medium: {
-    name: 'Environmental medium',
-    group: 'ENVO',
+    name: 'Environmental Medium',
+    group: 'MIxS Environmental Triad',
     sortKey: 3,
   },
   open_in_gold: {
     icon: 'mdi-link',
   },
-  /* END ENVO terms */
+  /* END MIxS Environmental Triad terms */
   /* disable uniques */
   scientific_objective: {
     hideFacet: true,

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -231,6 +231,7 @@ const fields: Record<string, FieldsData> = {
     hideAttr: true,
   },
   collection_date: {
+    name: 'Collection Date',
     icon: 'mdi-calendar',
   },
   ecosystem_path_id: {
@@ -256,8 +257,21 @@ const fields: Record<string, FieldsData> = {
   },
   gold_classification: {
     icon: 'mdi-pine-tree',
+    name: 'GOLD Classification',
     group: 'GOLD Ecosystems',
     sortKey: 0,
+  },
+  instrument_name: {
+    name: 'Instrument Name',
+    group: 'Omics Processing',
+  },
+  omics_type: {
+    name: 'Omics Type',
+    group: 'Omics Processing',
+  },
+  processing_institution: {
+    name: 'Processing Institution',
+    group: 'Omics Processing',
   },
   /* GOLD ecosystem type */
   ecosystem: {

--- a/web/src/views/Search/SearchSidebar.vue
+++ b/web/src/views/Search/SearchSidebar.vue
@@ -26,7 +26,7 @@ const FunctionSearchFacets: SearchFacet[] = [
     field: 'id',
     table: 'gene_function',
   },
-  /** ENVO */
+  /** MIxS Environmental Triad */
   {
     field: 'env_broad_scale',
     table: 'biosample',


### PR DESCRIPTION
Changes the title of the search sidebar section from "ENVO" to "MIxS Environmental Triad"
![image](https://github.com/user-attachments/assets/e645adc3-2150-4217-a909-257fcb04018e)

Additionally, changes all search facet names in the sidebar to be title case.

Fix #1175 