### PR TITLE
Use correct slot for study protocols for Berkeley schema

### DIFF
--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -86,6 +86,14 @@ def load(db: Session, cursor: Cursor):
                     doi_provider=doi.get("doi_provider", ""),
                 )
 
+        protocols = obj.pop("protocol_link", [])
+        relevant_protocols = []
+        if protocols:
+            for protocol in protocols:
+                if "url" in protocol:
+                    relevant_protocols.append(protocol["url"])
+        obj["relevant_protocols"] = relevant_protocols
+
         new_study = create_study(db, Study(**obj))
         if dois:
             for doi in dois:

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -86,13 +86,9 @@ def load(db: Session, cursor: Cursor):
                     doi_provider=doi.get("doi_provider", ""),
                 )
 
-        protocols = obj.pop("protocol_link", [])
-        relevant_protocols = []
-        if protocols:
-            for protocol in protocols:
-                if "url" in protocol:
-                    relevant_protocols.append(protocol["url"])
-        obj["relevant_protocols"] = relevant_protocols
+        protocol_links = obj.pop("protocol_link", None)
+        if protocol_links:
+            obj["relevant_protocols"] = [p["url"] for p in protocol_links if "url" in p]
 
         new_study = create_study(db, Study(**obj))
         if dois:


### PR DESCRIPTION
Fix #1406 

Updates ingest to pull study protocol URLs out of the correct slot. A potential follow-on task post rollout has been added to #1331 