### PR TITLE
Allow creating a submission with string or list of strings for `packageName`

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1178,6 +1178,14 @@ async def submit_metadata(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
+    # Old versions of the Field Notes app will continue to send a string for packageName
+    # for a little white. This code is to ease that transition and can be removed in the future.
+    if isinstance(body.metadata_submission.packageName, str):
+        if body.metadata_submission.packageName:
+            body.metadata_submission.packageName = [body.metadata_submission.packageName]
+        else:
+            body.metadata_submission.packageName = []
+
     submission = SubmissionMetadata(
         **body.dict(),
         author_orcid=user.orcid,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1179,7 +1179,7 @@ async def submit_metadata(
     user: models.User = Depends(get_current_user),
 ):
     # Old versions of the Field Notes app will continue to send a string for packageName
-    # for a little white. This code is to ease that transition and can be removed in the future.
+    # for a little while. This code is to ease that transition and can be removed in the future.
     if isinstance(body.metadata_submission.packageName, str):
         if body.metadata_submission.packageName:
             body.metadata_submission.packageName = [body.metadata_submission.packageName]

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
@@ -74,14 +74,18 @@ class ContextForm(BaseModel):
     unknownDoi: Optional[bool] = None
 
 
-class MetadataSubmissionRecord(BaseModel):
-    packageName: List[str]
+class MetadataSubmissionRecordCreate(BaseModel):
+    packageName: Union[str, List[str]]
     contextForm: ContextForm
     addressForm: AddressForm
     templates: List[str]
     studyForm: StudyForm
     multiOmicsForm: MultiOmicsForm
     sampleData: Dict[str, List[Any]]
+
+
+class MetadataSubmissionRecord(MetadataSubmissionRecordCreate):
+    packageName: List[str]
 
 
 class PartialMetadataSubmissionRecord(BaseModel):
@@ -95,7 +99,7 @@ class PartialMetadataSubmissionRecord(BaseModel):
 
 
 class SubmissionMetadataSchemaCreate(BaseModel):
-    metadata_submission: MetadataSubmissionRecord
+    metadata_submission: MetadataSubmissionRecordCreate
     status: Optional[str] = None
     source_client: Optional[str] = None
 


### PR DESCRIPTION
This is a bit of follow on work to the changes for #1367.

These changes allow a client to create a new submission using _either_ a list of strings or single string for the `packageName` field. The reason for this comes down to the fact that the release cycle for the Field Notes app is decoupled from the `nmdc-server` release cycle (by necessity, due to app store review delays). 

The app already knows how to deal with `packageName` values _coming from_ the server that are either string _or_ lists of strings. But when creating a new submission, the app doesn't know _a priori_ whether the server will accept a single string or an array of strings for the `packageName`. We will release an update to the app to make it send an array of strings by default, but it will take a little bit of time to get that change into user devices. In the meantime the app will continue sending a single string `packageName` for new submissions, and these backend changes will help ease that transition period.

P.S. In the future I'd like to use the information from the `/api/version` endpoint to make decisions in the app about which features the server supports. Hopefully that will mean fewer backend changes like this in the future. But it'll take a bit of architectural work in the app to do that, and that sadly isn't the top priority at the moment. 