### PR TITLE
Add ability to filter submissions based on submission type

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -869,22 +869,13 @@ async def list_submissions(
     pagination: Pagination = Depends(),
     column_sort: str = "created",
     sort_order: str = "desc",
-    filter_column: Optional[str] = None,
-    filter_value: Optional[str] = None,
+    is_test_submission_filter: Optional[bool] = None,
 ):
-    query = crud.get_submissions_for_user(db, user, column_sort, sort_order)
-    result = pagination.response(query)
-    if filter_column and filter_value:
-        filtered_result = []
-        tables = result["results"]
-        if filter_column in tables[0].__table__.columns.keys():  # type: ignore
-            for table in tables:
-                if filter_value.lower() in (str(getattr(table, filter_column))).lower():
-                    filtered_result.append(table)
-            result["results"] = filtered_result
-            result["count"] = len(filtered_result)
-
-    return result
+    query = crud.get_submissions_for_user(
+        db, user, column_sort, sort_order, is_test_submission_filter
+    )
+    # print(filters)
+    return pagination.response(query)
 
 
 @router.get(

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -877,8 +877,6 @@ async def list_submissions(
     if filter_column and filter_value:
         filtered_result = []
         tables = result["results"]
-        print(tables[0])
-        print(type(tables[0]))
         if filter_column in tables[0].__table__.columns.keys():  # type: ignore
             for table in tables:
                 if filter_value.lower() in (str(getattr(table, filter_column))).lower():

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -874,7 +874,6 @@ async def list_submissions(
     query = crud.get_submissions_for_user(
         db, user, column_sort, sort_order, is_test_submission_filter
     )
-    # print(filters)
     return pagination.response(query)
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -869,9 +869,24 @@ async def list_submissions(
     pagination: Pagination = Depends(),
     column_sort: str = "created",
     sort_order: str = "desc",
+    filter_column: Optional[str] = None,
+    filter_value: Optional[str] = None,
 ):
     query = crud.get_submissions_for_user(db, user, column_sort, sort_order)
-    return pagination.response(query)
+    result = pagination.response(query)
+    if filter_column and filter_value:
+        filtered_result = []
+        tables = result["results"]
+        print(tables[0])
+        print(type(tables[0]))
+        if filter_column in tables[0].__table__.columns.keys():  # type: ignore
+            for table in tables:
+                if filter_value.lower() in (str(getattr(table, filter_column))).lower():
+                    filtered_result.append(table)
+            result["results"] = filtered_result
+            result["count"] = len(filtered_result)
+
+    return result
 
 
 @router.get(

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -687,7 +687,9 @@ def can_edit_entire_submission(db: Session, submission_id: str, user_orcid: str)
     return (role and models.SubmissionEditorRole(role.role) in contributors_edit_roles) is True
 
 
-def get_submissions_for_user(db: Session, user: models.User, column_sort: str, order: str):
+def get_submissions_for_user(
+    db: Session, user: models.User, column_sort: str, order: str, is_test_submission_filter: bool | None
+):
     """Return all submissions that a user has permission to view."""
     column = (
         models.User.name
@@ -700,6 +702,11 @@ def get_submissions_for_user(db: Session, user: models.User, column_sort: str, o
         .join(models.User, models.SubmissionMetadata.author_id == models.User.id)
         .order_by(column.asc() if order == "asc" else column.desc())
     )
+
+    if is_test_submission_filter != None:
+        all_submissions = all_submissions.filter(
+            models.SubmissionMetadata.is_test_submission == is_test_submission_filter
+        )
 
     if user.is_admin:
         return all_submissions

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -692,7 +692,7 @@ def get_submissions_for_user(
     user: models.User,
     column_sort: str,
     order: str,
-    is_test_submission_filter: bool | None,
+    is_test_submission_filter: Optional[bool] = None,
 ):
     """Return all submissions that a user has permission to view."""
     column = (

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -688,7 +688,11 @@ def can_edit_entire_submission(db: Session, submission_id: str, user_orcid: str)
 
 
 def get_submissions_for_user(
-    db: Session, user: models.User, column_sort: str, order: str, is_test_submission_filter: bool | None
+    db: Session,
+    user: models.User,
+    column_sort: str,
+    order: str,
+    is_test_submission_filter: bool | None,
 ):
     """Return all submissions that a user has permission to view."""
     column = (

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -67,6 +67,10 @@ export default defineComponent({
     const isDeleteDialogOpen = ref(false);
     const deleteDialogSubmission = ref<MetadataSubmissionRecord | null>(null);
     const isTestFilter = ref(null);
+    const filterSelectValues = [
+      { text: 'All Submissions', val: null },
+      { text: 'Test Only', val: true },
+      { text: 'Real Only', val: false }];
 
     async function getSubmissions(params: SearchParams): Promise<PaginatedResponse<MetadataSubmissionRecord>> {
       return api.listRecords(params, isTestFilter.value);
@@ -135,14 +139,9 @@ export default defineComponent({
       headers,
       options,
       submission,
+      filterSelectValues,
     };
   },
-  data: () => ({
-    filterSelectValues: [
-      { text: 'All Submissions', val: null },
-      { text: 'Test Only', val: true },
-      { text: 'Real Only', val: false }],
-  }),
 });
 </script>
 
@@ -222,27 +221,27 @@ export default defineComponent({
         Past submissions
       </v-card-title>
       <v-row
-        align="center"
+        justify="space-between"
+        class="pb-2"
+        no-gutters
       >
         <v-col
-          class="d-flex"
-          cols="12"
-          sm="7"
-          align="top"
+          cols="5"
         >
           <v-card-text>
             Pick up where you left off or review a previous submission.
           </v-card-text>
+        </v-col>
+        <v-col
+          cols="3"
+        >
           <v-select
             v-model="isTestFilter"
-            class="my-2"
             :items="filterSelectValues"
             item-text="text"
             item-value="val"
-            :max-width="330"
-            label="Test Submission Filter"
-            hint="Filter whether all submissions should be shown or only some."
-            target="#submissionFilterDropdown"
+            label="Filter My Submissions"
+            hide-details
           />
         </v-col>
       </v-row>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -96,7 +96,6 @@ export default defineComponent({
       submission.setSortOptions(options.value.sortBy[0], sortOrder);
     }, { deep: true });
     watch(isTestFilter, () => {
-      console.log(isTestFilter.value);
       options.value.page = 1;
       submission.setPage(options.value.page);
       const sortOrder = options.value.sortDesc[0] ? 'desc' : 'asc';

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -24,6 +24,11 @@ const headers: DataTableHeader[] = [
     value: 'study_name',
   },
   {
+    text: '',
+    value: 'is_test_submission',
+    sortable: false,
+  },
+  {
     text: 'Author',
     value: 'author.name',
   },
@@ -67,10 +72,10 @@ export default defineComponent({
     const isDeleteDialogOpen = ref(false);
     const deleteDialogSubmission = ref<MetadataSubmissionRecord | null>(null);
     const isTestFilter = ref(null);
-    const filterSelectValues = [
-      { text: 'All Submissions', val: null },
-      { text: 'Test Only', val: true },
-      { text: 'Real Only', val: false }];
+    const testSubmissions = [
+      { text: 'Show all submissions', val: null },
+      { text: 'Show only test submissions', val: true },
+      { text: 'Hide test submissions', val: false }];
 
     async function getSubmissions(params: SearchParams): Promise<PaginatedResponse<MetadataSubmissionRecord>> {
       return api.listRecords(params, isTestFilter.value);
@@ -139,7 +144,7 @@ export default defineComponent({
       headers,
       options,
       submission,
-      filterSelectValues,
+      testSubmissions,
     };
   },
 });
@@ -237,7 +242,7 @@ export default defineComponent({
         >
           <v-select
             v-model="isTestFilter"
-            :items="filterSelectValues"
+            :items="testSubmissions"
             item-text="text"
             item-value="val"
             label="Filter My Submissions"
@@ -255,6 +260,26 @@ export default defineComponent({
           :items-per-page.sync="submission.data.limit"
           :footer-props="{ itemsPerPageOptions: [10, 20, 50] }"
         >
+          <template #[`item.is_test_submission`]="{ item }">
+            <v-tooltip
+              v-if="item.is_test_submission"
+              top
+            >
+              <template #activator="{ on }">
+                <!--- This is an alternate solution that would show an icon and tooltip for both
+                  <v-icon v-on="on">
+                    {{ item.is_test_submission ? 'mdi-test-tube' : 'mdi-test-tube-empty' }}
+                  </v-icon>
+                </template>
+                <span> {{ item.is_test_submission ? 'This is a test submission' : 'This is a genuine submission' }} </span>
+                --->
+                <v-icon v-on="on">
+                  mdi-test-tube
+                </v-icon>
+              </template>
+              <span> This is a test submission. </span>
+            </v-tooltip>
+          </template>
           <template #[`item.author.name`]="{ item }">
             <orcid-id
               :orcid-id="item.author.orcid"

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -24,11 +24,6 @@ const headers: DataTableHeader[] = [
     value: 'study_name',
   },
   {
-    text: '',
-    value: 'is_test_submission',
-    sortable: false,
-  },
-  {
     text: 'Author',
     value: 'author.name',
   },

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -72,7 +72,7 @@ export default defineComponent({
     const isDeleteDialogOpen = ref(false);
     const deleteDialogSubmission = ref<MetadataSubmissionRecord | null>(null);
     const isTestFilter = ref(null);
-    const testSubmissions = [
+    const testFilterValues = [
       { text: 'Show all submissions', val: null },
       { text: 'Show only test submissions', val: true },
       { text: 'Hide test submissions', val: false }];
@@ -144,7 +144,7 @@ export default defineComponent({
       headers,
       options,
       submission,
-      testSubmissions,
+      testFilterValues,
     };
   },
 });
@@ -242,10 +242,10 @@ export default defineComponent({
         >
           <v-select
             v-model="isTestFilter"
-            :items="testSubmissions"
+            :items="testFilterValues"
             item-text="text"
             item-value="val"
-            label="Filter My Submissions"
+            label="Test Submissions"
             hide-details
           />
         </v-col>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -260,25 +260,16 @@ export default defineComponent({
           :items-per-page.sync="submission.data.limit"
           :footer-props="{ itemsPerPageOptions: [10, 20, 50] }"
         >
-          <template #[`item.is_test_submission`]="{ item }">
-            <v-tooltip
+          <template #[`item.study_name`]="{ item }">
+            {{ item.study_name }}
+            <v-chip
               v-if="item.is_test_submission"
-              top
+              color="orange"
+              text-color="white"
+              small
             >
-              <template #activator="{ on }">
-                <!--- This is an alternate solution that would show an icon and tooltip for both
-                  <v-icon v-on="on">
-                    {{ item.is_test_submission ? 'mdi-test-tube' : 'mdi-test-tube-empty' }}
-                  </v-icon>
-                </template>
-                <span> {{ item.is_test_submission ? 'This is a test submission' : 'This is a genuine submission' }} </span>
-                --->
-                <v-icon v-on="on">
-                  mdi-test-tube
-                </v-icon>
-              </template>
-              <span> This is a test submission. </span>
-            </v-tooltip>
+              TEST
+            </v-chip>
           </template>
           <template #[`item.author.name`]="{ item }">
             <orcid-id

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -47,7 +47,20 @@ async function updateRecord(id: string, record: Partial<MetadataSubmission>, sta
   return { data: resp.data, httpStatus: resp.status };
 }
 
-async function listRecords(params: SearchParams) {
+async function listRecords(params: SearchParams, isTestFilter: boolean | null) {
+  console.log(isTestFilter);
+  if (isTestFilter !== null) {
+    const resp = await client.get<PaginatedResponse<MetadataSubmissionRecord>>('metadata_submission', {
+      params: {
+        limit: params.limit,
+        offset: params.offset,
+        column_sort: params.sortColumn,
+        sort_order: params.sortOrder,
+        is_test_submission_filter: isTestFilter,
+      },
+    });
+    return resp.data;
+  }
   const resp = await client.get<PaginatedResponse<MetadataSubmissionRecord>>('metadata_submission', {
     params: {
       limit: params.limit,

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -48,7 +48,6 @@ async function updateRecord(id: string, record: Partial<MetadataSubmission>, sta
 }
 
 async function listRecords(params: SearchParams, isTestFilter: boolean | null) {
-  console.log(isTestFilter);
   if (isTestFilter !== null) {
     const resp = await client.get<PaginatedResponse<MetadataSubmissionRecord>>('metadata_submission', {
       params: {


### PR DESCRIPTION
This PR will update the `GET api/metadata_submission` endpoint to support filtering and add front end changes to allow users to filter submissions on the portal.