### PR TITLE
Add ability to track which client created a submission

### DIFF
--- a/nmdc_server/migrations/versions/b6e2cb2f8f36_add_submission_source_client.py
+++ b/nmdc_server/migrations/versions/b6e2cb2f8f36_add_submission_source_client.py
@@ -1,0 +1,49 @@
+"""Add source_client column to submission_metadata table
+
+Revision ID: b6e2cb2f8f36
+Revises: 6cdad9ad6543
+Create Date: 2024-07-17 22:52:01.118381
+
+"""
+
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b6e2cb2f8f36"
+down_revision: Optional[str] = "6cdad9ad6543"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    # The enum type must be created manually first. For some reason add_column
+    # doesn't do it automatically.
+    submissionsourceclient_enum = sa.Enum(
+        "submission_portal", "field_notes", name="submissionsourceclient"
+    )
+    submissionsourceclient_enum.create(op.get_bind())
+
+    op.add_column(
+        "submission_metadata",
+        sa.Column(
+            "source_client",
+            submissionsourceclient_enum,
+            nullable=True,
+        ),
+    )
+
+    # Assume that all existing submissions were created by the submission portal
+    op.execute("UPDATE submission_metadata SET source_client = 'submission_portal'")
+
+    op.create_unique_constraint(
+        op.f("uq_submission_role_submission_id"), "submission_role", ["submission_id", "user_orcid"]
+    )
+
+
+def downgrade():
+    op.drop_constraint(op.f("uq_submission_role_submission_id"), "submission_role", type_="unique")
+    op.drop_column("submission_metadata", "source_client")
+    op.execute("DROP TYPE submissionsourceclient")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -770,6 +770,11 @@ class SubmissionEditorRole(str, enum.Enum):
     reviewer = "reviewer"
 
 
+class SubmissionSourceClient(str, enum.Enum):
+    submission_portal = "submission_portal"
+    field_notes = "field_notes"
+
+
 class SubmissionMetadata(Base):
     __tablename__ = "submission_metadata"
 
@@ -779,6 +784,10 @@ class SubmissionMetadata(Base):
     status = Column(String, nullable=False, default="in-progress")
     metadata_submission = Column(JSONB, nullable=False)
     author_id = Column(UUID(as_uuid=True), ForeignKey(User.id))
+
+    # The client which initially created the submission. A null value indicates it was created by
+    # an "unregistered" client. This could be legitimate usage, but it should be monitored.
+    source_client = Column(Enum(SubmissionSourceClient), nullable=True)
 
     author = relationship(
         "User", foreign_keys=[author_id], primaryjoin="SubmissionMetadata.author_id == User.id"

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -94,6 +94,7 @@ class PartialMetadataSubmissionRecord(BaseModel):
 class SubmissionMetadataSchemaCreate(BaseModel):
     metadata_submission: MetadataSubmissionRecord
     status: Optional[str]
+    source_client: Optional[str]
 
 
 class SubmissionMetadataSchemaPatch(BaseModel):

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -1,3 +1,4 @@
+import { AxiosResponse } from 'axios';
 import { client, SearchParams, User } from '@/data/api';
 import { HARMONIZER_TEMPLATES } from '../harmonizerApi';
 
@@ -45,6 +46,7 @@ interface MetadataSubmissionRecord {
   locked_by: User;
   lock_updated: string;
   permission_level: string | null;
+  source_client: 'submission_portal' | 'field_notes' | null;
 }
 
 interface PaginatedResponse<T> {
@@ -53,8 +55,13 @@ interface PaginatedResponse<T> {
 }
 
 async function createRecord(record: MetadataSubmission) {
-  const resp = await client.post<MetadataSubmissionRecord>('metadata_submission', {
+  const resp = await client.post<
+    MetadataSubmissionRecord,
+    AxiosResponse<MetadataSubmissionRecord>,
+    Partial<MetadataSubmissionRecord>
+  >('metadata_submission', {
     metadata_submission: record,
+    source_client: 'submission_portal',
   });
   return resp.data;
 }


### PR DESCRIPTION
This is in support of https://github.com/microbiomedata/nmdc-field-notes/issues/128.

These changes add a `source_client` column to the `submission_metadata` table. The column is nullable and its type is an enum with our two "known" clients: the submission portal and the field notes app. All existing submissions are assumed to have come from the submission portal. A `null` value in this column would indicate the submission came from somewhere other than our two first-party clients. This should be something we keep an eye on, possibly included in the reports we produce for @mslarae13 when she goes hunting for submissions to delete.

These changes also update the corresponding frontend code to set the `source_client` to `submission_portal`. Other than that the new column isn't really used anywhere in the frontend or backend. It's mainly just bookkeeping to help answer inevitable metrics questions later.

cc: @eecavanna 