### PR TITLE
Fix metap ingest

### DIFF
--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -34,7 +34,7 @@ class WorkflowActivityTypeEnum(Enum):
     metabolomics_analysis = "nmdc:MetabolomicsAnalysis"
     metagenome_assembly = "nmdc:MetagenomeAssembly"
     metagenome_annotation = "nmdc:MetagenomeAnnotation"
-    metaproteomic_analysis = "nmdc:MetaproteomicAnalysis"
+    metaproteomic_analysis = "nmdc:MetaproteomicsAnalysis"
     metatranscriptome = "nmdc:MetatranscriptomeAnalysis"
     metatranscriptome_assembly = "nmdc:MetatranscriptomeAssembly"
     metatranscriptome_annotation = "nmdc:MetatranscriptomeAnnotation"

--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -220,7 +220,7 @@ def load(db: Session, function_limit=None, skip_annotation=False):
         pipeline.load(
             db,
             mongodb[workflow_set].find(
-                {"type": "nmdc:MetaproteomicsAnalysis"},
+                {"type": WorkflowActivityTypeEnum.metaproteomic_analysis.value},
                 no_cursor_timeout=True,
             ),
             pipeline.load_mp_analysis,

--- a/nmdc_server/ingest/pipeline.py
+++ b/nmdc_server/ingest/pipeline.py
@@ -92,7 +92,6 @@ def load_mp_analysis(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObjectRe
             "gene_function_id": {
                 "$regex": gene_regex,
             },
-            "best_protein": True,
         },
         no_cursor_timeout=True,
         projection={
@@ -100,7 +99,6 @@ def load_mp_analysis(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObjectRe
             "was_generated_by": True,
             "count": True,
             "gene_function_id": True,
-            "best_protein": True,
         },
     )
     if kwargs.get("function_limit"):
@@ -116,7 +114,7 @@ def load_mp_analysis(db: Session, obj: Dict[str, Any], **kwargs) -> LoadObjectRe
                 metaproteomic_analysis_id=pipeline.id,
                 gene_function_id=function_id,
                 count=annotation["count"],
-                best_protein=annotation["best_protein"],
+                best_protein=True,
             )
         )
     if metap_gene_function_aggregations:

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -384,7 +384,13 @@ class BaseQuerySchema(BaseModel):
 
             # Gene function queries are treated differently because they join
             # in three different places (metaT, metaG and metaP).
-            if table == Table.gene_function:
+            if table in [
+                Table.gene_function,
+                Table.kegg_function,
+                Table.go_function,
+                Table.pfam_function,
+                Table.cog_function,
+            ]:
                 metag_matches = filter.matches(db, self.table)
                 metap_conditions = [
                     SimpleConditionSchema(


### PR DESCRIPTION
Fix #1496 
Closes #1468 

Special logic for gene function search wasn't being applied in all cases. Additionally, there were issues with ingesting MetaP gene function annotations that are resolved here, including a slight change to the data model on the mongo side. Further work should be done to remove the `best_protein` column from our database.

Since the initial change is intended to be a hotfix, I am leaving out any data model changes to keep scope and complexity at a minimum. That progress will be tracked in #1484 