### PR TITLE
Add GH action to build berkeley schema images

### DIFF
--- a/.github/workflows/berkeley-image.yml
+++ b/.github/workflows/berkeley-image.yml
@@ -37,9 +37,8 @@ jobs:
             ghcr.io/microbiomedata/nmdc-server/${{ matrix.image }}
           flavor: |
             latest=false
-            prefix=berkeley
           tags: |
-            type=ref,event=branch
+            type=raw,value=berkeley
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Triggers on pushes to protected branch `berkeley-schema-migration`.
Builds images and tags them as related to the migration effort.