### PR TITLE
Change down_revision of COG table migration

### DIFF
--- a/nmdc_server/migrations/versions/317274ad8137_add_cog_mappings.py
+++ b/nmdc_server/migrations/versions/317274ad8137_add_cog_mappings.py
@@ -1,7 +1,7 @@
 """Add COG mappings
 
 Revision ID: 317274ad8137
-Revises: 0ff690fb929d
+Revises: 5403c7fe0b33
 Create Date: 2024-08-30 20:13:12.480955
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "317274ad8137"
-down_revision: Optional[str] = "0ff690fb929d"
+down_revision: Optional[str] = "5403c7fe0b33"
 branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 


### PR DESCRIPTION
A hotfix introduced a new migration between the development and final review/ merging of the COG ingest changes, which resulted in a revision tree with multiple heads. In this state, Alembic does not know how to proceed and so deployments of the data portal were not starting up correctly.

Fix #1386 

### Changes
Linearizes the Alembic migration files. The two migrations in particular are completely separate, so there's no conflict to resolve within the migrations themselves.

Note: see #909 for a similar situation and resolution