### PR TITLE
Add schema version identifiers to /api/version response

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from starlette.responses import StreamingResponse
 
-from nmdc_server import __version__, crud, jobs, models, query, schemas, schemas_submission
+from nmdc_server import crud, jobs, models, query, schemas, schemas_submission
 from nmdc_server.auth import admin_required, get_current_user, login_required_responses
 from nmdc_server.bulk_download_schema import BulkDownload, BulkDownloadCreate
 from nmdc_server.config import Settings
@@ -38,9 +38,9 @@ async def get_settings() -> Dict[str, Any]:
 
 
 # get application version number
-@router.get("/version", name="Get application version identifier")
-async def get_version() -> Dict[str, Any]:
-    return {"nmdc-server": __version__}
+@router.get("/version", name="Get application and schema version identifiers")
+async def get_version() -> schemas.VersionInfo:
+    return schemas.VersionInfo()
 
 
 # get the current user information

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from enum import Enum
+from importlib.metadata import version
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import quote
 from uuid import UUID
@@ -18,7 +19,7 @@ from pydantic import BaseModel, Field, validator
 from sqlalchemy import BigInteger, Column, DateTime, Float, Integer, LargeBinary, String
 from sqlalchemy.dialects.postgresql.json import JSONB
 
-from nmdc_server import models
+from nmdc_server import __version__, models
 from nmdc_server.data_object_filters import DataObjectFilter, WorkflowActivityTypeEnum
 
 DateType = Union[datetime, date]
@@ -688,3 +689,20 @@ class LockOperationResult(BaseModel):
     message: str
     locked_by: Optional[User]
     lock_updated: Optional[datetime]
+
+
+class VersionInfo(BaseModel):
+    """Version information for the nmdc-server itself and the schemas.
+
+    This model has default field values and is immutable because these values cannot
+    change at runtime.
+    """
+
+    nmdc_server: str = __version__
+    nmdc_schema: str = version("nmdc-schema")
+    nmdc_submission_schema: str = version("nmdc-submission-schema")
+
+    class Config:
+        # In Pydantic V2, use `frozen=True`
+        # https://docs.pydantic.dev/2.8/concepts/models/#faux-immutability
+        allow_mutation = False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import json
+from importlib.metadata import version
 from itertools import product
 
 import pytest
@@ -33,7 +34,11 @@ def test_get_settings(client: TestClient):
 def test_get_version(client: TestClient):
     resp = client.get("/api/version")
     assert resp.status_code == 200
-    assert resp.json()["nmdc-server"] == nmdc_server.__version__
+
+    body = resp.json()
+    assert body["nmdc_server"] == nmdc_server.__version__
+    assert body["nmdc_schema"] == version("nmdc-schema")
+    assert body["nmdc_submission_schema"] == version("nmdc-submission-schema")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is part of https://github.com/microbiomedata/nmdc-field-notes/issues/156

These changes add the `nmdc-schema` and `nmdc-submission-schema` version identifiers to the response of the existing `/api/version` endpoint.

⚠️ Quasi-breaking change ⚠️ 

The response used to contain the key `nmdc-server`. I changed it to `nmdc_server` along with adding new keys that also use underscores instead of dashes. This makes it easier to deal with in both Python and JavaScript/TypeScript code. I don't _think_ there are any existing clients of this endpoint, but if anyone is uncomfortable with that change let me know.