### PR TITLE
Centralize generating static content

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -14,6 +14,7 @@ from nmdc_server import jobs
 from nmdc_server.config import Settings
 from nmdc_server.database import SessionLocalIngest
 from nmdc_server.ingest import errors
+from nmdc_server.static_files import generate_submission_schema_files, initialize_static_directory
 
 
 def send_slack_message(text: str) -> bool:
@@ -339,6 +340,16 @@ def load_db(key_file, user, host, list_backups, backup_file):
         sys.exit(1)
 
     click.secho(f"\nSuccessfully loaded {settings.current_db_uri}", fg="green")
+
+
+@cli.command()
+@click.option("--remove-existing", is_flag=True, default=False)
+def generate_static_files(remove_existing):
+    click.echo("Generating static files...")
+    static_path = initialize_static_directory(remove_existing=remove_existing)
+    click.echo("Generating submission schema files...")
+    generate_submission_schema_files(directory=static_path)
+    click.echo("Done generating static files.")
 
 
 if __name__ == "__main__":

--- a/nmdc_server/static_files.py
+++ b/nmdc_server/static_files.py
@@ -5,12 +5,20 @@ from pathlib import Path
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import json_dumper
 
+static_path = Path("static")
+
 
 def initialize_static_directory(*, remove_existing=False) -> Path:
-    static_path = Path("static")
     if remove_existing:
+        # Delete existing contents of the static directory,
+        # but keep the directory itself, since it may already
+        # be mounted by the FastAPI app.
         try:
-            shutil.rmtree(static_path)
+            for child in static_path.iterdir():
+                if child.is_dir():
+                    shutil.rmtree(child)
+                else:
+                    child.unlink()
         except FileNotFoundError:
             pass
     static_path.mkdir(parents=True, exist_ok=True)

--- a/start.sh
+++ b/start.sh
@@ -18,5 +18,8 @@ PGDATABASE=postgres psql -c "create database nmdc_b;" || true
 # Apply pending alembic migrations
 nmdc-server migrate
 
+# Generate static content
+nmdc-server generate-static-files --remove-existing
+
 ## Start the server
 uvicorn nmdc_server.asgi:app --host 0.0.0.0 --port 8000

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,9 @@ setenv =
   SQLALCHEMY_SILENCE_UBER_WARNING=1
 passenv =
   NMDC_TESTING_DATABASE_URI
-commands = pytest {posargs} tests/
+commands =
+    nmdc-server generate-static-files --remove-existing
+    pytest {posargs} tests/
 
 [testenv:ingest]
 setenv =


### PR DESCRIPTION
Fix #1486 

Only generate once before the app starts up, and mount normally as part of application startup. This change prevents multiple workers from all trying to generate the same static directory. 