### PR TITLE
Initial implementation of metadata suggestion endpoint

### DIFF
--- a/nmdc_server/metadata.py
+++ b/nmdc_server/metadata.py
@@ -1,0 +1,47 @@
+import re
+from typing import Dict, Optional
+
+from nmdc_geoloc_tools import GeoEngine
+
+
+class SampleMetadataSuggester:
+    """A class to suggest sample metadata values based on partial sample metadata."""
+
+    def __init__(self):
+        self._geo_engine: Optional[GeoEngine] = None
+
+    @property
+    def geo_engine(self) -> GeoEngine:
+        """A GeoEngine instance for looking up geospatial data."""
+        if self._geo_engine is None:
+            self._geo_engine = GeoEngine()
+        return self._geo_engine
+
+    def suggest_elevation(self, sample: Dict[str, str]) -> Optional[float]:
+        """Suggest an elevation for a sample based on its lat_lon."""
+        lat_lon = sample.get("lat_lon", None)
+        if lat_lon is None:
+            return None
+        lat_lon_split = re.split("[, ]+", lat_lon)
+        if len(lat_lon_split) == 2:
+            try:
+                lat, lon = map(float, lat_lon_split)
+                return self.geo_engine.get_elevation((lat, lon))
+            except ValueError:
+                # This could happen if the lat_lon string is not parseable as a float
+                # or the GeoEngine determined they are invalid values. In either case,
+                # just don't suggest an elevation.
+                pass
+        return None
+
+    def get_suggestions(self, sample: Dict[str, str]) -> Dict[str, str]:
+        """Suggest metadata values for a sample.
+
+        Returns a dictionary where the keys are sample metadata slots and the values are suggested
+        values.
+        """
+        suggestions = {}
+        elevation = self.suggest_elevation(sample)
+        if elevation is not None:
+            suggestions["elev"] = str(elevation)
+        return suggestions

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, validator
@@ -144,3 +144,15 @@ class SubmissionMetadataSchema(SubmissionMetadataSchemaCreate):
 
 
 SubmissionMetadataSchema.update_forward_refs()
+
+
+class MetadataSuggestionRequest(BaseModel):
+    row: int
+    data: Dict[str, str]
+
+
+class MetadataSuggestion(BaseModel):
+    op: Literal["add", "remove", "replace"]
+    row: int
+    slot: str
+    value: str

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Literal
+from enum import Enum
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, validator
@@ -151,8 +152,13 @@ class MetadataSuggestionRequest(BaseModel):
     data: Dict[str, str]
 
 
+class MetadataSuggestionType(str, Enum):
+    ADD = "add"
+    REPLACE = "replace"
+
+
 class MetadataSuggestion(BaseModel):
-    op: Literal["add", "remove", "replace"]
+    type: MetadataSuggestionType
     row: int
     slot: str
     value: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "ipython==8.10.0",
     "itsdangerous==2.0.1",
     "mypy<0.920",
+    "nmdc-geoloc-tools==0.1.1",
     "nmdc-schema==10.8.0",
     "nmdc-submission-schema==10.8.0",
     "pint==0.18",

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,33 @@
+from nmdc_server.metadata import SampleMetadataSuggester
+
+
+def test_sample_metadata_suggester_elevation():
+    suggester = SampleMetadataSuggester()
+
+    # Test with valid lat_lon
+    sample = {"lat_lon": "37.875766 -122.248580"}
+    elevation = suggester.suggest_elevation(sample)
+    assert elevation == 16.0
+
+    # Be tolerant of a comma separator
+    sample = {"lat_lon": "37.875766, -122.248580"}
+    elevation = suggester.suggest_elevation(sample)
+    assert elevation == 16.0
+
+    # Don't return a suggestion when lat_lon is missing
+    sample = {}
+    elevation = suggester.suggest_elevation(sample)
+    assert elevation is None
+
+    # Don't return a suggestion when lat_lon is invalid
+    sample = {"lat_lon": "91.0 -122.248580"}
+    elevation = suggester.suggest_elevation(sample)
+    assert elevation is None
+
+    sample = {"lat_lon": "no good"}
+    elevation = suggester.suggest_elevation(sample)
+    assert elevation is None
+
+    sample = {"lat_lon": "0 0 0"}
+    elevation = suggester.suggest_elevation(sample)
+    assert elevation is None

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,28 +6,28 @@ def test_sample_metadata_suggester_elevation():
 
     # Test with valid lat_lon
     sample = {"lat_lon": "37.875766 -122.248580"}
