### PR TITLE
Get ORCID Base URL from environment variable (to enable usage of ORCID sandbox)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@
 # ORCID OAuth Setup
 # NMDC_ORCID_CLIENT_ID=changeme
 # NMDC_ORCID_CLIENT_SECRET=changeme
+#
+# Base URL (without a trailing slash) at which the application can access an instance of ORCID.
+# Note: For the production instance of ORCID, use: https://orcid.org (default)
+#       For the sandbox instance of ORCID, use: https://sandbox.orcid.org
+# NMDC_ORCID_BASE_URL=https://orcid.org
 
 # MongoDB Ingest Setup
 # NMDC_MONGO_USER=changeme

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -58,7 +58,7 @@ AUTHORIZATION_CODE_INVALID_EXCEPTION = HTTPException(
 )
 
 API_JWT_ALGORITHM = "HS256"
-ORCID_JWT_ISSUER = "https://orcid.org"
+ORCID_JWT_ISSUER = settings.orcid_base_url  # e.g. "https://orcid.org" or "https://sandbox.orcid.org"
 
 
 class JwtTypes(str, Enum):
@@ -305,7 +305,7 @@ async def oidc_login(body: OidcLoginRequestBody, db: Session = Depends(get_db)):
 
     The endpoint can be used as an alternative to the flow initiated by the /auth/login route. If a
     client has already obtained an OpenID Connect token from ORCID, they can exchange it for a
-    nmdc-server tokens using this route. The OIDC token is decoded and validated by looking for
+    nmdc-server token using this route. The OIDC token is decoded and validated by looking for
     ORCID as the issuer and the nmdc-server client ID as the audience. If the token is valid, the
     claims in the token are used to create or update a user in the database. Finally, new tokens are
     generated for the user.

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -58,7 +58,7 @@ AUTHORIZATION_CODE_INVALID_EXCEPTION = HTTPException(
 )
 
 API_JWT_ALGORITHM = "HS256"
-ORCID_JWT_ISSUER = settings.orcid_base_url  # e.g. "https://orcid.org" or "https://sandbox.orcid.org"
+ORCID_JWT_ISSUER = settings.orcid_base_url  # e.g. "https://orcid.org", "https://sandbox.orcid.org"
 
 
 class JwtTypes(str, Enum):

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -305,7 +305,7 @@ async def oidc_login(body: OidcLoginRequestBody, db: Session = Depends(get_db)):
 
     The endpoint can be used as an alternative to the flow initiated by the /auth/login route. If a
     client has already obtained an OpenID Connect token from ORCID, they can exchange it for a
-    nmdc-server token using this route. The OIDC token is decoded and validated by looking for
+    nmdc-server tokens using this route. The OIDC token is decoded and validated by looking for
     ORCID as the issuer and the nmdc-server client ID as the audience. If the token is valid, the
     claims in the token are used to create or update a user in the database. Finally, new tokens are
     generated for the user.

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-from pydantic import BaseSettings, computed_field
+from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
@@ -38,7 +38,7 @@ class Settings(BaseSettings):
     orcid_client_secret: str = "oauth secret key"
     orcid_authorize_scope: str = "/authenticate"
 
-    @computed_field
+    @property
     def orcid_openid_config_url(self) -> str:
         r"""
         Derives the `orcid_openid_config_url` field's value based upon another field's value.

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -42,7 +42,14 @@ class Settings(BaseSettings):
     def orcid_openid_config_url(self) -> str:
         r"""
         Derives the `orcid_openid_config_url` field's value based upon another field's value.
