### PR TITLE
Synchronize portal's navigation menu with upstream website's navigation menu

### DIFF
--- a/web/src/menus.ts
+++ b/web/src/menus.ts
@@ -23,10 +23,6 @@ const Menus = [
         href: 'https://microbiomedata.org/faqs/',
       },
       {
-        label: 'Diversity, Equity, and Inclusion',
-        href: 'https://microbiomedata.org/idea-action-plan/',
-      },
-      {
         label: 'Data Use Policy',
         href: 'https://microbiomedata.org/nmdc-data-use-policy/',
       },


### PR DESCRIPTION
In this branch, I removed an item from the navigation menu so that the menu would match that of the upstream website.