### PR TITLE
Address empty fields not being marked as invalid

### DIFF
--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -146,6 +146,7 @@ export default defineComponent({
           outlined
           validate-on-blur
           dense
+          :error-messages="multiOmicsForm.JGIStudyId ? undefined : ['JGI Proposal ID/Study ID is required when processing was done at JGI']"
         />
       </div>
 
@@ -189,6 +190,7 @@ export default defineComponent({
           outlined
           validate-on-blur
           dense
+          :error-messages="multiOmicsForm.studyNumber ? undefined : ['EMSL Study Number is required when processing was done at EMSL']"
         />
       </div>
       <!-- Other -->

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -238,13 +238,13 @@ export default defineComponent({
             <v-text-field
               v-if="studyForm.fundingSources !== null"
               v-model="studyForm.fundingSources[i]"
-              :rules="requiredRules('Field cannot be empty.')"
               label="Funding Source *"
               :hint="Definitions.fundingSources"
+              persistent-hint
               outlined
               dense
-              persistent-hint
               class="mb-2 mr-3"
+              :error-messages="studyForm.fundingSources[i] ? undefined : ['Field cannot be empty.']"
             >
               <template #message="{ message }">
                 <span v-html="message" />
@@ -290,12 +290,12 @@ export default defineComponent({
           <div class="d-flex">
             <v-text-field
               v-model="contributor.name"
-              :rules="requiredRules('Full name is required')"
               label="Full name *"
               :hint="Definitions.contributorFullName"
               outlined
               dense
               persistent-hint
+              :error-messages="contributor.name ? undefined : ['Field cannot be empty.']"
               class="mb-2 mr-3"
             />
             <v-text-field
@@ -317,7 +317,6 @@ export default defineComponent({
           <div class="d-flex">
             <v-select
               v-model="contributor.roles"
-              :rules="[v => v.length >= 1 || 'At least one role is required']"
               :items="Object.keys(NmdcSchema.enums.CreditEnum.permissible_values)"
               label="CRediT Roles *"
               :hint="Definitions.contributorRoles"
@@ -328,6 +327,7 @@ export default defineComponent({
               small-chips
               dense
               persistent-hint
+              :error-messages="!contributor.roles || contributor.roles.length === 0 ? ['At least one role is required'] : undefined"
               class="mb-2 mr-3"
             >
               <template #message="{ message }">


### PR DESCRIPTION
Closes #1370 
Allow required fields to show up with a red box and required message without first needing to click on the field, like this: 

![image](https://github.com/user-attachments/assets/480deea1-4a6c-4766-9d07-940ec03b66ef)

Do this for:
- funding sources
- contributors
- JGI project ID
- EMSL project ID