### PR TITLE
Use correct slot when querying gene aggregations

### DIFF
--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -225,7 +225,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
             ),
             pipeline.load_mp_analysis,
             WorkflowActivityTypeEnum.metaproteomic_analysis.value,
-            annotations=mongodb["metap_gene_function_aggregation"],
+            annotations=mongodb["functional_annotation_agg"],
             function_limit=function_limit,
         )
         db.commit()

--- a/nmdc_server/ingest/pipeline.py
+++ b/nmdc_server/ingest/pipeline.py
@@ -31,7 +31,7 @@ def load_mg_annotation(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObject
 
     query = annotations.find(
         {
-            "metagenome_annotation_id": pipeline.id,
+            "was_generated_by": pipeline.id,
             "gene_function_id": {
                 "$regex": gene_regex,
             },
@@ -39,7 +39,7 @@ def load_mg_annotation(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObject
         no_cursor_timeout=True,
         projection={
             "_id": False,
-            "metagenome_annotation_id": True,
+            "was_generated_by": True,
             "count": True,
             "gene_function_id": True,
         },
@@ -88,7 +88,7 @@ def load_mp_analysis(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObjectRe
 
     query = annotations.find(
         {
-            "metaproteomic_analysis_id": pipeline.id,
+            "was_generated_by": pipeline.id,
             "gene_function_id": {
                 "$regex": gene_regex,
             },
@@ -97,7 +97,7 @@ def load_mp_analysis(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObjectRe
         no_cursor_timeout=True,
         projection={
             "_id": False,
-            "metaproteomic_analysis_id": True,
+            "was_generated_by": True,
             "count": True,
             "gene_function_id": True,
             "best_protein": True,
@@ -139,7 +139,7 @@ def load_mt_annotation(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObject
     # Query gene function annotations from mongo and build the appropriate objects
     query = annotations.find(
         {
-            "metagenome_annotation_id": pipeline.id,
+            "was_generated_by": pipeline.id,
             "gene_function_id": {
                 "$regex": gene_regex,
             },
@@ -147,7 +147,7 @@ def load_mt_annotation(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObject
         no_cursor_timeout=True,
         projection={
             "_id": False,
-            "metatranscriptome_annotation_id": True,
+            "was_generated_by": True,
             "count": True,
             "gene_function_id": True,
         },


### PR DESCRIPTION
# Breaking Changes
This PR includes changes to ingest. Until upstream data is migrated to include the [schema changes](https://github.com/microbiomedata/nmdc-schema/pull/2203) that necessitated this change, ingest will fail to create records based on `functional_annotation_agg`s

#### Summary of changes
The slot that links `functional_annotation_agg` members to their `workflow_execution`s has been changed to be `was_generated_by`. This change is now reflected in ingest code.

#### To test
Make sure ingest populates the ____GeneFunctionAggregation tables.