### PR TITLE
Add delete submission button and overflow menu

### DIFF
--- a/web/src/use/usePaginatedResults.ts
+++ b/web/src/use/usePaginatedResults.ts
@@ -81,6 +81,7 @@ export default function usePaginatedResult<T>(
     error,
     loading,
     page,
+    refetch: fetchResults,
     setPage,
     setItemsPerPage,
     setSortOptions,

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -68,8 +68,8 @@ export default defineComponent({
       mustSort: false,
     });
     const deleteDialog = ref(false);
-    let deleteConfirmation = false;
-    let dialogUpdated = false;
+    const deleteConfirmation = ref(false);
+    const dialogUpdated = ref(false);
 
     function getStatus(item: api.MetadataSubmissionRecord) {
       const color = item.status === submissionStatus.Complete ? 'success' : 'default';
@@ -91,7 +91,7 @@ export default defineComponent({
     function waitForDialogUpdate(): Promise<void> {
       return new Promise<void>((resolve) => {
         const intervalId = setInterval(() => {
-          if (dialogUpdated === true) {
+          if (dialogUpdated.value === true) {
             clearInterval(intervalId);
             resolve();
           }
@@ -109,14 +109,14 @@ export default defineComponent({
       }
 
       deleteDialog.value = false;
-      deleteConfirmation = false;
-      dialogUpdated = false;
+      deleteConfirmation.value = false;
+      dialogUpdated.value = false;
       return item;
     }
 
     function deleteDialogUpdate(confirmation: boolean) {
-      deleteConfirmation = confirmation;
-      dialogUpdated = true;
+      deleteConfirmation.value = confirmation;
+      dialogUpdated.value = true;
     }
 
     async function handleOverflowMenu(item: api.MetadataSubmissionRecord, title: String) {
@@ -125,7 +125,7 @@ export default defineComponent({
           deleteSubmission(item);
           break;
         default:
-          console.log('Something went wrong');
+          break;
       }
     }
 
@@ -297,7 +297,6 @@ export default defineComponent({
       <v-dialog
         v-model="deleteDialog"
         class="ma-5"
-        persistent
       >
         <v-card>
           <v-card-title class="text-h5">

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -216,39 +216,41 @@ export default defineComponent({
             </v-chip>
           </template>
           <template #[`item.action`]="{ item }">
-            <v-btn
-              small
-              color="primary"
-              @click="() => resume(item)"
-            >
-              Resume
-              <v-icon class="pl-1">
-                mdi-arrow-right-circle
-              </v-icon>
-            </v-btn>
-            <v-menu
-              offset-x
-            >
-              <template #activator="{ on }">
-                <v-btn
-                  text
-                  icon
-                  class="ml-1"
-                  v-on="on"
-                >
-                  <v-icon>
-                    mdi-dots-vertical
-                  </v-icon>
-                </v-btn>
-              </template>
-              <v-list>
-                <v-list-item
-                  @click="() => handleOpenDeleteDialog(item)"
-                >
-                  <v-list-item-title>Delete</v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
+            <div class="d-flex align-center">
+              <v-btn
+                small
+                color="primary"
+                @click="() => resume(item)"
+              >
+                Resume
+                <v-icon class="pl-1">
+                  mdi-arrow-right-circle
+                </v-icon>
+              </v-btn>
+              <v-menu
+                offset-x
+              >
+                <template #activator="{ on }">
+                  <v-btn
+                    text
+                    icon
+                    class="ml-1"
+                    v-on="on"
+                  >
+                    <v-icon>
+                      mdi-dots-vertical
+                    </v-icon>
+                  </v-btn>
+                </template>
+                <v-list>
+                  <v-list-item
+                    @click="() => handleOpenDeleteDialog(item)"
+                  >
+                    <v-list-item-title>Delete</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
+            </div>
           </template>
         </v-data-table>
       </v-card>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -217,6 +217,7 @@ export default defineComponent({
           </template>
           <template #[`item.action`]="{ item }">
             <div class="d-flex align-center">
+              <v-spacer />
               <v-btn
                 small
                 color="primary"

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -42,12 +42,6 @@ const headers: DataTableHeader[] = [
     value: 'action',
     sortable: false,
   },
-  {
-    text: '',
-    value: 'menu',
-    align: 'end',
-    sortable: false,
-  },
 ];
 
 export default defineComponent({
@@ -95,23 +89,21 @@ export default defineComponent({
             clearInterval(intervalId);
             resolve();
           }
-        }, 600);
+        }, 100);
       });
     }
 
     async function deleteSubmission(item: api.MetadataSubmissionRecord) {
       deleteDialog.value = true;
       await waitForDialogUpdate();
-      if (deleteConfirmation) {
-        //do the deletion
-        //for now we just resume as a confirmation that the logic worked
-        resume(item);
+      if (deleteConfirmation.value) {
+        //router?.push({})
+        router?.push({ name: 'Submission Context', params: { id: item.id } });
       }
 
       deleteDialog.value = false;
       deleteConfirmation.value = false;
       dialogUpdated.value = false;
-      return item;
     }
 
     function deleteDialogUpdate(confirmation: boolean) {
@@ -262,14 +254,11 @@ export default defineComponent({
                 mdi-arrow-right-circle
               </v-icon>
             </v-btn>
-          </template>
-          <template #[`item.menu`]="{ item }">
             <v-menu
               offset-x
             >
               <template #activator="{ on }">
                 <v-btn
-                  class="ml-1"
                   icon="mdi-dots-vertical"
                   text
                   v-on="on"
@@ -296,22 +285,35 @@ export default defineComponent({
     <v-row justify="center">
       <v-dialog
         v-model="deleteDialog"
+        :width="630"
         class="ma-5"
       >
         <v-card>
-          <v-card-title class="text-h5">
+          <v-spacer />
+          <v-card-title class="ma-3 text-h4">
             Are you sure you want to delete this submission in progress?
           </v-card-title>
-          <v-btn
-            @click="deleteDialogUpdate(true)"
-          >
-            Delete
-          </v-btn>
-          <v-btn
-            @click="deleteDialogUpdate(false)"
-          >
-            Cancel
-          </v-btn>
+          <v-card-text class="ma-3 text-h5">
+            This cannot be undone.
+          </v-card-text>
+          <v-divider />
+          <v-card-actions>
+            <v-spacer />
+            <v-btn
+              color="red"
+              class="ml-3 white--text"
+              @click="deleteDialogUpdate(true)"
+            >
+              Delete
+            </v-btn>
+            <v-btn
+              color="primary"
+              class="ma-3"
+              @click="deleteDialogUpdate(false)"
+            >
+              Cancel
+            </v-btn>
+          </v-card-actions>
         </v-card>
       </v-dialog>
     </v-row>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -40,6 +40,11 @@ const headers: DataTableHeader[] = [
   {
     text: '',
     value: 'action',
+    sortable: false,
+  },
+  {
+    text: '',
+    value: 'menu',
     align: 'end',
     sortable: false,
   },
@@ -80,6 +85,10 @@ export default defineComponent({
       router?.push({ name: 'Submission Context', params: { id: item.id } });
     }
 
+    async function deleteSubmission(item: api.MetadataSubmissionRecord) {
+      return item;
+    }
+
     const submission = usePaginatedResults(ref([]), api.listRecords, ref([]), itemsPerPage);
     watch(options, () => {
       submission.setPage(options.value.page);
@@ -95,6 +104,7 @@ export default defineComponent({
       createNewSubmission,
       getStatus,
       resume,
+      deleteSubmission,
       headers,
       options,
       submission,
@@ -103,9 +113,7 @@ export default defineComponent({
   data: () => ({
     OverFlowMenuItems: [
       { title: 'Delete' },
-      { title: 'Click Me' },
-      { title: 'Click Me' },
-      { title: 'Click Me 2' },
+      { title: 'Future button' },
     ],
   }),
 });
@@ -210,13 +218,15 @@ export default defineComponent({
                 mdi-arrow-right-circle
               </v-icon>
             </v-btn>
-            <v-menu offset-y>
-              <template #activator="{ props }">
+          </template>
+          <template #[`item.menu`]="{ item }">
+            <v-menu>
+              <template #activator="{ on }">
                 <v-btn
                   class="ml-1"
                   icon="mdi-dots-vertical"
                   variant="text"
-                  v-bind="props"
+                  v-on="on"
                 >
                   <v-icon>
                     mdi-dots-vertical
@@ -227,6 +237,7 @@ export default defineComponent({
                 <v-list-item
                   v-for="(entry, i) in OverFlowMenuItems"
                   :key="i"
+                  @click="() => deleteSubmission(item)"
                 >
                   <v-list-item-title>{{ entry.title }}</v-list-item-title>
                 </v-list-item>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -100,6 +100,14 @@ export default defineComponent({
       submission,
     };
   },
+  data: () => ({
+    OverFlowMenuItems: [
+      { title: 'Delete' },
+      { title: 'Click Me' },
+      { title: 'Click Me' },
+      { title: 'Click Me 2' },
+    ],
+  }),
 });
 </script>
 
@@ -202,6 +210,28 @@ export default defineComponent({
                 mdi-arrow-right-circle
               </v-icon>
             </v-btn>
+            <v-menu offset-y>
+              <template #activator="{ props }">
+                <v-btn
+                  class="ml-1"
+                  icon="mdi-dots-vertical"
+                  variant="text"
+                  v-bind="props"
+                >
+                  <v-icon>
+                    mdi-dots-vertical
+                  </v-icon>
+                </v-btn>
+              </template>
+              <v-list>
+                <v-list-item
+                  v-for="(entry, i) in OverFlowMenuItems"
+                  :key="i"
+                >
+                  <v-list-item-title>{{ entry.title }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
           </template>
         </v-data-table>
       </v-card>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -40,6 +40,7 @@ const headers: DataTableHeader[] = [
   {
     text: '',
     value: 'action',
+    align: 'end',
     sortable: false,
   },
 ];
@@ -98,12 +99,13 @@ export default defineComponent({
       await waitForDialogUpdate();
       if (deleteConfirmation.value) {
         //router?.push({})
-        router?.push({ name: 'Submission Context', params: { id: item.id } });
+        //router?.push({ name: 'Submission Context', params: { id: item.id } });
       }
 
       deleteDialog.value = false;
       deleteConfirmation.value = false;
       dialogUpdated.value = false;
+      return item;
     }
 
     function deleteDialogUpdate(confirmation: boolean) {
@@ -114,7 +116,9 @@ export default defineComponent({
     async function handleOverflowMenu(item: api.MetadataSubmissionRecord, title: String) {
       switch (title) {
         case 'Delete':
-          deleteSubmission(item);
+          if (getStatus(item).text === 'in-progress') {
+            deleteSubmission(item);
+          }
           break;
         default:
           break;
@@ -259,8 +263,9 @@ export default defineComponent({
             >
               <template #activator="{ on }">
                 <v-btn
-                  icon="mdi-dots-vertical"
                   text
+                  icon
+                  class="ml-1"
                   v-on="on"
                 >
                   <v-icon>

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -111,6 +111,11 @@ async function unlockSubmission(id: string) {
   return resp.data;
 }
 
+async function deleteSubmission(id: string) {
+  const resp = await client.delete(`metadata_submission/${id}`);
+  return resp.data;
+}
+
 export {
   NmdcAddress,
   addressToString,
@@ -122,4 +127,5 @@ export {
   updateRecord,
   lockSubmission,
   unlockSubmission,
+  deleteSubmission,
 };


### PR DESCRIPTION
This PR is linked to issue: https://github.com/microbiomedata/issues/issues/826
The goal is to add a delete submission button inside an overflow menu that could be added to later.
Clicking the delete button will show a confirmation menu, and when confirmed the submission will be deleted from the front-end schema.

