### PR TITLE
Fix DataHarmonizer help sidebar positioning

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -62,6 +62,8 @@ const ColorKey = {
   },
 };
 
+const HELP_SIDEBAR_WIDTH = '300px';
+
 const EXPORT_FILENAME = 'nmdc_sample_export.xlsx';
 
 const SAMP_NAME = 'samp_name';
@@ -466,6 +468,7 @@ export default defineComponent({
 
     return {
       APP_HEADER_HEIGHT,
+      HELP_SIDEBAR_WIDTH,
       ColorKey,
       HARMONIZER_TEMPLATES,
       columnVisibility,
@@ -831,14 +834,17 @@ export default defineComponent({
     <div
       class="harmonizer-style-container harmonizer-and-sidebar"
     >
-      <div id="harmonizer-root" />
+      <div
+        id="harmonizer-root"
+        :style="{
+          'padding-right': sidebarOpen ? HELP_SIDEBAR_WIDTH : '0px',
+        }"
+      />
 
       <div
+        class="harmonizer-sidebar"
         :style="{
-          'width': sidebarOpen ? '300px' : '0px',
-          'font-size': '14px',
-          'position': 'relative',
-          'flex-shrink': '0',
+          'width': sidebarOpen ? HELP_SIDEBAR_WIDTH : '0px',
         }"
       >
         <v-btn
@@ -1077,12 +1083,19 @@ html {
 }
 
 .harmonizer-and-sidebar {
-  display: flex;
-  flex-direction: row;
+  position: relative;
   width: 100%;
   height: 100%;
   flex-grow: 1;
   overflow: auto;
+}
+
+.harmonizer-sidebar {
+  font-size: 14px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
 }
 
 /* Grid */


### PR DESCRIPTION
Fixes #1304 

### Description 

I think I got a little overzealous with using flexbox layouts in https://github.com/microbiomedata/nmdc-server/pull/1267, which resulted in this bug being introduced. 

These changes fix the issue by having the help sidebar container be absolutely positioned within its parent element. When toggling the sidebar open/closed a corresponding amount of padding is added to/removed from its sibling element which holds the DataHarmonizer instance. This is so that the sidebar doesn't cover the rightmost columns.

This approach is conceptually similar to the way it worked before https://github.com/microbiomedata/nmdc-server/pull/1267 except it uses absolute positioning instead of `float`. I find `float` has more unpredictable side effects, so I tend to avoid it.

### Testing

Ensure that the help sidebar can be opened and closed while scrolled to any horizontal position in the DataHarmonizer grid. While scrolled all the way to the right, ensure that the final columns can always be accessed.