### PR TITLE
Post message to Slack when ingest completes successfully

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ NMDC_ENVIRONMENT="development"
 
 # Uncomment to enable CORS for local development of the nmdc-field-notes
 # NMDC_CORS_ALLOW_ORIGINS=capacitor://localhost,ionic://localhost,http://localhost,http://127.0.0.1:8100
+
+# (Optional) Slack incoming webhook URL the ingester can use to post messages to Slack.
+# Reference: https://api.slack.com/messaging/webhooks#create_a_webhook
+# SLACK_WEBHOOK_URL_FOR_INGESTER=changeme

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -146,7 +146,7 @@ def ingest(verbose, function_limit, skip_annotation, swap_rancher_secrets):
 
     # Post a message to Slack if a Slack webhook URL is defined.
     # Reference: https://api.slack.com/messaging/webhooks#posting_with_webhooks
-    if settings.slack_webhook_url_for_ingester not in [None, ""]:
+    if isinstance(settings.slack_webhook_url_for_ingester, str):
         click.echo("Posting message to Slack.")
         response = requests.post(
             settings.slack_webhook_url_for_ingester,

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -144,6 +144,21 @@ def ingest(verbose, function_limit, skip_annotation, swap_rancher_secrets):
 
         click.echo("Done")
 
+    # Post a message to Slack if a Slack webhook URL is defined.
+    # Reference: https://api.slack.com/messaging/webhooks#posting_with_webhooks
+    if settings.slack_webhook_url_for_ingester not in [None, ""]:
+        click.echo(f"Posting message to Slack.")
+        response = requests.post(
+            settings.slack_webhook_url_for_ingester,
+            json={"text": "Ingest is done."},
+            headers={"Content-type": "application/json"},
+        )
+        # Note: We currently consider the posting of a Slack message to be a "nice
+        #       to have" as opposed to a "must have." So, if it happens to fail,
+        #       we just echo an error message instead of `raise`-ing an exception.
+        if r.status_code != 200:
+            click.echo(f"Failed to post message to Slack.", err=True)
+
 
 @cli.command()
 @click.option("--print-sql", is_flag=True, default=False)

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -147,7 +147,7 @@ def ingest(verbose, function_limit, skip_annotation, swap_rancher_secrets):
     # Post a message to Slack if a Slack webhook URL is defined.
     # Reference: https://api.slack.com/messaging/webhooks#posting_with_webhooks
     if settings.slack_webhook_url_for_ingester not in [None, ""]:
-        click.echo(f"Posting message to Slack.")
+        click.echo("Posting message to Slack.")
         response = requests.post(
             settings.slack_webhook_url_for_ingester,
             json={"text": "Ingest is done."},
@@ -156,8 +156,8 @@ def ingest(verbose, function_limit, skip_annotation, swap_rancher_secrets):
         # Note: We currently consider the posting of a Slack message to be a "nice
         #       to have" as opposed to a "must have." So, if it happens to fail,
         #       we just echo an error message instead of `raise`-ing an exception.
-        if r.status_code != 200:
-            click.echo(f"Failed to post message to Slack.", err=True)
+        if response.status_code != 200:
+            click.echo("Failed to post message to Slack.", err=True)
 
 
 @cli.command()

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -89,6 +89,10 @@ class Settings(BaseSettings):
     rancher_backend_workload_id: Optional[str] = None
     rancher_worker_workload_id: Optional[str] = None
 
+    # Parameters related to posting messages to Slack.
+    # Reference: https://api.slack.com/messaging/webhooks
+    slack_webhook_url_for_ingester: Optional[str] = None
+
     # CORS settings necessary for allowing request from Field Notes app
     cors_allow_origins: Optional[str] = None  # comma separated list of allowed origins
 


### PR DESCRIPTION
In this branch, I updated the ingest CLI script so that, when it finishes a successful run, **if a Slack incoming webhook URL is defined**, the script uses that URL to post a message to a Slack channel. This technique for posting messages to Slack is documented [here](https://api.slack.com/messaging/webhooks).

Outside of this PR, I have created a Slack app and—for that Slack app—generated an incoming webhook URL. That is what I plan to use on Spin (in all of our environments) once this code gets deployed there. For any reviewers that intend to test this locally, I can also provide that URL to you via Snappass (or Spin). Using that specific URL, the Slack message will be posted to the newly-created `#ingest-notifications` channel in the NMDC Slack workspace.