-    elevation = suggester.suggest_elevation(sample)
+    elevation = suggester.suggest_elevation_from_lat_lon(sample)
     assert elevation == 16.0
 
     # Be tolerant of a comma separator
     sample = {"lat_lon": "37.875766, -122.248580"}
-    elevation = suggester.suggest_elevation(sample)
+    elevation = suggester.suggest_elevation_from_lat_lon(sample)
     assert elevation == 16.0
 
     # Don't return a suggestion when lat_lon is missing
     sample = {}
-    elevation = suggester.suggest_elevation(sample)
+    elevation = suggester.suggest_elevation_from_lat_lon(sample)
     assert elevation is None
 
     # Don't return a suggestion when lat_lon is invalid
     sample = {"lat_lon": "91.0 -122.248580"}
-    elevation = suggester.suggest_elevation(sample)
+    elevation = suggester.suggest_elevation_from_lat_lon(sample)
     assert elevation is None
 
     sample = {"lat_lon": "no good"}
-    elevation = suggester.suggest_elevation(sample)
+    elevation = suggester.suggest_elevation_from_lat_lon(sample)
     assert elevation is None
 
     sample = {"lat_lon": "0 0 0"}
-    elevation = suggester.suggest_elevation(sample)
+    elevation = suggester.suggest_elevation_from_lat_lon(sample)
     assert elevation is None

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -610,3 +610,18 @@ def test_sync_submission_study_name(db: Session, client: TestClient, logged_in_u
     response = client.request(method="GET", url=f"/api/metadata_submission/{submission.id}")
     assert response.status_code == 200
     assert response.json()["study_name"] == expected_val
+
+
+def test_metadata_suggest_elevation(client: TestClient, logged_in_user):
+    payload = [
+        {"row": 1, "data": {"foo": "bar", "lat_lon": "44.058648, -123.095277"}},
+        {"row": 3, "data": {"elev": 0, "lat_lon": "44.046389 -123.051910"}},
+        {"row": 4, "data": {"foo": "bar"}},
+        {"row": 5, "data": {"lat_lon": "garbage foo bar"}},
+    ]
+    response = client.request(method="POST", url="/api/metadata_submission/suggest", json=payload)
+    assert response.status_code == 200
+    assert response.json() == [
+        {"op": "add", "row": 1, "slot": "elev", "value": "16.0"},
+        {"op": "replace", "row": 3, "slot": "elev", "value": "16.0"},
+    ]

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -11,6 +11,16 @@ from nmdc_server.models import SubmissionEditorRole, SubmissionRole
 from nmdc_server.schemas_submission import SubmissionMetadataSchema, SubmissionMetadataSchemaPatch
 
 
+@pytest.fixture
+def suggest_payload():
+    return [
+        {"row": 1, "data": {"foo": "bar", "lat_lon": "44.058648, -123.095277"}},
+        {"row": 3, "data": {"elev": 0, "lat_lon": "44.046389 -123.051910"}},
+        {"row": 4, "data": {"foo": "bar"}},
+        {"row": 5, "data": {"lat_lon": "garbage foo bar"}},
+    ]
+
+
 def test_list_submissions(db: Session, client: TestClient, logged_in_user):
     submission = fakes.MetadataSubmissionFactory(
         author=logged_in_user, author_orcid=logged_in_user.orcid
@@ -612,16 +622,46 @@ def test_sync_submission_study_name(db: Session, client: TestClient, logged_in_u
     assert response.json()["study_name"] == expected_val
 
 
-def test_metadata_suggest_elevation(client: TestClient, logged_in_user):
-    payload = [
-        {"row": 1, "data": {"foo": "bar", "lat_lon": "44.058648, -123.095277"}},
-        {"row": 3, "data": {"elev": 0, "lat_lon": "44.046389 -123.051910"}},
-        {"row": 4, "data": {"foo": "bar"}},
-        {"row": 5, "data": {"lat_lon": "garbage foo bar"}},
-    ]
-    response = client.request(method="POST", url="/api/metadata_submission/suggest", json=payload)
+def test_metadata_suggest(client: TestClient, suggest_payload, logged_in_user):
+    response = client.request(
+        method="POST", url="/api/metadata_submission/suggest", json=suggest_payload
+    )
     assert response.status_code == 200
     assert response.json() == [
-        {"op": "add", "row": 1, "slot": "elev", "value": "16.0"},
-        {"op": "replace", "row": 3, "slot": "elev", "value": "16.0"},
+        {"type": "add", "row": 1, "slot": "elev", "value": "16.0"},
+        {"type": "replace", "row": 3, "slot": "elev", "value": "16.0"},
     ]
+
+
+def test_metadata_suggest_single_type(client: TestClient, suggest_payload, logged_in_user):
+    response = client.request(
+        method="POST",
+        url="/api/metadata_submission/suggest?types=add",
+        json=suggest_payload,
+    )
+    assert response.status_code == 200
+    assert response.json() == [
+        {"type": "add", "row": 1, "slot": "elev", "value": "16.0"},
+    ]
+
+
+def test_metadata_suggest_multiple_types(client: TestClient, suggest_payload, logged_in_user):
+    response = client.request(
+        method="POST",
+        url="/api/metadata_submission/suggest?types=add&types=replace",
+        json=suggest_payload,
+    )
+    assert response.status_code == 200
+    assert response.json() == [
+        {"type": "add", "row": 1, "slot": "elev", "value": "16.0"},
+        {"type": "replace", "row": 3, "slot": "elev", "value": "16.0"},
+    ]
+
+
+def test_metadata_suggest_invalid_type(client: TestClient, suggest_payload, logged_in_user):
+    response = client.request(
+        method="POST",
+        url="/api/metadata_submission/suggest?types=whatever",
+        json=suggest_payload,
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
Fixes #1382 

### Summary

The context for this change is Milestone 3.3 (https://github.com/microbiomedata/issues/issues/473), which is about adding functionality to the submission portal where partial sample metadata is used to make suggestions for other metadata fields.

These changes add an initial metadata suggestion endpoint. It implements suggestions for elevation based on latitude and longitude (via the [`nmdc-geoloc-tools`](https://github.com/microbiomedata/geoloc-tools/) package). There is a bit of an eye here towards making it easy to extend this in the future.

The new endpoint is not currently used by anything. See https://github.com/microbiomedata/nmdc-server/issues/1381 and https://github.com/microbiomedata/nmdc-server/issues/1383 for more info on how this will be integrated on the client side.

### Details

* New dependency on [`nmdc-geoloc-tools`](https://github.com/microbiomedata/geoloc-tools/) which encapsulates requests to ORNL geolocation services. That codebase was provided a _looong_ time ago by someone at ORNL. I recently went in and cleaned up the repo to get it ready for publishing to PyPI, but I don't know a lot about the services it interacts with. Because of that I added an `autouse` test fixture (`tests/conftest.py`) which stubs out all of the methods that make external network requests.
* New class `SampleMetadataSuggester` which is responsible for generating metadata suggestions. The main method here is `get_suggestions` which in turn defers to methods focused on providing suggestions for a individual metadata fields. Currently there is only one such method, `suggest_elevation_from_lat_lon`. 
* A new `/metadata_submission/suggest` is added which accepts list of partial sample metadata records (the "rows" terminology is derived from the fact that, in practice, this information will come from DataHarmonizer) and returns a list of suggested changes.
