### PR TITLE
Update submission report to include "Source Client" and "Status"

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -658,6 +658,8 @@ async def get_metadata_submissions_report(
         "Study Name",
         "PI Name",
         "PI Email",
+        "Source Client",
+        "Status",
     ]
     data_rows = []
     for s in submissions:
@@ -667,7 +669,7 @@ async def get_metadata_submissions_report(
         study_name = study_form["studyName"] if "studyName" in study_form else ""
         pi_name = study_form["piName"] if "piName" in study_form else ""
         pi_email = study_form["piEmail"] if "piEmail" in study_form else ""
-        data_row = [s.id, s.author_orcid, author_user.name, study_name, pi_name, pi_email]
+        data_row = [s.id, s.author_orcid, author_user.name, study_name, pi_name, pi_email, s.source_client, s.status]
         data_rows.append(data_row)
 
     # Build the report as an in-memory TSV "file" (buffer).

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -669,7 +669,16 @@ async def get_metadata_submissions_report(
         study_name = study_form["studyName"] if "studyName" in study_form else ""
         pi_name = study_form["piName"] if "piName" in study_form else ""
         pi_email = study_form["piEmail"] if "piEmail" in study_form else ""
-        data_row = [s.id, s.author_orcid, author_user.name, study_name, pi_name, pi_email, s.source_client, s.status]
+        data_row = [
+            s.id,
+            s.author_orcid,
+            author_user.name,
+            study_name,
+            pi_name,
+            pi_email,
+            s.source_client,
+            s.status,
+        ]
         data_rows.append(data_row)
 
     # Build the report as an in-memory TSV "file" (buffer).

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -111,8 +111,8 @@ def test_get_metadata_submissions_report_as_admin(
     assert data_row["Study Name"] == ""
     assert data_row["PI Name"] == ""
     assert data_row["PI Email"] == ""
-    assert data_row["Source Client"] is None
-    assert data_row["Status"] == "In Progress"  # matches the default value defined in the faker
+    assert data_row["Source Client"] == ""  # upstream faker does not have a `source_client` attribute
+    assert data_row["Status"] == "In Progress"  # matches the default value defined in upstream faker
 
 
 def test_obtain_submission_lock(db: Session, client: TestClient, logged_in_user):

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -65,6 +65,8 @@ def test_get_metadata_submissions_report_as_admin(
                 "piEmail": "My PI email",
             },
         },
+        status="in-progress",
+        source_client="field_notes",
     )
     db.commit()
 
@@ -82,6 +84,8 @@ def test_get_metadata_submissions_report_as_admin(
         "Study Name",
         "PI Name",
         "PI Email",
+        "Source Client",
+        "Status",
     ]
     reader = DictReader(response.text.splitlines(), fieldnames=fieldnames, delimiter="\t")
     rows = [row for row in reader]
@@ -97,6 +101,8 @@ def test_get_metadata_submissions_report_as_admin(
     assert data_row["Study Name"] == "My study name"
     assert data_row["PI Name"] == "My PI name"
     assert data_row["PI Email"] == "My PI email"
+    assert data_row["Source Client"] == "field_notes"
+    assert data_row["Status"] == "in-progress"
 
     data_row = rows[2]  # gets the second data row
     assert data_row["Submission ID"] == str(submission.id)
@@ -105,6 +111,8 @@ def test_get_metadata_submissions_report_as_admin(
     assert data_row["Study Name"] == ""
     assert data_row["PI Name"] == ""
     assert data_row["PI Email"] == ""
+    assert data_row["Source Client"] is None
+    assert data_row["Status"] == "In Progress"  # matches the default value defined in the faker
 
 
 def test_obtain_submission_lock(db: Session, client: TestClient, logged_in_user):

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -111,8 +111,8 @@ def test_get_metadata_submissions_report_as_admin(
     assert data_row["Study Name"] == ""
     assert data_row["PI Name"] == ""
     assert data_row["PI Email"] == ""
-    assert data_row["Source Client"] == ""  # upstream faker does not have a `source_client` attribute
-    assert data_row["Status"] == "In Progress"  # matches the default value defined in upstream faker
+    assert data_row["Source Client"] == ""  # upstream faker lacks `source_client` attribute
+    assert data_row["Status"] == "In Progress"  # matches value in upstream faker
 
 
 def test_obtain_submission_lock(db: Session, client: TestClient, logged_in_user):


### PR DESCRIPTION
In this branch, I updated the `/metadata_submission/report` API endpoint so that the TSV file it generates includes two additional columns: "Source Client" and "Status". I also updated the test that targets that endpoint so it asserts that those columns contain the values I expect.