### PR TITLE
Revalidate form when permission level changes

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -284,6 +284,7 @@ export default defineComponent({
               outlined
               dense
               persistent-hint
+              @change="() => formRef.validate()"
             >
               <template #prepend-inner>
                 <v-tooltip


### PR DESCRIPTION
Due to how Vuetify's [form validation](https://v2.vuetifyjs.com/en/components/forms/#usage) works by default, having validation rules that check mulitple values on a single form don't cause unchanged fields to revalidate. Thus, fields must revalidate the form when changed if they have dependant fields.

In this particular case, the ORCID field's validation state depends on the contributor permission level. So whenever a contributor permission level changes, we must revalidate the form to obtain the correct validation state of the ORCID fields.

## Previous Behavior
[Observable in dev, prod, sandbox]
Adding a contributor to a submission's study form and filling out Name, Credit Roles, and permission level don't trigger validation for the ORCID field. The expected behavior is that once a permission level is specified, the form should be rendered invalid if the corresponding ORCID field is blank.

## Testing
Create a submission and go to the Study Form. Add a contributor. In this order, add the contributor's Name, Credit Roles, and assign a permission level. The ORCID field should turn red, display an error message, and the "Go to next step" button should be disabled until you enter a value into the ORCID field. 