### PR TITLE
Add additional data proxies

### DIFF
--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -15,6 +15,8 @@ from nmdc_server import models
 data_url_hosts = [
     (re.compile("^https://data.microbiomedata.org(/data)?"), "/data"),
     (re.compile("^https://nmdcdemo.emsl.pnnl.gov"), "/nmdcdemo"),
+    (re.compile("^https://portal.nersc.gov"), "/nerscportal"),
+    (re.compile("^https://storage.neonscience.org"), "/neonscience"),
 ]
 
 

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -42,5 +42,13 @@ http {
         location /nmdcdemo/ {
             proxy_pass https://nmdcdemo.emsl.pnnl.gov/;
         }
+
+        location /nerscportal {
+            proxy_pass https://portal.nersc.gov/;
+        }
+
+        location /neonscience {
+            proxy_pass https://storage.neonscience.org/;
+        }
     }
 }


### PR DESCRIPTION
Resolve data object ingest errors where data objects are skipped if their URL is not one of the whitelisted domains for the NMDC data portal.