### PR TITLE
Support Lipidome Results

### DIFF
--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -145,15 +145,17 @@ with m as (select
     bit_or(
         case
             when op.annotations->>'omics_type' = 'Metabolomics' then
-                b'{MultiomicsValue.mb.value:05b}'
+                b'{MultiomicsValue.mb.value:06b}'
             when op.annotations->>'omics_type' = 'Metagenome' then
-                b'{MultiomicsValue.mg.value:05b}'
+                b'{MultiomicsValue.mg.value:06b}'
             when op.annotations->>'omics_type' = 'Proteomics' then
-                b'{MultiomicsValue.mp.value:05b}'
+                b'{MultiomicsValue.mp.value:06b}'
             when op.annotations->>'omics_type' = 'Metatranscriptome' then
-                b'{MultiomicsValue.mt.value:05b}'
+                b'{MultiomicsValue.mt.value:06b}'
             when op.annotations->>'omics_type' = 'Organic Matter Characterization' then
-                b'{MultiomicsValue.om.value:05b}'
+                b'{MultiomicsValue.om.value:06b}'
+            when op.annotations->>'omics_type' = 'Lipidomics' then
+                b'{MultiomicsValue.li.value:06b}'
         end
     )::integer as multiomics
 from biosample b
@@ -169,15 +171,17 @@ with m as (select
     bit_or(
         case
             when op.annotations->>'omics_type' = 'Metabolomics' then
-                b'{MultiomicsValue.mb.value:05b}'
+                b'{MultiomicsValue.mb.value:06b}'
             when op.annotations->>'omics_type' = 'Metagenome' then
-                b'{MultiomicsValue.mg.value:05b}'
+                b'{MultiomicsValue.mg.value:06b}'
             when op.annotations->>'omics_type' = 'Proteomics' then
-                b'{MultiomicsValue.mp.value:05b}'
+                b'{MultiomicsValue.mp.value:06b}'
             when op.annotations->>'omics_type' = 'Metatranscriptome' then
-                b'{MultiomicsValue.mt.value:05b}'
+                b'{MultiomicsValue.mt.value:06b}'
             when op.annotations->>'omics_type' = 'Organic Matter Characterization' then
-                b'{MultiomicsValue.om.value:05b}'
+                b'{MultiomicsValue.om.value:06b}'
+            when op.annotations->>'omics_type' = 'Lipidomics' then
+                b'{MultiomicsValue.li.value:06b}'
         end
     )::integer as multiomics
 from study s

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -30,6 +30,8 @@ omics_types = {
     "metatranscriptome": "Metatranscriptome",
     "organic matter characterization": "Organic Matter Characterization",
     "nom": "Organic Matter Characterization",
+    "lipidome": "Lipidomics",
+    "lipidomics": "Lipidomics",
 }
 
 

--- a/nmdc_server/multiomics.py
+++ b/nmdc_server/multiomics.py
@@ -3,8 +3,9 @@ from enum import Enum
 
 #: Bitmasks for omics types (see database.update_multiomics_sql)
 class MultiomicsValue(Enum):
-    mb = 0b10000
-    mg = 0b01000
-    mp = 0b00100
-    mt = 0b00010
-    om = 0b00001
+    mb = 0b100000
+    mg = 0b010000
+    mp = 0b001000
+    mt = 0b000100
+    om = 0b000010
+    li = 0b000001

--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -39,7 +39,7 @@ export default defineComponent({
     };
     const fontSize = 12;
 
-    const setOrder = ['MG', 'MT', 'MP', 'MB', 'NOM'];
+    const setOrder = ['MG', 'MT', 'MP', 'MB', 'NOM', 'LI'];
     const Samples = 'Samples';
     const Studies = 'Studies';
     const seriesTitles = [Samples, Studies];

--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -39,7 +39,7 @@ export default defineComponent({
     };
     const fontSize = 12;
 
-    const setOrder = ['MG', 'MT', 'MP', 'MB', 'NOM', 'LI'];
+    const setOrder = ['MG', 'MT', 'MP', 'MB', 'NOM', 'LIP'];
     const Samples = 'Samples';
     const Studies = 'Studies';
     const seriesTitles = [Samples, Studies];

--- a/web/src/components/SampleListExpansion.vue
+++ b/web/src/components/SampleListExpansion.vue
@@ -5,10 +5,6 @@ import { fieldDisplayName } from '@/util';
 import { BiosampleSearchResult } from '@/data/api';
 import DataObjectTable from './DataObjectTable.vue';
 
-const hiddenOmicsTypes = [
-  'lipidomics',
-];
-
 const buttonOrder = [
   'metagenome',
   'metatranscriptome',
@@ -44,8 +40,7 @@ export default defineComponent({
     }
 
     const filteredOmicsProcessing = computed(() => Object.entries(groupBy(
-      props.result.omics_processing
-        .filter((p) => hiddenOmicsTypes.indexOf((p.annotations.omics_type as string).toLowerCase()) === -1),
+      props.result.omics_processing,
       (p) => p.annotations.omics_type,
     )).sort(([agroup], [bgroup]) => {
       const ai = buttonOrder.indexOf(agroup.toLowerCase());

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -496,8 +496,6 @@ async function getFacetSummary(
       facet: facetName,
       count: data.facets[facetName],
     }))
-    /* TODO: Take out all these lipidomics hacks */
-    .filter((facetName) => (facetName.facet !== 'Lipidomics'))
     .sort((a, b) => b.count - a.count);
 }
 

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -245,7 +245,7 @@ function makeSetsFromBitmask(mask_str: string) {
     sets.push('MG');
   }
   if (1 & mask) {
-    sets.push('LI');
+    sets.push('LIP');
   }
   return sets;
 }
@@ -649,7 +649,7 @@ const MultiomicsValue = {
   MP: 0b001000,
   MT: 0b000100,
   NOM: 0b000010,
-  LI: 0b000001,
+  LIP: 0b000001,
 };
 
 export {

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -229,20 +229,23 @@ function makeSetsFromBitmask(mask_str: string) {
   const sets = [];
 
   /* eslint-disable no-bitwise */
-  if (1 & mask) {
+  if ((1 << 1) & mask) {
     sets.push('NOM');
   }
-  if ((1 << 4) & mask) {
+  if ((1 << 5) & mask) {
     sets.push('MB');
   }
-  if ((1 << 2) & mask) {
+  if ((1 << 3) & mask) {
     sets.push('MP');
   }
-  if ((1 << 1) & mask) {
+  if ((1 << 2) & mask) {
     sets.push('MT');
   }
-  if ((1 << 3) & mask) {
+  if ((1 << 4) & mask) {
     sets.push('MG');
+  }
+  if (1 & mask) {
+    sets.push('LI');
   }
   return sets;
 }
@@ -641,11 +644,12 @@ function getField(name: string, table?: entityType): FieldsData {
 }
 
 const MultiomicsValue = {
-  MB: 0b10000,
-  MG: 0b01000,
-  MP: 0b00100,
-  MT: 0b00010,
-  NOM: 0b00001,
+  MB: 0b100000,
+  MG: 0b010000,
+  MP: 0b001000,
+  MT: 0b000100,
+  NOM: 0b000010,
+  LI: 0b000001,
 };
 
 export {

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -221,6 +221,8 @@ export default defineComponent({
 
 <style scoped>
 .upset-legend {
+  display: flex;
+  flex-wrap: wrap;
   line-height: 0.9em;
 }
 .upset-legend > span {

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -31,7 +31,7 @@ const staticUpsetTooltips = {
   MB: 'Metabolomics',
   MT: 'Metatranscriptomics',
   NOM: 'Natural Organic Matter',
-  LI: 'Lipidomics',
+  LIP: 'Lipidomics',
 };
 
 export default defineComponent({

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -31,6 +31,7 @@ const staticUpsetTooltips = {
   MB: 'Metabolomics',
   MT: 'Metatranscriptomics',
   NOM: 'Natural Organic Matter',
+  LI: 'Lipidomics',
 };
 
 export default defineComponent({
@@ -210,6 +211,7 @@ export default defineComponent({
             <span>MP: metaproteomics</span>
             <span>MB: metabolomics</span>
             <span>NOM: natural organic matter</span>
+            <span>LI: Lipidomics</span>
           </div>
         </TooltipCard>
       </v-col>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -356,7 +356,7 @@ export default defineComponent({
                             v-for="item in props.result.omics_processing_counts"
                           >
                             <v-chip
-                              v-if="item.count && (item.type.toLowerCase() !== 'lipidomics')"
+                              v-if="item.count"
                               :key="item.type"
                               small
                               class="mr-2 my-1"
@@ -414,7 +414,7 @@ export default defineComponent({
                                   v-for="item in childProps.result.omics_processing_counts"
                                 >
                                   <v-chip
-                                    v-if="item.count && (item.type.toLowerCase() !== 'lipidomics')"
+                                    v-if="item.count"
                                     :key="item.type"
                                     small
                                     class="mr-2 my-1"
@@ -535,7 +535,7 @@ export default defineComponent({
                             v-for="item in props.result.omics_processing_counts"
                           >
                             <v-chip
-                              v-if="item.count && (item.type.toLowerCase() !== 'lipidomics')"
+                              v-if="item.count"
                               :key="item.type"
                               small
                               class="mr-2 my-1"
@@ -593,7 +593,7 @@ export default defineComponent({
                                   v-for="item in childProps.result.omics_processing_counts"
                                 >
                                   <v-chip
-                                    v-if="item.count && (item.type.toLowerCase() !== 'lipidomics')"
+                                    v-if="item.count"
                                     :key="item.type"
                                     small
                                     class="mr-2 my-1"


### PR DESCRIPTION
Fix #1464 

## Changes

### Backend

#### 1. Updates to Ingest
Incoming `data_generation` documents with an `analyte_category` of `"lipidome"` are now ingested correctly, and the associated fields in postgres, including the `multiomics` bitmap are populated with that in mind. (The bitmap used for type now uses 6 bits instead of 5).

### Frontend

#### 1. Lipidomics added to upset plot
Added Lipidomics as a new category and updated the bit manipulation on the frontend to makes sure the "multiomics" facet works with lipidomics.

![image](https://github.com/user-attachments/assets/d8ce4559-7d34-4a2e-b303-eac83bb762c4)


#### 2. Uncommented filters that took out lipidomics data
Previously there were explicit filters in front end code that prevented display of lipidomics data. These have been removed. As a result, lipidomics now appear in the bar chart, the flyout for the Data Generation type facet, and as a drop-down in the biosample result section.

![image](https://github.com/user-attachments/assets/86d68715-dc64-43b8-8153-58c52625ec52)

![image](https://github.com/user-attachments/assets/b6095e2f-836f-41d6-b438-b91e07f14644)

![image](https://github.com/user-attachments/assets/50f86e89-d3b1-4e48-87ac-2458753fa133)
