### PR TITLE
Replace types-pkg-resources with types-setuptools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
   mypy
   pydantic
   sqlalchemy-stubs>=0.4
-  types-pkg-resources
+  types-setuptools
   types-python-dateutil
   types-requests
   types-click


### PR DESCRIPTION
Fixes #1324 

As @JamesTessmer discovered in https://github.com/microbiomedata/nmdc-server/pull/1323, all versions of `types-pkg-resources` have been yanked from PyPI (see linked issue for details). This updates the `typecheck` testenv dependencies as needed.