### PR TITLE
Skip BRITE terms

### DIFF
--- a/nmdc_server/ingest/kegg.py
+++ b/nmdc_server/ingest/kegg.py
@@ -124,13 +124,19 @@ delimeted_files: Dict[str, Dict[str, Union[str, List[str]]]] = {
 }
 
 
+def is_brite_hierarchy_term(term: str):
+    pass
+
+
 def get_search_records():
     records: Dict[str, str] = {}
 
     def ingest_tree(node: dict) -> None:
         if not node.get("children", False):
             term, *text = node["name"].split("  ", maxsplit=1)
-            records[term] = text[0] if text else ""
+            if "BR:" not in term:
+                # Skip over BRITE term hierarchies that have no children
+                records[term] = text[0] if text else ""
 
         for child in node.get("children", ()):
             ingest_tree(child)

--- a/nmdc_server/ingest/kegg.py
+++ b/nmdc_server/ingest/kegg.py
@@ -124,10 +124,6 @@ delimeted_files: Dict[str, Dict[str, Union[str, List[str]]]] = {
 }
 
 
-def is_brite_hierarchy_term(term: str):
-    pass
-
-
 def get_search_records():
     records: Dict[str, str] = {}
 


### PR DESCRIPTION
Fix #1385 

### Changes
Explicitly skip BRITE hierarchy terms that don't have any children.

#### Problem
The data portal uses a JSON blob from https://www.genome.jp/kegg-bin/download_htext?htext=ko00001&format=json to populate its tables of KO terms. It appears as though this file contains KO terms grouped by Brite hierarchies. Ingest code appears to anticipate this, and does not add rows for parent nodes that don't have children.

This is a problem since there is one parent node without children that we want to skip, since we don't support the full Brite hierarchy at this time. This new change handles the issue by safeguarding against this specific case. 