### PR TITLE
Update httpx to 0.23.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "dnspython==2.3.0",
     "fastapi==0.71.0",
     "factory-boy==3.2.1",
-    "httpx<=0.18.2",
+    "httpx==0.23.0",
     "ipython==7.31.1",
     "itsdangerous==2.0.1",
     "mypy<0.920",


### PR DESCRIPTION
This resolves a security warning from dependabot.

### Changes
Updates our dependency on `httpx` (`0.18.0 -> 0.23.0`), the minimum version to resolve the warning.

### Testing
Please check out this branch and make sure the docker image builds and the app run as expected on your local machine.