### PR TITLE
nginx payload size config and sample metadata loading indicator

### DIFF
--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -14,6 +14,8 @@ http {
 
         server_name localhost;
 
+        client_max_body_size ${NGINX_CLIENT_MAX_BODY_SIZE};
+
         location / {
             try_files ${DOLLAR}uri ${DOLLAR}uri/ /index.html;
         }

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -658,7 +658,7 @@ export default defineComponent({
             color="primary"
             :width="1"
             size="20"
-            value="70"
+            indeterminate
           />
           Saving progress
         </span>

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -172,12 +172,13 @@ export default defineComponent({
     ));
 
     const saveRecordRequest = useRequest();
+    const saveRecord = () => saveRecordRequest.request(() => incrementalSaveRecord(root.$route.params.id));
 
     const onDataChange = async () => {
       hasChanged.value += 1;
       const data = harmonizerApi.exportJson();
       mergeSampleData(activeTemplate.value.sampleDataSlot, data);
-      await saveRecordRequest.request(() => incrementalSaveRecord(root.$route.params.id));
+      saveRecord(); // This is a background save that we intentionally don't wait for
       tabsValidated.value[activeTemplateKey.value] = false;
     };
     const { request: schemaRequest, loading: schemaLoading } = useRequest();
@@ -228,7 +229,7 @@ export default defineComponent({
         ...invalidCells.value,
         [activeTemplateKey.value]: result,
       };
-      incrementalSaveRecord(root.$route.params.id);
+      saveRecord(); // This is a background save that we intentionally don't wait for
       if (valid === false) {
         errorClick(0);
       }
@@ -441,7 +442,7 @@ export default defineComponent({
 
         // Sync with backend
         hasChanged.value += 1;
-        incrementalSaveRecord(root.$route.params.id);
+        saveRecord(); // This is a background save that we intentionally don't wait for
 
         // Load data for active tab into DataHarmonizer
         harmonizerApi.loadData(activeTemplateData.value);

--- a/web/start.sh
+++ b/web/start.sh
@@ -1,6 +1,7 @@
 set -e
 export DOLLAR='$'
 export DNS_ADDRESS=$(grep -m 1 ^nameserver /etc/resolv.conf | sed -E -n 's/\D*(\d+\.\d+\.\d+\.\d+)\D*/\1/p')
+export NGINX_CLIENT_MAX_BODY_SIZE=${NGINX_CLIENT_MAX_BODY_SIZE:-10m}
 
 envsubst < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 nginx -g 'daemon off;'


### PR DESCRIPTION
Fixes #1444 

### Summary

These changes address two items exposed by a user attempting to save a large set of sample metadata:

1. The save request was being rejected because of nginx's maximum payload size setting
2. The UI was not telling the user that the request failed

### Details

First, the [`client_max_body_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) directive has been added to the nginx config template. It is populated with the value of the `NGINX_CLIENT_MAX_BODY_SIZE` environment variable. If this variable is not set manually, it will get set to `10m` via `web/start.sh`. This will allow payload sizes of 10 MB (the default is 1 MB). We can also choose to set the `NGINX_CLIENT_MAX_BODY_SIZE` in Rancher if we need to adjust the value on the fly for whatever reason.

Second, I updated `HarmoinzerView.vue` so that all of the `incrementalSaveRecord` calls are made via `useRequest`. This means that the loading and error state tracking doesn't need to be done manually, and it can be done uniformly for every call. The previous loading and error state tracking was a bit faulty because `await incrementalSaveRecord(...)` will raise an exception if the underlying HTTP request fails, meaning the bit where `isSaving` was set to `false` was never reached. These changes also make it so that the loading indicator is shown whenever a save is happening (including after importing an XLSX file).