### PR TITLE
Conditionally prefetch omics processing data

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -227,7 +227,10 @@ async def search_biosample(
         return biosample
 
     results = pagination.response(
-        crud.search_biosample(db, query.conditions, data_object_filter), insert_selected
+        crud.search_biosample(
+            db, query.conditions, data_object_filter, prefetch_omics_processing_data=True
+        ),
+        insert_selected,
     )
     if any(
         [

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -350,10 +350,11 @@ def search_biosample(
     db: Session,
     conditions: List[query.ConditionSchema],
     data_object_filter: List[query.DataObjectFilter],
+    prefetch_omics_processing_data: bool = False,
 ) -> Query:
     return query.BiosampleQuerySchema(
         conditions=conditions, data_object_filter=data_object_filter
-    ).execute(db)
+    ).execute(db, prefetch_omics_processing_data)
 
 
 def facet_biosample(


### PR DESCRIPTION
This aims to reduce the number of queries that the biosample search endpoint uses by using `selectinload` to reduce n+1 queries.

This table shows the before/after locally when querying with no conditions/filters with different limits.

| limit | queries before | queries after | time before (ms) | time after (ms) |
| ----- | -------------- | ------------- | ----------- | ---------- |
| 1     | 26             | 27            | 100         | 65         |
| 15    | 306            | 27            | 770         | 125        |
| 25    | 500            | 27            | 1250        | 170        |

FYI @naglepuff This appears to change the ordering of `omics_processing` results, though it seems like it was already an undefined sort order so maybe this isn't an issue.