### PR TITLE
Display LC/MS Configurations for Lipidomics and Metabolomics

### DIFF
--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -175,7 +175,7 @@ def load_omics_processing(db: Session, obj: Dict[str, Any], mongodb: Database, l
 
 def load(db: Session, cursor: Cursor, mongodb: Database):
     logger = get_logger(__name__)
-    config_map = {}
+    config_map: dict[str, dict[str, Any]] = {}
     for obj in cursor:
         try:
             load_omics_processing(db, obj, mongodb, logger, config_map)

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -95,7 +95,6 @@ export default defineComponent({
       return omicsProcessing.omics_data.map((omics) => {
         const omicsCopy = { ...omics };
         omicsCopy.inputIds = biosampleInputIds;
-        omicsCopy.omicsProcessingName = omicsProcessing.name;
         if (annotations.mass_spectrometry_configuration_id) {
           omicsCopy.massSpecConfigId = annotations.mass_spectrometry_configuration_id || '';
           omicsCopy.massSpecConfigName = annotations.mass_spectrometry_configuration_name || '';
@@ -197,17 +196,22 @@ export default defineComponent({
         >
           <td colspan="6">
             <b>Workflow Activity:</b> {{ item.group_name }}
-            <span v-if="omicsType === 'Metabolomics' || omicsType === 'Lipidomics'">
+            <span
+              v-if="
+                (omicsType === 'Metabolomics' || omicsType === 'Lipidomics')
+                  && (item.omics_data.massSpecConfigId || item.omics_data.chromConfigId)
+              "
+            >
               <br>
-              <b>Data Generation Activity: </b> {{ item.omics_data.omicsProcessingName }} {{ item.omics_data.omics_processing_id }}
-            </span>
-            <span v-if="item.omics_data.massSpecConfigId">
-              <br>
-              <b>LC/MS Configurations: </b>
-              {{ item.omics_data.massSpecConfigName }}:
-              {{ item.omics_data.massSpecConfigId }};
-              {{ item.omics_data.chromConfigName }}:
-              {{ ' ' + item.omics_data.chromConfigId }}
+              <b>Data Generation Configurations</b>
+              <span v-if="item.omics_data.massSpecConfigId">
+                {{ item.omics_data.massSpecConfigName }}:
+                {{ item.omics_data.massSpecConfigId }};
+              </span>
+              <span v-if="item.omics_data.chromConfigId">
+                {{ item.omics_data.chromConfigName }}:
+                {{ ' ' + item.omics_data.chromConfigId }}
+              </span>
             </span>
             <br>
             <div v-if="getRelatedBiosampleIds(item.omics_data).length">


### PR DESCRIPTION
Fix #1514 

## Changes

### Ingest
On ingest of `data_generation` records, there is now an additional check to see if slots `has_mass_spectrometry_configuration` and `has_chromatography_configuration`. In the case that one or both of those slots is populated, we'll do an additional lookup to the `configuration_set` collection in mongo, and store the `id` and `name` of the `configuration` document in the `annotations` column of the `omics_processing` table.

They are stored in the `annotations` blob as:
- `mass_spectrometry_configuration_name`
- `mass_spectrometry_configuration_id`
- `chromatography_configuration_id`
- `chromatography_configuration_name`

Storing these fields in the json blob has the advantage of not needing to update our database model. Our search already handles lookups into the `annotations` column (so we won't need to change how this is stored when it comes to implementing #1517), and the `annotations` blob is available on the client and can be put into the UI as needed.

### Data Object Table (Vue component)
There is some additional processing to make the new data available to the vue component. This data is disaplayed in a header just above relevant data objects.

![image](https://github.com/user-attachments/assets/09c04963-8946-4c90-9719-8a15b96b230e)

#### Update 1/30/25
![image](https://github.com/user-attachments/assets/f13dc923-603f-4451-a3dd-b9d3783b9afd)


## Testing
To test, you'll need to run an ingest using the changes in this PR (from prod). The, use the biosample ID search to find a biosample such as `nmdc:bsm-13-2yga6857`, which has connections to `data_generation` records that point to LC/MS config records. View the data object tables for the relevant data types and verify the information displays as expected.

This PR does not add a facet to the search sidebar for LC/MS configs, but a side effect of the ingest changes is that one can use the API to filter on config names and IDs. For example, you can test out the `/api/data_generation/search` endpoint with the following request body:
```
{
  "conditions": [{
    "value": "nmdc:mscon-14-5jk7rg60",
    "field": "mass_spectrometry_configuration_id",
    "table": "omics_processing"
  }]
}
```


