### PR TITLE
Add SQLAlchemy panel to debug toolbar

### DIFF
--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -63,6 +63,8 @@ field and click "Authorize".
         app.add_middleware(
             DebugToolbarMiddleware,
             panels=["nmdc_server.database.SQLAlchemyPanel"],
+            # Uncheck the profiling feature since it doesn't work for AJAX requests
+            disable_panels=["debug_toolbar.panels.profiling.ProfilingPanel"],
         )
 
     @app.get("/docs", response_class=RedirectResponse, status_code=301, include_in_schema=False)

--- a/nmdc_server/app.py
+++ b/nmdc_server/app.py
@@ -60,7 +60,10 @@ field and click "Authorize".
         lifespan=lifespan,
     )
     if settings.environment == "development":
-        app.add_middleware(DebugToolbarMiddleware)
+        app.add_middleware(
+            DebugToolbarMiddleware,
+            panels=["nmdc_server.database.SQLAlchemyPanel"],
+        )
 
     @app.get("/docs", response_class=RedirectResponse, status_code=301, include_in_schema=False)
     async def redirect_docs():

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -1,3 +1,4 @@
+from debug_toolbar.panels.sqlalchemy import SQLAlchemyPanel as BasePanel
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen
 from sqlalchemy.ext.declarative import declarative_base
@@ -18,6 +19,12 @@ engine = create_engine(settings.current_db_uri, **_engine_kwargs)
 engine_ingest = create_engine(settings.ingest_database_uri, **_engine_kwargs)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 SessionLocalIngest = sessionmaker(autocommit=False, autoflush=False, bind=engine_ingest)
+
+
+class SQLAlchemyPanel(BasePanel):
+    async def add_engines(self, request):
+        self.engines.add(engine)
+
 
 # This is to avoid having to manually name all constraints
 # See: http://alembic.zzzcomputing.com/en/latest/naming.html


### PR DESCRIPTION
This adds the SQLAlchemy panel to the debug toolbar which should let us view the queries executed in development.

Example:
![fastapi-debug-toolbar](https://github.com/user-attachments/assets/d581b5bf-9076-4c68-81ac-e7d9a78fe662)
