### PR TITLE
Display UI banner about upcoming downtime event (January 26-February 3)

### DIFF
--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -20,20 +20,19 @@ export default defineComponent({
     <p
       class="title"
     >
-      Upcoming maintenance (January 26-February 3)
+      Upcoming maintenance (January 26 - February 3)
     </p>
     <p>
-      From Sunday, January 26 to Sunday, February 2, our data storage system will be
-      undergoing scheduled maintenance. During that time, the downloading of data files
-      will be disabled.
+      Sunday, 01/26/2025 - Sunday, 02/02/2025: Storage system will be undergoing
+      scheduled maintenance. Downloading of data files will be disabled.
     </p>
     <p>
-      Then, on Monday, February 3, the NMDC Data Portal and NMDC Submission Portal will be
-      undergoing software updates. During that time, both portals will be offline.
+      Monday, 02/03/2025 (until 5pm PST): NMDC Data Portal, Submission Portal, and
+      API will be offline for software updates.
     </p>
     <p>
-      Both portals will be back online and fully functional by Monday, February 3,
-      at 5:00 p.m. Pacific time.
+      We expect our systems to be back online and fully functional by Monday,
+      02/03/2025 at 5pm PST.
     </p>
   </v-banner>
 </template>

--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -27,8 +27,8 @@ export default defineComponent({
       scheduled maintenance. Downloading of data files will be disabled.
     </p>
     <p>
-      Monday, 02/03/2025 (until 5pm PST): NMDC Data Portal, Submission Portal, and
-      API will be offline for software updates.
+      Monday, 02/03/2025 (until 5pm PST): The NMDC API will be offline for
+      software updates.
     </p>
     <p>
       We expect our systems to be back online and fully functional by Monday,

--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -3,7 +3,7 @@ import { defineComponent, ref } from '@vue/composition-api';
 
 export default defineComponent({
   setup() {
-    const showAppBanner = ref(false);
+    const showAppBanner = ref(true);
     return { showAppBanner };
   },
 });
@@ -20,10 +20,20 @@ export default defineComponent({
     <p
       class="title"
     >
-      Banner title (replace me)
+      Upcoming maintenance (January 26-February 3)
     </p>
     <p>
-      Banner content (replace me)
+      From Sunday, January 26 to Sunday, February 2, our data storage system will be
+      undergoing scheduled maintenance. During that time, the downloading of data files
+      will be disabled.
+    </p>
+    <p>
+      Then, on Monday, February 3, the NMDC Data Portal and NMDC Submission Portal will be
+      undergoing software updates. During that time, both portals will be offline.
+    </p>
+    <p>
+      Both portals will be back online and fully functional by Monday, February 3,
+      at 5:00 p.m. Pacific time.
     </p>
   </v-banner>
 </template>


### PR DESCRIPTION
I am creating this PR because that is what the final step of the [hotfix instructions](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-server.md#developing-and-releasing-a-hotfix) says to do and I don't want to deviate from those instructions right now. I do not want this PR branch to be merged into `main`, since `main` already contains a new and improved version of the banner functionality. I plan to close this PR immediately after opening it.

CC: @naglepuff, @pkalita-lbl 