### PR TITLE
Replace Omics with Data Generation

### DIFF
--- a/web/src/components/FacetedSearch.vue
+++ b/web/src/components/FacetedSearch.vue
@@ -11,7 +11,7 @@ const groupOrders = [
   'sample',
   'gold ecosystems',
   'mixs environmental triad',
-  'omics processing',
+  'data generation',
 ];
 
 export interface SearchFacet {

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -100,9 +100,9 @@ const types: Record<entityType, EntityData> = {
   },
   omics_processing: {
     icon: 'mdi-file-table-box-multiple-outline',
-    heading: 'Omics Types',
+    heading: 'Data Types',
     name: 'omics_processing',
-    plural: 'Omics Processing',
+    plural: 'Data Generations',
     visible: true,
     schemaName: 'OmicsProcessing',
   },
@@ -263,15 +263,15 @@ const fields: Record<string, FieldsData> = {
   },
   instrument_name: {
     name: 'Instrument Name',
-    group: 'Omics Processing',
+    group: 'Data Generation',
   },
   omics_type: {
-    name: 'Omics Type',
-    group: 'Omics Processing',
+    name: 'Data Type',
+    group: 'Data Generation',
   },
   processing_institution: {
     name: 'Processing Institution',
-    group: 'Omics Processing',
+    group: 'Data Generation',
   },
   /* GOLD ecosystem type */
   ecosystem: {

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -229,7 +229,7 @@ export default defineComponent({
                   height="30px"
                 >
                   <v-tab key="omics">
-                    Omics
+                    Data Type
                   </v-tab>
                   <v-tab key="environments">
                     Environment

--- a/web/src/views/Search/SearchSidebar.vue
+++ b/web/src/views/Search/SearchSidebar.vue
@@ -76,21 +76,21 @@ const FunctionSearchFacets: SearchFacet[] = [
     table: 'study',
     group: 'Study',
   },
-  /** Omics Processing */
+  /** Data Generation */
   {
     field: 'instrument_name',
     table: 'omics_processing',
-    group: 'Omics Processing',
+    group: 'Data Generation',
   },
   {
     field: 'omics_type',
     table: 'omics_processing',
-    group: 'Omics Processing',
+    group: 'Data Generation',
   },
   {
     field: 'processing_institution',
     table: 'omics_processing',
-    group: 'Omics Processing',
+    group: 'Data Generation',
   },
 ];
 


### PR DESCRIPTION
### Description
Replace instances of "omics," "omics type", etc. with the appropriate Berkeley language (e.g. "Data Generation"). Applies to user-facing places to the data portal only.

See the issues for the specific requests. Changes include:

- The tab for the bar chart on the home page changed ("Omics" -> "Data Type")
- The search sidebar facet section changed ("Omics Processing" -> "Data Generation")
- The search sidebar facet changed ("Omics Type" -> "Data Type")

Fix #1326 