### PR TITLE
Use same object for tooltips and legend

### DIFF
--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -206,12 +206,12 @@ export default defineComponent({
             </template>
           </ChartContainer>
           <div class="mx-5 upset-legend">
-            <span>MG: metagenomics</span>
-            <span>MT: metatranscriptomics</span>
-            <span>MP: metaproteomics</span>
-            <span>MB: metabolomics</span>
-            <span>NOM: natural organic matter</span>
-            <span>LI: Lipidomics</span>
+            <span
+              v-for="value, key in staticUpsetTooltips"
+              :key="key"
+            >
+              {{ key }}: {{ value }}
+            </span>
           </div>
         </TooltipCard>
       </v-col>


### PR DESCRIPTION
Fix #1501 

### Changes

Previously, the legend for the upset plot used hard-coded string values to map abbreviations to data type. There is already an object being used as a dictionary to map abbreviations to data type. This PR removes the hard-coded `<span>`s in favor of using the existing object.

It also fixes the issue where the label on the upset plot for lipidomics didn't match the key in the legend.