### PR TITLE
Rename omics_processing endpoints to data_generation

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -411,13 +411,18 @@ async def get_study_image(study_id: str, db: Session = Depends(get_db)):
     return StreamingResponse(BytesIO(image), media_type="image/jpeg")
 
 
-# omics_processing
+# data_generation
+# Note the intermingling of the terms "data generation" and "omics processing."
+# The Berkeley schema (NMDC schema v11) did away with the phrase "omics processing."
+# As a result, public-facing uses of "omics processing" should be replaced with
+# "data generation."
+# Future work should go in to a more thorough conversion of omics process to data generation.
 @router.post(
-    "/omics_processing/search",
+    "/data_generation/search",
     response_model=query.OmicsProcessingSearchResponse,
-    tags=["omics_processing"],
-    name="Search for omics processings",
-    description="Faceted search of omics_processing data.",
+    tags=["data_generation"],
+    name="Search for data generations",
+    description="Faceted search of data_generation data.",
 )
 async def search_omics_processing(
     query: query.SearchQuery = query.SearchQuery(),
@@ -428,9 +433,9 @@ async def search_omics_processing(
 
 
 @router.post(
-    "/omics_processing/facet",
+    "/data_generation/facet",
     response_model=query.FacetResponse,
-    tags=["omics_processing"],
+    tags=["data_generation"],
     name="Get all values of an attribute",
 )
 async def facet_omics_processing(query: query.FacetQuery, db: Session = Depends(get_db)):
@@ -438,9 +443,9 @@ async def facet_omics_processing(query: query.FacetQuery, db: Session = Depends(
 
 
 @router.post(
-    "/omics_processing/binned_facet",
+    "/data_generation/binned_facet",
     response_model=query.BinnedFacetResponse,
-    tags=["omics_processing"],
+    tags=["data_generation"],
     name="Get all values of a non-string attribute with binning",
 )
 async def binned_facet_omics_processing(
@@ -450,26 +455,26 @@ async def binned_facet_omics_processing(
 
 
 @router.get(
-    "/omics_processing/{omics_processing_id}",
+    "/data_generation/{data_generation_id}",
     response_model=schemas.OmicsProcessing,
-    tags=["omics_processing"],
+    tags=["data_generation"],
 )
-async def get_omics_processing(omics_processing_id: str, db: Session = Depends(get_db)):
-    db_omics_processing = crud.get_omics_processing(db, omics_processing_id)
+async def get_omics_processing(data_generation_id: str, db: Session = Depends(get_db)):
+    db_omics_processing = crud.get_omics_processing(db, data_generation_id)
     if db_omics_processing is None:
         raise HTTPException(status_code=404, detail="OmicsProcessing not found")
     return db_omics_processing
 
 
 @router.get(
-    "/omics_processing/{omics_processing_id}/outputs",
+    "/data_generation/{data_generation_id}/outputs",
     response_model=List[schemas.DataObject],
-    tags=["omics_processing"],
+    tags=["data_generation"],
 )
 async def list_omics_processing_data_objects(
-    omics_processing_id: str, db: Session = Depends(get_db)
+    data_generation_id: str, db: Session = Depends(get_db)
 ):
-    return crud.list_omics_processing_data_objects(db, omics_processing_id).all()
+    return crud.list_omics_processing_data_objects(db, data_generation_id).all()
 
 
 # data object

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -153,7 +153,7 @@ def test_get_environmental_aggregation(db: Session, client: TestClient):
 @pytest.mark.parametrize(
     "endpoint",
     [
-        "omics_processing",
+        "data_generation",
     ],
 )
 def test_list_data_objects(db: Session, client: TestClient, endpoint: str):

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -402,7 +402,7 @@ async function searchStudy(params: SearchParams) {
 }
 
 async function searchOmicsProcessing(params: SearchParams) {
-  return _search<OmicsProcessingResult>('omics_processing', params);
+  return _search<OmicsProcessingResult>('data_generation', params);
 }
 
 async function searchReadsQC(params: SearchParams) {
@@ -483,7 +483,7 @@ async function getFacetSummary(
   field: string,
   conditions: Condition[],
 ): Promise<FacetSummaryResponse[]> {
-  const path = type;
+  const path = type === 'omics_processing' ? 'data_generation' : type;
   const { data } = await client.post<{ facets: Record<string, number> }>(`${path}/facet`, {
     conditions, attribute: field,
   });
@@ -504,7 +504,8 @@ async function getBinnedFacet<T = string | number>(
   numBins: number,
   resolution: 'day' | 'week' | 'month' | 'year' = 'month',
 ) {
-  const { data } = await client.post<BinResponse<T>>(`${table}/binned_facet`, {
+  const path = table === 'omics_processing' ? 'data_generation' : table;
+  const { data } = await client.post<BinResponse<T>>(`${path}/binned_facet`, {
     attribute,
     conditions,
     resolution,
@@ -588,7 +589,8 @@ async function getDataObjectList(
     'metaproteomic_analysis',
   ];
   if (supportedTypes.indexOf(type) >= 0) {
-    const { data } = await client.get<DataObjectSearchResult[]>(`${type}/${parentId}/outputs`);
+    const path = type === 'omics_processing' ? 'data_generation' : type;
+    const { data } = await client.get<DataObjectSearchResult[]>(`${path}/${parentId}/outputs`);
     return data;
   }
   return [];


### PR DESCRIPTION
Fix #1394 

Update the public-facing endpoints in the "omics_processing" group to use "data_generation" instead. 

The scope of this change is limited to updating those API endpoint URLs only, and makes sure that corresponding code on the client uses the new route names. It does not attempt to scrub the phrase "omics_processing" from this code base. That is a much larger task that is outside the scope of the "MVP" release of the Berkeley schema.