### PR TITLE
Add facets for mass spec and chromatography configs

### DIFF
--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -604,7 +604,16 @@ const tableFields: Record<entityType, Record<string, FieldsData>> = {
   },
   biosample: {},
   study: {},
-  omics_processing: {},
+  omics_processing: {
+    mass_spectrometry_configuration_name: {
+      name: 'Mass Spectrometry Method',
+      schemaName: 'MassSpectrometryConfiguration',
+    },
+    chromatography_configuration_name: {
+      name: 'Chromatography Method',
+      schemaName: 'ChromatographyConfiguration',
+    },
+  },
   reads_qc: {},
   metagenome_annotation: {},
   metagenome_assembly: {},

--- a/web/src/views/Search/SearchSidebar.vue
+++ b/web/src/views/Search/SearchSidebar.vue
@@ -105,6 +105,16 @@ const FunctionSearchFacets: SearchFacet[] = [
     table: 'omics_processing',
     group: 'Data Generation',
   },
+  {
+    field: 'mass_spectrometry_configuration_name',
+    table: 'omics_processing',
+    group: 'Data Generation',
+  },
+  {
+    field: 'chromatography_configuration_name',
+    table: 'omics_processing',
+    group: 'Data Generation',
+  },
 ];
 
 export default defineComponent({


### PR DESCRIPTION
Fix #1517 

### Changes

Adds UI for filtering by Mass Spec configuration and Chromatography configuration. The new facets are grouped under "Data Generation" like so:
![image](https://github.com/user-attachments/assets/52e5f73a-d273-418a-ab83-fe5061c5ed14)

Each of these facets allows users to select from a list of configuration names:
![image](https://github.com/user-attachments/assets/92702e50-8241-4245-b0e1-f36bc77dddbf)

![image](https://github.com/user-attachments/assets/b026d720-936c-440b-87c8-9766f528278c)

Note that these screenshots are from my local development environment, so any counts could be out of sync with the data currently available in mongo.

@kheal adding you as a reviewer to catch anything that might be off in the screenshots before this gets merged into dev for testing.