### PR TITLE
Show per-workflow and per-filetype sizes in bulk download

### DIFF
--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -175,6 +175,7 @@ def get_data_object_aggregation(
             models.DataObject.workflow_type,
             models.DataObject.file_type,
             func.count(models.DataObject.id),
+            func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)),
         )
         .filter(
             models.DataObject.workflow_type != None,
@@ -195,6 +196,7 @@ def get_data_object_aggregation(
         db.query(
             models.DataObject.workflow_type,
             func.count(models.DataObject.id),
+            func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)),
         )
         .filter(
             models.DataObject.workflow_type != None,
@@ -205,6 +207,7 @@ def get_data_object_aggregation(
     )
     for row in rows:
         agg[row[0]].count = row[1]
+        agg[row[0]].size = row[2]
 
     # aggregate file_types
     rows = (
@@ -212,6 +215,7 @@ def get_data_object_aggregation(
             models.DataObject.workflow_type,
             models.DataObject.file_type,
             func.count(models.DataObject.id),
+            func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)),
         )
         .filter(
             models.DataObject.workflow_type != None,
@@ -222,5 +226,7 @@ def get_data_object_aggregation(
         .group_by(models.DataObject.workflow_type, models.DataObject.file_type)
     )
     for row in rows:
-        agg[row[0]].file_types[row[1]] = row[2]
+        agg[row[0]].file_types[row[1]] = schemas.DataObjectAggregationNode(
+            count=row[2], size=row[3]
+        )
     return agg

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -189,9 +189,13 @@ class EnvironmentGeospatialAggregation(BaseModel):
         orm_mode = True
 
 
-class DataObjectAggregationElement(BaseModel):
+class DataObjectAggregationNode(BaseModel):
     count: int = 0
-    file_types: Dict[str, int] = {}
+    size: int = 0
+
+
+class DataObjectAggregationElement(DataObjectAggregationNode):
+    file_types: Dict[str, DataObjectAggregationNode] = {}
 
 
 DataObjectAggregation = Dict[str, DataObjectAggregationElement]

--- a/web/src/components/BulkDownload.vue
+++ b/web/src/components/BulkDownload.vue
@@ -35,13 +35,21 @@ export default defineComponent({
       download,
     } = useBulkDownload(stateRefs.conditions, dataObjectFilter);
 
+    function createLabelString(label: string, count: number, size: number): string {
+      const labelString = `${label} (${count}`;
+      if (size > 0) {
+        return `${labelString}, ${humanFileSize(size)})`;
+      }
+      return `${labelString})`;
+    }
+
     const options = computed(() => Object.entries(downloadOptions.value)
       .map(([key, val]) => ({
         id: key,
-        label: `${key} (${val.count})`,
-        children: Object.entries(val.file_types).map(([filetype, count]) => ({
+        label: createLabelString(key, val.count, val.size),
+        children: Object.entries(val.file_types).map(([filetype, fileTypeStats]) => ({
           id: `${key}::${filetype}`,
-          label: `${filetype} (${count})`,
+          label: createLabelString(filetype, fileTypeStats.count, fileTypeStats.size),
         })),
       })));
 

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -294,7 +294,8 @@ export const opMap: Record<opType, string> = {
 // See https://github.com/microbiomedata/nmdc-server/pull/403 for documentation
 export type BulkDownloadSummary = Record<string, {
   count: number;
-  file_types: Record<string, number>,
+  size: number;
+  file_types: Record<string, { count: number, size: number }>,
 }>;
 
 export type BulkDownloadAggregateSummary = {


### PR DESCRIPTION
Fix #1344 

### Changes
Modifies the query used by the `/data_object/workflow_summary` endpoint to include a sum of the sizes of the data objects at the workflow type and file type level. Updates the frontend to display these sizes (if non-zero) in the bulk download control

### Testing
Check out the new labels for the tree view in the bulk download control! They also show up when you select file types to add to the bulk download:
![image](https://github.com/user-attachments/assets/0d3e90a5-e94b-4549-8289-bcfe34120986)


