### PR TITLE
1281 update shipping info

### DIFF
--- a/nmdc_server/fakes.py
+++ b/nmdc_server/fakes.py
@@ -380,6 +380,7 @@ class MetadataSubmissionFactory(SQLAlchemyModelFactory):
                 "city": "",
                 "state": "",
                 "postalCode": "",
+                "country": "",
             },
             "shippingConditions": "",
             "sample": "",

--- a/nmdc_server/migrations/versions/18127fd43a8b_add_country_to_shipper_info.py
+++ b/nmdc_server/migrations/versions/18127fd43a8b_add_country_to_shipper_info.py
@@ -1,7 +1,7 @@
 """add-country-to-shipper-info
 
 Revision ID: 18127fd43a8b
-Revises: afa1ff687968
+Revises: 4b2d6ee63752
 Create Date: 2025-01-24 15:53:45.897421
 
 """
@@ -21,7 +21,7 @@ Base = declarative_base()
 
 # revision identifiers, used by Alembic.
 revision: str = "18127fd43a8b"
-down_revision: Optional[str] = "afa1ff687968"
+down_revision: Optional[str] = "4b2d6ee63752"
 branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 

--- a/nmdc_server/migrations/versions/18127fd43a8b_add_country_to_shipper_info.py
+++ b/nmdc_server/migrations/versions/18127fd43a8b_add_country_to_shipper_info.py
@@ -1,0 +1,116 @@
+"""add-country-to-shipper-info
+
+Revision ID: 18127fd43a8b
+Revises: afa1ff687968
+Create Date: 2025-01-24 15:53:45.897421
+
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import uuid4
+
+from alembic import op
+from pydantic import BaseModel
+from sqlalchemy import Column, orm
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+# revision identifiers, used by Alembic.
+revision: str = "18127fd43a8b"
+down_revision: Optional[str] = "afa1ff687968"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+# Redefine SubmissionMetadata, including only what we need for this migration
+# to ensure this migration is self-contained.
+# https://stackoverflow.com/questions/17547119/accessing-models-in-alembic-migrations
+class SubmissionMetadata(Base):
+    __tablename__ = "submission_metadata"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    metadata_submission = Column(JSONB, nullable=False)
+
+
+# Similarly, redefine pydantic models for context_ and address_form
+class NmcdAddress(BaseModel):
+    name: str = ""
+    email: str = ""
+    phone: str = ""
+    line1: str = ""
+    line2: str = ""
+    city: str = ""
+    state: str = ""
+    postalCode: str = ""
+    country: str = ""
+
+
+class AddressForm(BaseModel):
+    shipper: NmcdAddress = NmcdAddress()
+    expectedShippingDate: Optional[datetime] = None
+    shippingConditions: str = ""
+    sample: str = ""
+    description: str = ""
+    experimentalGoals: str = ""
+    randomization: str = ""
+    usdaRegulated: Optional[bool] = None
+    permitNumber: str = ""
+    biosafetyLevel: str = ""
+    irpOrHipaa: Optional[bool] = None
+    irbNumber: str = ""
+    irbAddress: NmcdAddress = NmcdAddress()
+    comments: str = ""
+
+
+class ContextForm(BaseModel):
+    datasetDoi: str = ""
+    dataGenerated: Optional[bool] = None
+    facilityGenerated: Optional[bool] = None
+    facilities: List[str] = []
+    award: Optional[str] = None
+    otherAward: str = ""
+
+
+def upgrade():
+    session = orm.Session(bind=op.get_bind())
+    mappings = []
+    for submission_metadata in session.query(SubmissionMetadata):
+        metadata_submission = submission_metadata.metadata_submission
+        if isinstance(metadata_submission, List):
+            continue
+
+        if not metadata_submission.get("contextForm", None):
+            context_form = ContextForm().dict()
+            context_form["datasetDoi"] = metadata_submission.get("multiOmicsForm", {}).get(
+                "datasetDoi", ""
+            )
+            metadata_submission["contextForm"] = context_form
+        if not metadata_submission.get("addressForm"):
+            metadata_submission["addressForm"] = AddressForm().dict()
+
+        if metadata_submission.get("addressForm"):
+            address_form = metadata_submission["addressForm"]
+            if not address_form.get("shipper", {}).get("country"):
+                address_form["shipper"]["country"] = "USA"
+        mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
+    session.bulk_update_mappings(SubmissionMetadata, mappings)
+    session.commit()
+
+
+def downgrade():
+    session = orm.Session(bind=op.get_bind())
+    mappings = []
+    for submission_metadata in session.query(SubmissionMetadata):
+        metadata_submission = submission_metadata.metadata_submission
+        if isinstance(metadata_submission, List):
+            continue
+        if metadata_submission.get("addressForm"):
+            address_form = metadata_submission["addressForm"]
+            if address_form.get("shipper", {}).get("country") == "USA":
+                del address_form["shipper"]["country"]
+        mappings.append({"id": submission_metadata.id, "metadata_submission": metadata_submission})
+    session.bulk_update_mappings(SubmissionMetadata, mappings)
+    session.commit()

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -47,6 +47,7 @@ class NmcdAddress(BaseModel):
     city: str
     state: str
     postalCode: str
+    country: str
 
 
 class AddressForm(BaseModel):

--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -73,6 +73,7 @@ class ContextForm(BaseModel):
     award: Optional[str] = None
     otherAward: str
     unknownDoi: Optional[bool] = None
+    ship: Optional[bool] = None
 
 
 class MetadataSubmissionRecordCreate(BaseModel):

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextForm.vue
@@ -177,8 +177,24 @@ export default defineComponent({
           hide-details
           @change="facilityChange"
         />
-        <submission-context-shipping-form
+        <v-radio-group
           v-if="contextForm.dataGenerated === false && contextForm.facilities.includes('EMSL')"
+          v-model="contextForm.ship"
+          label="Will samples be shipped? *"
+          :rules="[v => (v === true || v === false) || 'This field is required']"
+          @change="revalidate"
+        >
+          <v-radio
+            label="No"
+            :value="false"
+          />
+          <v-radio
+            label="Yes"
+            :value="true"
+          />
+        </v-radio-group>
+        <submission-context-shipping-form
+          v-if="contextForm.dataGenerated === false && contextForm.ship"
         />
         <v-radio-group
           v-if="contextForm.dataGenerated === false && contextForm.facilities.length > 0"
@@ -338,7 +354,7 @@ export default defineComponent({
         color="gray"
         depressed
         :to="{ name: 'Study Form' }"
-        :disabled="!contextFormValid || (contextForm.facilities.includes('EMSL') && !addressFormValid)"
+        :disabled="!contextFormValid || ((contextForm.facilities.includes('EMSL') && contextForm.ship) && !addressFormValid)"
       >
         Go to next step
         <v-icon class="pl-1">

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -157,18 +157,15 @@ export default defineComponent({
             <!-- Shipper Name, E-mail address, etc. -->
             <v-text-field
               v-model="addressForm.shipper.name"
-              :rules="requiredRules('Name is required', [])"
-              label="Shipper Name *"
+              label="Shipper Name"
               outlined
               dense
               class="mt-2"
             />
             <v-text-field
               v-model="addressForm.shipper.email"
-              :rules="requiredRules('E-mail is required', [
-                v => /.+@.+\..+/.test(v) || 'E-mail must be valid',
-              ])"
-              label="E-mail Address *"
+              :rules="[v => !v || /.+@.+\..+/.test(v) || 'E-mail must be valid']"
+              label="E-mail Address"
               outlined
               dense
             />
@@ -180,8 +177,7 @@ export default defineComponent({
             />
             <v-text-field
               v-model="addressForm.shipper.line1"
-              :rules="requiredRules('Address Line 1 is required', [])"
-              label="Address Line 1 *"
+              label="Address Line 1"
               outlined
               dense
             />
@@ -193,33 +189,37 @@ export default defineComponent({
             />
             <v-text-field
               v-model="addressForm.shipper.city"
-              :rules="requiredRules('City is required', [])"
-              label="City *"
+              label="City"
               outlined
               dense
             />
             <div class="d-flex">
               <v-text-field
                 v-model="addressForm.shipper.state"
-                :rules="requiredRules('State is required', [])"
-                label="State *"
+                label="State"
                 outlined
                 dense
                 class="mr-4"
               />
               <v-text-field
                 v-model="addressForm.shipper.postalCode"
-                :rules="requiredRules('Zip code is required', [])"
-                label="Zip Code *"
+                label="Zip Code"
+                outlined
+                dense
+                class="mr-4"
+              />
+              <v-text-field
+                v-model="addressForm.shipper.country"
+                :rules="requiredRules('Country is required', [])"
+                label="Country *"
                 outlined
                 dense
               />
             </div>
             <v-combobox
               v-model="addressForm.shippingConditions"
-              label="Shipping Conditions *"
+              label="Shipping Conditions"
               :items="shippingConditionsItems"
-              :rules="requiredRules('Shipping conditions are required', [])"
               outlined
               dense
             />
@@ -234,8 +234,7 @@ export default defineComponent({
               <template #activator="{ on, attrs }">
                 <v-text-field
                   v-model="expectedShippingDateString"
-                  :rules="requiredRules('Expected Shipping Date is required', [])"
-                  label="Expected Shipping Date *"
+                  label="Expected Shipping Date"
                   prepend-icon="mdi-calendar"
                   clearable
                   readonly
@@ -259,7 +258,6 @@ export default defineComponent({
             <v-divider />
             <v-select
               v-model="addressForm.sample"
-              :rules="requiredRules('Sample Type/Species is required', [])"
               class="mt-2"
               :items="sampleEnumValues"
               label="Sample Type/Species"
@@ -277,7 +275,6 @@ export default defineComponent({
             <v-textarea
               v-model="addressForm.experimentalGoals"
               label="Experiment Goals"
-              :rules="requiredRules('Experiment Goals are required', [])"
               hint="Briefly describe the goal for your experiment"
               outlined
               dense
@@ -309,10 +306,9 @@ export default defineComponent({
             <div class="d-flex">
               <v-select
                 v-model="addressForm.biosafetyLevel"
-                :rules="requiredRules('Biosafety level is required', [])"
                 class="mr-4"
                 :items="biosafetyLevelValues"
-                label="Biosafety Level *"
+                label="Biosafety Level"
                 dense
                 outlined
               />

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingForm.vue
@@ -109,7 +109,7 @@ export default defineComponent({
         v-if="!addressFormValid"
         class="error--text"
       >
-        Shipping information is required
+        Sender's shipping information is required
       </p>
       <submission-context-shipping-summary
         class="mt-6"
@@ -133,13 +133,28 @@ export default defineComponent({
           v-bind="attrs"
           v-on="on"
         >
-          Enter shipping info
+          Enter sender info
         </v-btn>
       </template>
       <v-card>
         <v-card-title>
           <v-spacer />
           <span class="text-h5">Shipping Information</span>
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <v-btn
+                icon
+                color="primary"
+                v-bind="attrs"
+                v-on="on"
+              >
+                <v-icon>
+                  mdi-information
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Provide the address that the samples are being shipped from. </span>
+          </v-tooltip>
           <v-spacer />
         </v-card-title>
         <v-card-text>
@@ -151,13 +166,13 @@ export default defineComponent({
             :disabled="!canEditSubmissionMetadata()"
           >
             <v-subheader>
-              <span class="text-h6">Shipper</span>
+              <span class="text-h6">Sender</span>
             </v-subheader>
             <v-divider />
             <!-- Shipper Name, E-mail address, etc. -->
             <v-text-field
               v-model="addressForm.shipper.name"
-              label="Shipper Name"
+              label="Sender Name"
               outlined
               dense
               class="mt-2"

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingSummary.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingSummary.vue
@@ -13,6 +13,7 @@ export default defineComponent({
         addressForm.shipper.city,
         addressForm.shipper.state,
         addressForm.shipper.postalCode,
+        addressForm.shipper.country,
       ];
       const existingShipperData = shipperData.filter((shipperDatum) => !!shipperDatum.trim());
       return existingShipperData.join(', ');

--- a/web/src/views/SubmissionPortal/Components/SubmissionContextShippingSummary.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionContextShippingSummary.vue
@@ -92,7 +92,7 @@ export default defineComponent({
           </v-icon>
         </template>
         <div class="header">
-          <span class="mr-2">Shipper</span>
+          <span class="mr-2">Sender</span>
           <span class="expansion-panel-preview">{{ shipperAddressOneLiner }}</span>
         </div>
       </v-expansion-panel-header>

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -11,6 +11,7 @@ interface NmdcAddress {
   city: string;
   state: string;
   postalCode: string;
+  country: string;
 }
 
 function addressToString(address: NmdcAddress): string {

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -4,9 +4,9 @@ import CompositionApi, {
 } from '@vue/composition-api';
 import { clone, forEach } from 'lodash';
 import axios from 'axios';
+import { User } from '@/data/api';
 import * as api from './api';
 import { getVariants, HARMONIZER_TEMPLATES } from '../harmonizerApi';
-import { User } from '@/data/api';
 
 // TODO: Remove in version 3;
 Vue.use(CompositionApi);
@@ -94,6 +94,7 @@ const addressFormDefault = {
     city: '',
     state: '',
     postalCode: '',
+    country: '',
   } as api.NmdcAddress,
   expectedShippingDate: undefined as undefined | Date,
   shippingConditions: '',
@@ -111,6 +112,7 @@ const addressFormDefault = {
 const contextFormDefault = {
   dataGenerated: undefined as undefined | boolean,
   awardDois: [] as string[] | null,
+  ship: undefined as undefined | boolean,
   facilityGenerated: undefined as undefined | boolean,
   facilities: [] as string[],
   award: undefined as undefined | string,


### PR DESCRIPTION
Closes #1281 
Included in this PR

- An additional user input regarding if the samples will be shipped (EMSL)
- Adds the 'country' field to the shipping info
- Makes _only_ the country field required
- Adds a tooltip explaining that the sender's info is needed and updates help text