### PR TITLE
Add `nmdc_edge` as a permissible `source_client` value

### DIFF
--- a/nmdc_server/migrations/versions/4aee1e10bb24_add_nmdc_edge_source_client.py
+++ b/nmdc_server/migrations/versions/4aee1e10bb24_add_nmdc_edge_source_client.py
@@ -1,0 +1,25 @@
+"""Add nmdc_edge as a source_client value
+
+Revision ID: 4aee1e10bb24
+Revises: b22c459110a0
+Create Date: 2024-11-26 19:16:09.105692
+
+"""
+
+from typing import Optional
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4aee1e10bb24"
+down_revision: Optional[str] = "b22c459110a0"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.execute("ALTER TYPE submissionsourceclient ADD VALUE 'nmdc_edge'")
+
+
+def downgrade():
+    op.execute("ALTER TYPE submissionsourceclient DROP VALUE 'nmdc_edge'")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -879,6 +879,7 @@ class SubmissionEditorRole(str, enum.Enum):
 class SubmissionSourceClient(str, enum.Enum):
     submission_portal = "submission_portal"
     field_notes = "field_notes"
+    nmdc_edge = "nmdc_edge"
 
 
 class SubmissionMetadata(Base):

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -46,7 +46,7 @@ interface MetadataSubmissionRecord {
   locked_by: User;
   lock_updated: string;
   permission_level: string | null;
-  source_client: 'submission_portal' | 'field_notes' | null;
+  source_client: 'submission_portal' | 'field_notes' | 'nmdc_edge' | null;
   study_name: string;
   templates: string[];
 }


### PR DESCRIPTION
Fixes #1469 

This addresses a request from NMDC EDGE developers who are working on functionality to create submission records from the EDGE interface (https://github.com/microbiomedata/nmdc-edge/issues/103).