### PR TITLE
Guard against null `funding_sources`

### DIFF
--- a/web/src/components/TeamInfo.vue
+++ b/web/src/components/TeamInfo.vue
@@ -127,11 +127,13 @@ export default defineComponent({
               </v-card>
             </v-menu>
           </div>
-          <div class="text-h5 py-2 primary--text">
-            Funding Sources
-          </div>
-          <div>
-            {{ item.funding_sources.flat().toString() }}
+          <div v-if="item.funding_sources">
+            <div class="text-h5 py-2 primary--text">
+              Funding Sources
+            </div>
+            <div>
+              {{ item.funding_sources.flat().toString() }}
+            </div>
           </div>
         </v-card>
       </v-row>

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -180,7 +180,7 @@ export interface StudySearchResults extends BaseSearchResult {
   add_date: string;
   mod_date: string;
   open_in_gold: string;
-  funding_sources: string[];
+  funding_sources?: string[];
   relevant_protocols: string[];
   gold_study_identifiers: string[];
   sample_count: number;

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -95,7 +95,7 @@ export default defineComponent({
 
     const goldLinks = computed(() => {
       if (!item.value?.gold_study_identifiers && !item.value?.open_in_gold) {
-        return [];
+        return new Set();
       }
       const links = new Set();
       if (item.value.open_in_gold) {
@@ -279,7 +279,7 @@ export default defineComponent({
             </v-list>
             <template
               v-if="
-                goldLinks.keys.length > 0 ||
+                goldLinks.size > 0 ||
                   item.relevant_protocols||
                   item.principal_investigator_websites.length > 0"
             >
@@ -287,7 +287,7 @@ export default defineComponent({
                 Additional Resources
               </div>
               <v-list
-                v-if="goldLinks || item.relevant_protocols.length > 0"
+                v-if="goldLinks.size > 0 || item.relevant_protocols.length > 0"
               >
                 <v-list-item v-if="item.relevant_protocols">
                   <v-list-item-avatar>

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -309,7 +309,7 @@ export default defineComponent({
                     field: 'relevant_protocols' }
                   "
                 />
-                <v-list-item v-if="item.principal_investigator_websites.length > 0">
+                <v-list-item v-if="goldLinks.size > 0 || item.principal_investigator_websites.length > 0">
                   <v-list-item-avatar>
                     <v-icon>mdi-file-document</v-icon>
                   </v-list-item-avatar>


### PR DESCRIPTION
Fix #1493 

## Hotfix
This issue and PR will likely be associated with a hotfix in order to fix the issue straightaway on production. Upon approval of this PR I intend to follow the standard procedure and create a tag from the HEAD of this branch to use as the hotfix version.

@aclum does a hotfix sound like the right thing to do for this issue?

### Changes
Straightforward and simple guardrail added to handle `null` values for a study's `funding_sources`.

### Testing
Obtain a copy of the most recent data. With your local docker stack up, running

```bash
docker compose run backend nmdc-server load-db -u <nersc-username>
```

will prompt you for your password + MFA key (or you can create/use an ssh key, read the help for that command for some additional details). Once authentication succeeds you will get a copy of the most recent dump.

The study ID we are interested in is `nmdc:sty-11-fkbnah04`. Visit the [study detail page](http://127.0.0.1:8081/details/study/nmdc:sty-11-fkbnah04) for that study and verify you see the PI name, image, and ORCID iD.