-        Reference: https://docs.pydantic.dev/2.7/concepts/fields/#the-computed_field-decorator
+
+        Note: This project currently depends upon Pydantic version 1, which does not offer
+              the `@computed_field` decorator offered by Pydantic version 2. So, we implement
+              a "getter" method using Python's built-in `@property` decorator instead.
+
+              References:
+              - https://docs.python.org/3/library/functions.html#property
+              - https://docs.pydantic.dev/2.7/concepts/fields/#the-computed_field-decorator
         """
         return f"{self.orcid_base_url}/.well-known/openid-configuration"
 

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, computed_field
 
 
 class Settings(BaseSettings):
@@ -33,10 +33,18 @@ class Settings(BaseSettings):
 
     # for orcid oauth
     session_secret_key: str = "secret"
+    orcid_base_url: str = "https://orcid.org"
     orcid_client_id: str = "oauth client id"
     orcid_client_secret: str = "oauth secret key"
-    orcid_openid_config_url: str = "https://orcid.org/.well-known/openid-configuration"
     orcid_authorize_scope: str = "/authenticate"
+
+    @computed_field
+    def orcid_openid_config_url(self) -> str:
+        r"""
+        Derives the `orcid_openid_config_url` field's value based upon another field's value.
+        Reference: https://docs.pydantic.dev/2.7/concepts/fields/#the-computed_field-decorator
+        """
+        return f"{self.orcid_base_url}/.well-known/openid-configuration"
 
     # host name for the ORCID oauth2 redirect and our own JWT issuer
     host: str = "http://127.0.0.1:8000"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert resp.next.url.startswith(f"{settings.orcid_base_url}/oauth/authorize"),  # type: ignore
+    assert resp.next.url.startswith(f"{settings.orcid_base_url}/oauth/authorize")  # type: ignore
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,8 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert resp.next.url.startswith("https://orcid.org/oauth/authorize")  # type: ignore
+    assert resp.next.url.startswith("https://orcid.org/oauth/authorize") or \
+           resp.next.url.startswith("https://sandbox.orcid.org/oauth/authorize")   # type: ignore
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,10 +14,12 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert any((
-        resp.next.url.startswith("https://orcid.org/oauth/authorize"),  # type: ignore
-        resp.next.url.startswith("https://sandbox.orcid.org/oauth/authorize"),  # type: ignore
-    ))
+    assert any(
+        (
+            resp.next.url.startswith("https://orcid.org/oauth/authorize"),  # type: ignore
+            resp.next.url.startswith("https://sandbox.orcid.org/oauth/authorize"),  # type: ignore
+        )
+    )
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,8 +14,10 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert resp.next.url.startswith("https://orcid.org/oauth/authorize") or \
-           resp.next.url.startswith("https://sandbox.orcid.org/oauth/authorize")   # type: ignore
+    assert any((
+        resp.next.url.startswith("https://orcid.org/oauth/authorize"),  # type: ignore
+        resp.next.url.startswith("https://sandbox.orcid.org/oauth/authorize"),  # type: ignore
+    ))
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert resp.next.url.startswith(settings.orcid_base_url),  # type: ignore
+    assert resp.next.url.startswith(f"{settings.orcid_base_url}/oauth/authorize"),  # type: ignore
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,12 +14,7 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert any(
-        (
-            resp.next.url.startswith("https://orcid.org/oauth/authorize"),  # type: ignore
-            resp.next.url.startswith("https://sandbox.orcid.org/oauth/authorize"),  # type: ignore
-        )
-    )
+    assert resp.next.url.startswith(settings.orcid_base_url),  # type: ignore
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/web/src/components/Presentation/OrcidId.vue
+++ b/web/src/components/Presentation/OrcidId.vue
@@ -20,6 +20,10 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    orcidBaseUrl: {
+      type: String,
+      default: ORCID_BASE_URL,
+    },
   },
 });
 </script>
@@ -27,7 +31,7 @@ export default defineComponent({
 <template>
   <div :style="{display: 'flex'}">
     <a
-      :href="`${ORCID_BASE_URL}/${orcidId}`"
+      :href="`${orcidBaseUrl}/${orcidId}`"
       :style="{display: 'flex'}"
     >
       <span

--- a/web/src/components/Presentation/OrcidId.vue
+++ b/web/src/components/Presentation/OrcidId.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
+import { ORCID_BASE_URL } from '@/util';
 
 export default defineComponent({
   props: {
@@ -26,7 +27,7 @@ export default defineComponent({
 <template>
   <div :style="{display: 'flex'}">
     <a
-      :href="`https://orcid.org/${orcidId}`"
+      :href="`${ORCID_BASE_URL}/${orcidId}`"
       :style="{display: 'flex'}"
     >
       <span

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -188,3 +188,9 @@ export function formatBiosampleDepth(depthAnnotation, depth) {
   }
   return formattedStr;
 }
+
+/**
+ * Base URL (without a trailing slash) at which the user can access
+ * the same ORCID environment being used by the backend API.
+ */
+export const ORCID_BASE_URL = process.env.NMDC_ORCID_BASE_URL || "https://orcid.org";


### PR DESCRIPTION
In this branch, I made it so the backend would get the ORCID base URL from an environment variable. This will allow developers to configure the backend to use the sandbox ORCID environment versus the production ORCID environment.

This [comment](https://github.com/microbiomedata/infra-admin/issues/96#issuecomment-2240260134) is what prompted me to implement this change.