### PR TITLE
Support pathway search with multiple prefixes

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -226,7 +226,7 @@ def list_omics_processing_data_objects(db: Session, id: str) -> Query:
 
 
 # KEGG
-def has_pathway_prefix(term) -> Optional[str]:
+def get_pathway_prefix(term) -> Optional[str]:
     pathway_prefixes = set(["map", "ko", "ec", "rn", "org"])
     pathway_re = f"^({'|'.join(re.escape(p) for p in pathway_prefixes)})"
     match = re.match(pathway_re, term)
@@ -244,7 +244,7 @@ def list_ko_terms_for_pathway(db: Session, pathway: str) -> List[str]:
 
 
 def kegg_text_search(db: Session, query: str, limit: int) -> List[models.KoTermText]:
-    pathway_prefix = has_pathway_prefix(query)
+    pathway_prefix = get_pathway_prefix(query)
     term = query.replace(pathway_prefix, "map") if pathway_prefix else query
     q = (
         db.query(models.KoTermText)
@@ -256,7 +256,7 @@ def kegg_text_search(db: Session, query: str, limit: int) -> List[models.KoTermT
     if pathway_prefix:
         default_pathway_prefix = "map"
         # Transform pathway results to match given prefix. They are ingested with the
-        # 'map' prefix.
+        # 'map' prefix, but can searched for with various other prefixes.
         for term_text in results:
             if term_text.term.startswith(default_pathway_prefix):
                 term_text.term = term_text.term.replace(default_pathway_prefix, pathway_prefix)

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, cast
 from uuid import UUID
@@ -224,6 +225,14 @@ def list_omics_processing_data_objects(db: Session, id: str) -> Query:
     )
 
 
+# KEGG
+def has_pathway_prefix(term) -> Optional[str]:
+    pathway_prefixes = set(["map", "ko", "ec", "rn", "org"])
+    pathway_re = f"^({'|'.join(re.escape(p) for p in pathway_prefixes)})"
+    match = re.match(pathway_re, term)
+    return match.group(0) if match else None
+
+
 def list_ko_terms_for_module(db: Session, module: str) -> List[str]:
     q = db.query(models.KoTermToModule.term).filter(models.KoTermToModule.module.ilike(module))
     return [row[0] for row in q]
@@ -235,13 +244,25 @@ def list_ko_terms_for_pathway(db: Session, pathway: str) -> List[str]:
 
 
 def kegg_text_search(db: Session, query: str, limit: int) -> List[models.KoTermText]:
+    pathway_prefix = has_pathway_prefix(query)
+    term = query.replace(pathway_prefix, "map") if pathway_prefix else query
+    print(f"\n\n\n{term}\n\n\n")
     q = (
         db.query(models.KoTermText)
-        .filter(models.KoTermText.text.ilike(f"%{query}%") | models.KoTermText.term.ilike(query))
+        .filter(models.KoTermText.text.ilike(f"%{term}%") | models.KoTermText.term.ilike(term))
         .order_by(models.KoTermText.term)
         .limit(limit)
     )
-    return list(q)
+    results = list(q)
+    if pathway_prefix:
+        default_pathway_prefix = "map"
+        # Transform pathway results to match given prefix. They are ingested with the
+        # 'map' prefix.
+        for term_text in results:
+            if term_text.term.startswith(default_pathway_prefix):
+                term_text.term = term_text.term.replace(default_pathway_prefix, pathway_prefix)
+            term_text.text = term_text.text.replace(default_pathway_prefix, pathway_prefix)
+    return results
 
 
 # biosample

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -246,7 +246,6 @@ def list_ko_terms_for_pathway(db: Session, pathway: str) -> List[str]:
 def kegg_text_search(db: Session, query: str, limit: int) -> List[models.KoTermText]:
     pathway_prefix = has_pathway_prefix(query)
     term = query.replace(pathway_prefix, "map") if pathway_prefix else query
-    print(f"\n\n\n{term}\n\n\n")
     q = (
         db.query(models.KoTermText)
         .filter(models.KoTermText.text.ilike(f"%{term}%") | models.KoTermText.term.ilike(term))

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -294,7 +294,6 @@ class BaseQuerySchema(BaseModel):
         if condition.key == "Table.gene_function:id" and type(condition.value) is str:
             if any([condition.value.startswith(val) for val in KeggTerms.PATHWAY[0]]):
                 prefix = [val for val in KeggTerms.PATHWAY[0] if condition.value.startswith(val)][0]
-                print(f"\n\n\n{prefix}\n\n\n")
                 searchable_name = condition.value.replace(prefix, KeggTerms.PATHWAY[1])
                 ko_terms = db.query(models.KoTermToPathway.term).filter(
                     models.KoTermToPathway.pathway.ilike(searchable_name)

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -292,10 +292,10 @@ class BaseQuerySchema(BaseModel):
     def transform_condition(self, db, condition: BaseConditionSchema) -> List[BaseConditionSchema]:
         # Transform KEGG.(PATH|MODULE) queries into their respective ORTHOLOGY terms
         if condition.key == "Table.gene_function:id" and type(condition.value) is str:
-            if condition.value.startswith(KeggTerms.PATHWAY[0]):
-                searchable_name = condition.value.replace(
-                    KeggTerms.PATHWAY[0], KeggTerms.PATHWAY[1]
-                )
+            if any([condition.value.startswith(val) for val in KeggTerms.PATHWAY[0]]):
+                prefix = [val for val in KeggTerms.PATHWAY[0] if condition.value.startswith(val)][0]
+                print(f"\n\n\n{prefix}\n\n\n")
+                searchable_name = condition.value.replace(prefix, KeggTerms.PATHWAY[1])
                 ko_terms = db.query(models.KoTermToPathway.term).filter(
                     models.KoTermToPathway.pathway.ilike(searchable_name)
                 )

--- a/nmdc_server/table.py
+++ b/nmdc_server/table.py
@@ -23,7 +23,16 @@ MetaTGeneFunction = aliased(models.GeneFunction)
 
 class KeggTerms:
     ORTHOLOGY = ("KEGG.ORTHOLOGY:K", "K")
-    PATHWAY = ("KEGG.PATHWAY:MAP", "MAP")
+    PATHWAY = (
+        [
+            "KEGG.PATHWAY:MAP",
+            "KEGG.PATHWAY:EC",
+            "KEGG.PATHWAY:RN",
+            "KEGG.PATHWAY:ORG",
+            "KEGG.PATHWAY:KO",
+        ],
+        "MAP",
+    )
     MODULE = ("KEGG.MODULE:M", "M")
 
 

--- a/nmdc_server/table.py
+++ b/nmdc_server/table.py
@@ -28,7 +28,6 @@ class KeggTerms:
             "KEGG.PATHWAY:MAP",
             "KEGG.PATHWAY:EC",
             "KEGG.PATHWAY:RN",
-            "KEGG.PATHWAY:ORG",
             "KEGG.PATHWAY:KO",
         ],
         "MAP",

--- a/web/src/components/FilterKegg.vue
+++ b/web/src/components/FilterKegg.vue
@@ -101,8 +101,8 @@ export default defineComponent({
         <p>
           KEGG Gene Function search filters results to
           samples that have at least one of the chosen KEGG terms.
-          Orthology, Pathway, and Module are supported.
-          Expected format: <code>K00000, M00000 or map00000</code>
+          Orthology, Module, and Pathway are supported.
+          Expected formats: <code>K00000, M00000, map00000, ko00000, rn00000, and ec00000</code>
         </p>
         <p class="text-subtitle-2">
           More information at <a href="https://www.genome.jp/kegg/">genome.jp/kegg</a>

--- a/web/src/components/FilterKegg.vue
+++ b/web/src/components/FilterKegg.vue
@@ -102,7 +102,7 @@ export default defineComponent({
           KEGG Gene Function search filters results to
           samples that have at least one of the chosen KEGG terms.
           Orthology, Pathway, and Module are supported.
-          Expected format: <code>K00000, M00000 or MAP00000</code>
+          Expected format: <code>K00000, M00000 or map00000</code>
         </p>
         <p class="text-subtitle-2">
           More information at <a href="https://www.genome.jp/kegg/">genome.jp/kegg</a>

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -32,7 +32,6 @@ const pathwayRegex = /^((map:?)|(path:?)|(ko:?)|(ec:?)|(rn:?)|(kegg.pathway:(map
 
 function pathwayPrefixShort(v: string) {
   const match = v.match(pathwayRegex);
-  console.log(match);
   if (match) {
     const prefix = match[8] ? match[8] : match[1].replace(/:$/, '');
     return prefix.toLowerCase();
@@ -42,7 +41,6 @@ function pathwayPrefixShort(v: string) {
 
 function pathwayPrefixLong(v: string) {
   const match = v.match(pathwayRegex);
-  console.log(match);
   if (match) {
     const prefix = match[7] ? match[7] : match[1].replace(match[1], `kegg.pathway:${match[1]}`);
     return prefix.toUpperCase();

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -74,11 +74,11 @@ const KeggPrefix: Record<string, PrefixInfo> = {
  * a KEGG identifier term.
  */
 function keggEncode(v: string, url = false) {
-  const prefixes = Object.keys(KeggPrefix);
+  const prefixes = Object.values(KeggPrefix);
   for (let i = 0; i < prefixes.length; i += 1) {
     const {
       pattern, short, long, urlBase,
-    } = KeggPrefix[prefixes[i]];
+    } = prefixes[i];
     const replacement = url ? short(v) : long(v);
     const transformed = v.replace(pattern, replacement);
     if (transformed !== v) {

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -65,7 +65,7 @@ const KeggPrefix: Record<string, PrefixInfo> = {
     pattern: /^((m:?)|(kegg.module:m))(?=\d{5})/i,
     short: () => 'M',
     long: () => 'KEGG.MODULE:M',
-    urlBase: 'https://www.genome.jp/brite/',
+    urlBase: 'https://www.kegg.jp/entry/',
   },
 };
 


### PR DESCRIPTION
Fix #1342

### Changes
This updates the KEGG facet to allow users to search for pathways terms using prefixes other than `map`. Supported prefixes for pathway searches now include `ko`, `ec`, and `rn` in addition to `map`. 

We store pathway terms in the `ko_term_text` table in postgres, all with the `map` prefix. In order to support searching on these terms we do some string substitution so that users can use whichever prefix they'd like. 

This affects free-text search for the KEGG facet on the frontend. If a user types in a term that begins with one of the prefixes associated with a pathway search, the associated backend code (`crud.py::kegg_text_search`) will interpret that as a request to search for pathways, making sure the results keep the the prefix that the user wanted. For example, a user search for `ec00010` in the Data Portal will be translated into a search for `map00010` in our database, and the results will be translated back to use the `ec` prefix.

This also affects some KEGG-related functions in `encoding.ts`. In order to support transforming search terms into proper strings used by the search engine and proper links to external sites, the `short` and `long` representations are now functions that adapt to the input.

A similar change has been implemented during search itself, where the check for whether or not a given search term is a pathway has been expanded.

The help text on the KEGG filter flyout has been updated to mention the new supported formats.


### Testing
Testing requires working with a database that has the KEGG terms and annotations ingested. I would recommend using the `nmdc-server` CLI to obtain a backup of the production database. From there, test the KEGG Filter by searching for pathways with various different prefixes. Make sure they return the same results. Additionally, make sure that the free text search results are consistent with the prefix you are using for search, and that the clickable links in the flyout when you have terms selected use the same prefix you searched with.