### PR TITLE
Upgrade to nmdc-submission-schema v11.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "itsdangerous==2.0.1",
     "mypy<0.920",
     "nmdc-schema==11.0.0rc20",
-    "nmdc-submission-schema==10.7.0",
+    "nmdc-submission-schema==11.0.0rc1",
     "pint==0.18",
     "psycopg2==2.9.3",
     "pydantic==1.10.2",


### PR DESCRIPTION
Part of https://github.com/microbiomedata/submission-schema/issues/220

v11.0.0rc1 is the first release candidate version of `nmdc-submission-schema` to be built off of a Berkeley release candidate of `nmdc-schema` (specifically v11.0.0rc20). Very little of the Berkeley changes in `nmdc-schema` affect `nmdc-submission-schema` so I wouldn't expect any major issues here. I tested this locally by viewing the DataHarmonizer screen of a submission (something seems wrong with the `/submission/{id}/context` route in the `berkeley-schema-migration` branch, but I could manually go to the `submission/{id}/samples` route) and doing some basic data entry and validation.