### PR TITLE
Make ORCID Base URL configurable via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@
 # ORCID OAuth Setup
 # NMDC_ORCID_CLIENT_ID=changeme
 # NMDC_ORCID_CLIENT_SECRET=changeme
+#
+# Base URL (without a trailing slash) at which the application can access an instance of ORCID.
+# Note: For the production instance of ORCID, use: "https://orcid.org" (default)
+#       For the sandbox instance of ORCID, use: "https://sandbox.orcid.org"
+# NMDC_ORCID_BASE_URL="https://orcid.org"
 
 # MongoDB Ingest Setup
 # NMDC_MONGO_USER=changeme

--- a/nmdc_server/auth.py
+++ b/nmdc_server/auth.py
@@ -58,7 +58,7 @@ AUTHORIZATION_CODE_INVALID_EXCEPTION = HTTPException(
 )
 
 API_JWT_ALGORITHM = "HS256"
-ORCID_JWT_ISSUER = "https://orcid.org"
+ORCID_JWT_ISSUER = settings.orcid_base_url  # e.g. "https://orcid.org", "https://sandbox.orcid.org"
 
 
 class JwtTypes(str, Enum):

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -33,10 +33,23 @@ class Settings(BaseSettings):
 
     # for orcid oauth
     session_secret_key: str = "secret"
+    orcid_base_url: str = "https://orcid.org"
     orcid_client_id: str = "oauth client id"
     orcid_client_secret: str = "oauth secret key"
-    orcid_openid_config_url: str = "https://orcid.org/.well-known/openid-configuration"
     orcid_authorize_scope: str = "/authenticate"
+
+    @property
+    def orcid_openid_config_url(self) -> str:
+        r"""
+        Derives the `orcid_openid_config_url` field's value based upon another field's value.
+        Note: This project currently depends upon Pydantic version 1, which does not offer
+              the `@computed_field` decorator offered by Pydantic version 2. So, we implement
+              a "getter" method using Python's built-in `@property` decorator instead.
+              References:
+              - https://docs.python.org/3/library/functions.html#property
+              - https://docs.pydantic.dev/2.7/concepts/fields/#the-computed_field-decorator
+        """
+        return f"{self.orcid_base_url}/.well-known/openid-configuration"
 
     # host name for the ORCID oauth2 redirect and our own JWT issuer
     host: str = "http://127.0.0.1:8000"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,7 @@ def test_login(client: TestClient):
     )
 
     assert resp.status_code == 302
-    assert resp.next.url.startswith("https://orcid.org/oauth/authorize")  # type: ignore
+    assert resp.next.url.startswith(f"{settings.orcid_base_url}/oauth/authorize")  # type: ignore
 
 
 def test_current_user(client: TestClient, logged_in_user):

--- a/web/src/components/Presentation/OrcidId.vue
+++ b/web/src/components/Presentation/OrcidId.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineComponent } from '@vue/composition-api';
+import { ORCID_BASE_URL } from '@/util';
 
 export default defineComponent({
   props: {
@@ -19,6 +20,10 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
+    orcidBaseUrl: {
+      type: String,
+      default: ORCID_BASE_URL,
+    },
   },
 });
 </script>
@@ -26,7 +31,7 @@ export default defineComponent({
 <template>
   <div :style="{display: 'flex'}">
     <a
-      :href="`https://orcid.org/${orcidId}`"
+      :href="`${orcidBaseUrl}/${orcidId}`"
       :style="{display: 'flex'}"
     >
       <span

--- a/web/src/util.js
+++ b/web/src/util.js
@@ -188,3 +188,9 @@ export function formatBiosampleDepth(depthAnnotation, depth) {
   }
   return formattedStr;
 }
+
+/**
+ * Base URL (without a trailing slash) at which the user can access
+ * the same ORCID environment being used by the backend API.
+ */
+export const ORCID_BASE_URL = process.env.NMDC_ORCID_BASE_URL || "https://orcid.org";


### PR DESCRIPTION
In this branch, I made it so the backend would get the ORCID Base URL from an environment variable. This will allow developers to configure the backend to use the sandbox ORCID environment vs. the production ORCID environment.

This [comment](https://github.com/microbiomedata/infra-admin/issues/96#issuecomment-2240260134) is what prompted me to implement this change.

---

Note: The changes in this PR were originally made with respect to the `berkeley-schema-migration` branch. Based upon some feedback in #1341, I have created this new branch in which the same changes have been made with respect to the `main` branch. Once this PR gets merged into `main`, I will close PR #1341 (and—instead—to a `main`-to-`berkeley-schema-migration` merge in order to "get these same changes" to exist in the `berkeley-schema-migration` branch).