### PR TITLE
Hide banner about Berkeley Schema Roll Out downtime, and reset its content

### DIFF
--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -8,16 +8,10 @@
     <p
       class="title"
     >
-      Upcoming maintenance (October 15-16)
+      Banner title (replace me)
     </p>
     <p>
-      On Tuesday, October 15, 2024, from 9 AM to 9 PM PDT, the NMDC Data Portal, Submission Portal, and API will be
-      unavailable for scheduled software upgrades.
-    </p>
-    <p>
-      On Wednesday, October 16, 2024, from 9 AM to 9 PM PDT, the data download functionality
-      of the Data Portal will be unavailable for system maintenance. All other features of the Data Portal will remain
-      available during that time.
+      Banner content (replace me)
     </p>
   </v-banner>
 </template>

--- a/web/src/views/IndividualResults/SamplePage.vue
+++ b/web/src/views/IndividualResults/SamplePage.vue
@@ -37,7 +37,7 @@ export default defineComponent({
 <template>
   <v-main v-if="result.id">
     <!-- TODO: Reference a boolean variable defined elsewhere (TBD). -->
-    <AppBanner v-if="true" />
+    <AppBanner v-if="false" />
     <v-container fluid>
       <IndividualTitle :item="result" />
       <AttributeList

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -236,7 +236,7 @@ export default defineComponent({
   <v-container fluid>
     <v-main v-if="item !== null">
       <!-- TODO: Reference a boolean variable defined elsewhere (TBD). -->
-      <AppBanner v-if="true" />
+      <AppBanner v-if="false" />
       <v-row :class="{'flex-column': $vuetify.breakpoint.xs}">
         <v-col
           cols="12"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -216,7 +216,7 @@ export default defineComponent({
         style="position: fixed; top: 64; z-index: 2;"
       />
       <!-- TODO: Reference a boolean variable defined elsewhere (TBD). -->
-      <AppBanner v-if="true" />
+      <AppBanner v-if="false" />
       <v-container
         fluid
         class="py-0"

--- a/web/src/views/SubmissionPortal/SubmissionView.vue
+++ b/web/src/views/SubmissionPortal/SubmissionView.vue
@@ -56,7 +56,7 @@ export default defineComponent({
 <template>
   <v-main>
     <!-- TODO: Reference a boolean variable defined elsewhere (TBD). -->
-    <AppBanner v-if="true" />
+    <AppBanner v-if="false" />
     <v-container
       v-if="!stateRefs.user.value && !req.loading.value"
     >

--- a/web/src/views/User/UserDetailPage.vue
+++ b/web/src/views/User/UserDetailPage.vue
@@ -62,7 +62,7 @@ export default defineComponent({
 <template>
   <v-main>
     <!-- TODO: Reference a boolean variable defined elsewhere (TBD). -->
-    <AppBanner v-if="true" />
+    <AppBanner v-if="false" />
     <v-container>
       <div v-if="userLoading">
         Loading...

--- a/web/src/views/User/UserPage.vue
+++ b/web/src/views/User/UserPage.vue
@@ -49,7 +49,7 @@ export default defineComponent({
 <template>
   <v-main>
     <!-- TODO: Reference a boolean variable defined elsewhere (TBD). -->
-    <AppBanner v-if="true" />
+    <AppBanner v-if="false" />
     <v-container>
       <v-card flat>
         <v-card-title class="text-h4">


### PR DESCRIPTION
In this branch, I hid the banner and reset its content with placeholder content.

I already deployed this to production via a hotfix (release `Release 2024.10.1` / tag `v1.0.1`). I'm opening this PR because the final step of our internal [Developing and releasing a hotfix](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-server.md#developing-and-releasing-a-hotfix) guide says to open a PR to merge the hotfix branch into `main`.