### PR TITLE
Use environment variables to populate Data Portal banner

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -39,6 +39,7 @@ async def get_settings() -> Dict[str, Any]:
     return {
         "disable_bulk_download": settings.disable_bulk_download.upper() == "YES",
         "portal_banner_message": settings.portal_banner_message,
+        "portal_banner_title": settings.portal_banner_title,
     }
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -36,7 +36,10 @@ router = APIRouter()
 @router.get("/settings", name="Get application settings")
 async def get_settings() -> Dict[str, Any]:
     settings = Settings()
-    return {"disable_bulk_download": settings.disable_bulk_download.upper() == "YES"}
+    return {
+        "disable_bulk_download": settings.disable_bulk_download.upper() == "YES",
+        "portal_banner_message": settings.portal_banner_message,
+    }
 
 
 # get application version number

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -80,6 +80,7 @@ class Settings(BaseSettings):
 
     # App settings related to UI behavior
     disable_bulk_download: str = ""
+    portal_banner_title: Optional[str] = None
     portal_banner_message: Optional[str] = None
 
     # Rancher information to swap databases after ingest

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -80,6 +80,7 @@ class Settings(BaseSettings):
 
     # App settings related to UI behavior
     disable_bulk_download: str = ""
+    portal_banner_message: Optional[str] = None
 
     # Rancher information to swap databases after ingest
     rancher_api_base_url: Optional[str] = None

--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -1,10 +1,13 @@
 <script lang="ts">
-import { defineComponent, ref } from '@vue/composition-api';
+import { computed, defineComponent } from '@vue/composition-api';
+import { stateRefs } from '@/store';
 
 export default defineComponent({
   setup() {
-    const showAppBanner = ref(false);
-    return { showAppBanner };
+    const message = stateRefs.bannerMessage;
+    const title = stateRefs.bannerTitle;
+    const showAppBanner = computed(() => message.value || title.value);
+    return { showAppBanner, message, title };
   },
 });
 </script>
@@ -20,10 +23,10 @@ export default defineComponent({
     <p
       class="title"
     >
-      Banner title (replace me)
+      {{ title || '' }}
     </p>
     <p>
-      Banner content (replace me)
+      {{ message || '' }}
     </p>
   </v-banner>
 </template>

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -695,8 +695,14 @@ async function updateUser(id: string, body: User) {
   return data;
 }
 
-async function getAppSettings() {
-  const { data } = await client.get<Record<string, boolean>>('settings');
+interface PortalSettings {
+  portal_banner_title: string | null;
+  portal_banner_message: string | null;
+  disable_bulk_download: boolean;
+}
+
+async function getAppSettings(): Promise<PortalSettings> {
+  const { data } = await client.get<PortalSettings>('settings');
   return data;
 }
 

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -21,6 +21,8 @@ const state = reactive({
   user: null as User | null,
   hasAcceptedTerms: false,
   treeData: null as EnvoTree | null,
+  bannerTitle: null as string | null,
+  bannerMessage: null as string | null,
 });
 const unreactive = {
   nodeMapId: {} as Record<string, EnvoNode>,
@@ -108,6 +110,13 @@ async function init(_router: VueRouter, loadUser = true, loginState = '' as stri
     } finally {
       state.userLoading = false;
     }
+  }
+  try {
+    const appSettings = await api.getAppSettings();
+    state.bannerTitle = appSettings.portal_banner_title;
+    state.bannerMessage = appSettings.portal_banner_message;
+  } catch (exception) {
+    console.error(exception);
   }
   router = _router;
   // Handle the login state

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -116,6 +116,7 @@ async function init(_router: VueRouter, loadUser = true, loginState = '' as stri
     state.bannerTitle = appSettings.portal_banner_title;
     state.bannerMessage = appSettings.portal_banner_message;
   } catch (exception) {
+    // eslint-disable-next-line no-console
     console.error(exception);
   }
   router = _router;


### PR DESCRIPTION
Fix #1439 

### Changes

#### Backend

The application settings, as defined in `config.py` contain two new variables:

- `portal_banner_title`: an optional string that determines the title of the banner that appears on the data portal when the team needs to communicate to users
- `portal_banner_message`: an optional string that holds the content of the banner

These two settings default to `None` and have been added to the `/settings` endpoint so they can be retrieved by the client.

#### Frontend
Two new `ref`s have been added to the store to track the app banner title and message.

In the `init` function (defined in `src/store/index.ts`), a request is made to the `/settings` endpoint. The response from this endpoint is used to populate the new refs. This function is called when the Vue App is mounted, and during the login flow.

The `AppBanner.vue` component uses these new `ref`s to determine both the visibility of the banner (based on truthiness of either the banner title OR banner message), and the content.

### Testing
You'll need to set a couple of environment variables in the environment where you run the FastAPI app. If using the stock `docker-compose.yml` file, add the following to your `.env`:

```
NMDC_PORTAL_BANNER_MESSAGE="Take a look at banner, Michael"
NMDC_PORTAL_BANNER_TITLE="Family love Michael"
```

Then, start your development server with `docker compose up`.

You can test the endpoint via the swagger docs at [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs), or use CURL:

```
curl -X GET http://127.0.0.1:8000/api/settings
```

You can check out the new front end behavior by starting up the vue development server and visiting [http://127.0.0.1:8081](http://127.0.0.1:8081).