### PR TITLE
Fix Berkeley schema element usage in frontend code

### DIFF
--- a/web/src/components/FacetedSearch.vue
+++ b/web/src/components/FacetedSearch.vue
@@ -83,7 +83,7 @@ export default Vue.extend({
     goldDescription() {
       // @ts-ignore
       const schema = NmdcSchema.slots.gold_path_field;
-      return schema.annotations.tooltip.value || '';
+      return schema.annotations?.tooltip?.value || '';
     },
   },
   methods: {

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -24,7 +24,7 @@ export default defineComponent({
   components: { SubmissionContextShippingForm, SubmissionDocsLink, SubmissionPermissionBanner },
   setup() {
     const formRef = ref();
-    const facilityEnum = Object.keys(NmdcSchema.enums.processing_institution_enum.permissible_values).filter(
+    const facilityEnum = Object.keys(NmdcSchema.enums.ProcessingInstitutionEnum.permissible_values).filter(
       (facility: string) => ['EMSL', 'JGI'].includes(facility),
     );
     const projectAwardValidationRules = () => [(v: string) => {


### PR DESCRIPTION
Just two quick fixes for places where the frontend code was tripping over some Berkeley schema changes:

* `web/src/components/FacetedSearch.vue`: The `gold_path_field` slot does not have the referenced annotation in the Berkeley schema. The change to add the annotation was merged into `nmdc-schema` on [July 17](https://github.com/microbiomedata/nmdc-schema/pull/2120) and the last time `berkeley-schema-fy24` was synced with `nmdc-schema` it included changes through [July 16](https://github.com/microbiomedata/berkeley-schema-fy24/pull/229). So the annotation should come back eventually. In the meantime this prevents a render-time error.
* `web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue`: We just needed to refer to the enum's new name.