### PR TITLE
Add "Data API" link to navbar ("Products" menu)

### DIFF
--- a/web/src/menus.ts
+++ b/web/src/menus.ts
@@ -55,6 +55,10 @@ const Menus = [
         label: 'Field Notes Mobile App',
         href: 'https://microbiomedata.org/field-notes/',
       },
+      {
+        label: 'Data API',
+        href: 'https://api.microbiomedata.org/docs',
+      },
     ],
   },
   {


### PR DESCRIPTION
In this branch, I added a new menu item to the navigation bar; specifically, I added a menu labeled "Data API", which links to the Runtime API's Swagger UI. Regarding why the name "Data API" was used, you can refer to [this conversation](https://github.com/microbiomedata/nmdc-server/issues/1330#issuecomment-2297711714) (the gist is that some people thought the word, "Runtime," would not be meaningful to people outside of our team).

Fixes https://github.com/microbiomedata/nmdc-server/issues/1363