### PR TITLE
Hotfix: Don't include invalid data objects in mod_zip file list

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -475,14 +475,6 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
             logger.warning(f"Data object url for {file.path} was {data_object.url}")
             continue
 
-        # Skip data objects whose `file_size_bytes` is `0` or `None`, since `mod_zip`
-        # considers a file list containing any file sizes of "0" or "" to be invalid.
-        if not data_object.file_size_bytes:
-            logger.warning(
-                f"Data object file_size_bytes for {file.path} was {data_object.file_size_bytes}"
-            )
-            continue
-
         # TODO: add crc checksums to support retries
         # TODO: add directory structure and metadata
         content.append(f"- {data_object.file_size_bytes} {url} {file.path}")

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -477,7 +477,7 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
 
         if not data_object.file_size_bytes:
             logger.warning(
-                f"Data object file_size_bytes for {file.path} was {data_object.file_sizey_bytes}"
+                f"Data object file_size_bytes for {file.path} was {data_object.file_size_bytes}"
             )
             continue
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -475,6 +475,8 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
             logger.warning(f"Data object url for {file.path} was {data_object.url}")
             continue
 
+        # Skip data objects whose `file_size_bytes` is `0` or `None`, since `mod_zip`
+        # considers a file list containing any file sizes of "0" or "" to be invalid.
         if not data_object.file_size_bytes:
             logger.warning(
                 f"Data object file_size_bytes for {file.path} was {data_object.file_size_bytes}"

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -475,10 +475,15 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
             logger.warning(f"Data object url for {file.path} was {data_object.url}")
             continue
 
+        if not data_object.file_size_bytes:
+            logger.warning(
+                f"Data object file_size_bytes for {file.path} was {data_object.file_sizey_bytes}"
+            )
+            continue
+
         # TODO: add crc checksums to support retries
         # TODO: add directory structure and metadata
-        file_size_string = data_object.file_size_bytes if data_object.file_size_bytes else ""
-        content.append(f"- {file_size_string} {url} {file.path}")
+        content.append(f"- {data_object.file_size_bytes} {url} {file.path}")
 
     bulk_download.expired = True
     db.commit()

--- a/nmdc_server/ingest/data_object.py
+++ b/nmdc_server/ingest/data_object.py
@@ -52,6 +52,12 @@ def load(db: Session, cursor: Cursor, file_types: List[Dict[str, Any]]):
         else:
             objects_without_type += 1
 
+        if obj.get("file_size_bytes", None) is None:
+            logger.warning(
+                f"data_object {obj['id']} has file_size_bytes {obj.get('file_size_bytes')} "
+                "and cannot be included in bulk downloads"
+            )
+
         db.add(DataObject(**obj))
 
     if objects_without_type:

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -926,7 +926,12 @@ class DataObjectQuerySchema(BaseQuerySchema):
 
     def aggregate(self, db: Session) -> DataObjectAggregation:
         """Return the number of files and total size of matched data objects."""
-        subquery = self.query(db).filter(models.DataObject.url != None).subquery()
+        subquery = (
+            self.query(db)
+            .filter(models.DataObject.url != None)
+            .filter(models.DataObject.file_size_bytes != None)
+            .subquery()
+        )
         row = db.query(
             func.count(subquery.c.id),
             func.sum(func.coalesce(subquery.c.file_size_bytes, 0)),


### PR DESCRIPTION
## Changes

### Previously
If a data object selected for bulk download had a file size of `NULL` or `0` (both perfectly valid NMDC data objects according to the [schema](https://microbiomedata.github.io/nmdc-schema/DataObject/)), we would include it in the file list for [mod_zip](https://github.com/evanmiller/mod_zip) like so:
```
-  data/object/url/...
```
This is not valid, per, mod_zip's documentation, and was preventing people from executing bulk downloads including these files.

### After this change
Construction of the file list for mod_zip has been changed. Files whose `file_size_bytes` is `NULL` or `0` are no longer included. Additionally, we log a warning.

## Hotfix

This is a hotfix. This branch was created from v1.3.0 (the January 2025 release). Normal hotfix procedure includes issuing a new tag to use for the production deployment at the same time this gets merged into development. Since this is hard to test locally, we could modify that procedure slightly by:

1. Merging into `main`, and testing on dev
2. Once testing is satisfactory, restore this branch and create tag v1.3.1