### PR TITLE
Add logic for showing sequencing data tabs

### DIFF
--- a/web/src/views/SubmissionPortal/Components/FindReplace.vue
+++ b/web/src/views/SubmissionPortal/Components/FindReplace.vue
@@ -7,7 +7,7 @@ import {
   PropType,
 } from '@vue/composition-api';
 import type { Ref } from '@vue/composition-api';
-import type { HarmonizerApi } from '../harmonizerApi';
+import type HarmonizerApi from '../harmonizerApi';
 
 type SearchResult = {
   row: number;

--- a/web/src/views/SubmissionPortal/Components/HarmonizerSidebar.vue
+++ b/web/src/views/SubmissionPortal/Components/HarmonizerSidebar.vue
@@ -3,7 +3,7 @@ import {
   defineComponent, PropType, ref,
 } from '@vue/composition-api';
 import FindReplace from '@/views/SubmissionPortal/Components/FindReplace.vue';
-import type { HarmonizerApi } from '@/views/SubmissionPortal/harmonizerApi';
+import type HarmonizerApi from '@/views/SubmissionPortal/harmonizerApi';
 import ContactCard from '@/views/SubmissionPortal/Components/ContactCard.vue';
 import ImportExportButtons from '@/views/SubmissionPortal/Components/ImportExportButtons.vue';
 import ColumnHelp from '@/views/SubmissionPortal/Components/ColumnHelp.vue';

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -20,7 +20,7 @@ import {
   SuggestionsMode,
   SuggestionType,
 } from '@/views/SubmissionPortal/types';
-import type { HarmonizerApi } from '@/views/SubmissionPortal/harmonizerApi';
+import type HarmonizerApi from '@/views/SubmissionPortal/harmonizerApi';
 import { getRejectedSuggestions, setRejectedSuggestions } from '@/store/localStorage';
 
 const suggestionModeOptions = Object.values(SuggestionsMode);

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -9,7 +9,7 @@ import { read, writeFile, utils } from 'xlsx';
 import { api } from '@/data/api';
 import useRequest from '@/use/useRequest';
 
-import { HarmonizerApi } from './harmonizerApi';
+import HarmonizerApi from './harmonizerApi';
 import {
   packageName,
   sampleData,
@@ -29,10 +29,14 @@ import {
   isTestSubmission,
 } from './store';
 import {
+  DATA_MG_INTERLEAVED,
+  DATA_MG,
+  DATA_MT,
+  DATA_MT_INTERLEAVED,
   HARMONIZER_TEMPLATES,
   EMSL,
   JGI_MG,
-  JGT_MT,
+  JGI_MT,
   JGI_MG_LR,
   SuggestionsMode,
 } from '@/views/SubmissionPortal/types';
@@ -349,7 +353,19 @@ export default defineComponent({
       if (templateKey === JGI_MG_LR) {
         return row_types.includes('metagenomics_long_read');
       }
-      if (templateKey === JGT_MT) {
+      if (templateKey === JGI_MT) {
+        return row_types.includes('metatranscriptomics');
+      }
+      if (templateKey === DATA_MG) {
+        return row_types.includes('metagenomics');
+      }
+      if (templateKey === DATA_MG_INTERLEAVED) {
+        return row_types.includes('metagenomics');
+      }
+      if (templateKey === DATA_MT) {
+        return row_types.includes('metatranscriptomics');
+      }
+      if (templateKey === DATA_MT_INTERLEAVED) {
         return row_types.includes('metatranscriptomics');
       }
       return false;

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -6,10 +6,6 @@ import { DataHarmonizer, Footer } from 'data-harmonizer';
 import {
   CellData,
   HARMONIZER_TEMPLATES,
-  EMSL,
-  JGI_MG,
-  JGI_MG_LR,
-  JGT_MT,
   MetadataSuggestionRequest,
   ColumnHelpInfo,
 } from '@/views/SubmissionPortal/types';
@@ -38,27 +34,7 @@ const GOLD_FIELDS = {
   },
 };
 
-export function getVariants(checkBoxes: string[], dataGenerated: boolean | undefined, base: string[]): string[] {
-  const templates = new Set(base);
-  if (dataGenerated) {
-    return Array.from(templates);
-  }
-  if (checkBoxes.includes('mp-emsl') || checkBoxes.includes('mb-emsl') || checkBoxes.includes('nom-emsl')) {
-    templates.add(EMSL);
-  }
-  if (checkBoxes.includes('mg-jgi')) {
-    templates.add(JGI_MG);
-  }
-  if (checkBoxes.includes('mg-lr-jgi')) {
-    templates.add(JGI_MG_LR);
-  }
-  if (checkBoxes.includes('mt-jgi')) {
-    templates.add(JGT_MT);
-  }
-  return Array.from(templates);
-}
-
-export class HarmonizerApi {
+export default class HarmonizerApi {
   schemaSectionNames: Ref<Record<string, string>>;
 
   schemaSectionColumns: Ref<Record<string, Record<string, number>>>;

--- a/web/src/views/SubmissionPortal/types.ts
+++ b/web/src/views/SubmissionPortal/types.ts
@@ -6,7 +6,12 @@ import { User } from '@/types';
 export const EMSL = 'emsl';
 export const JGI_MG = 'jgi_mg';
 export const JGI_MG_LR = 'jgi_mg_lr';
-export const JGT_MT = 'jgi_mt';
+export const JGI_MT = 'jgi_mt';
+export const DATA_MG = 'data_mg';
+export const DATA_MG_INTERLEAVED = 'data_mg_interleaved';
+export const DATA_MT = 'data_mt';
+export const DATA_MT_INTERLEAVED = 'data_mt_interleaved';
+
 export interface HarmonizerTemplateInfo {
   displayName: string,
   schemaClass?: string,
@@ -120,10 +125,34 @@ export const HARMONIZER_TEMPLATES: Record<string, HarmonizerTemplateInfo> = {
     sampleDataSlot: 'jgi_mg_lr_data',
     status: 'mixin',
   },
-  [JGT_MT]: {
+  [JGI_MT]: {
     displayName: 'JGI MT',
     schemaClass: 'JgiMtInterface',
     sampleDataSlot: 'jgi_mt_data',
+    status: 'mixin',
+  },
+  [DATA_MG]: {
+    displayName: 'MetaG Data',
+    schemaClass: 'MetagenomeSequencingNonInterleavedDataInterface',
+    sampleDataSlot: 'metagenome_sequencing_non_interleaved_data',
+    status: 'mixin',
+  },
+  [DATA_MG_INTERLEAVED]: {
+    displayName: 'MetaG Data (Interleaved)',
+    schemaClass: 'MetagenomeSequencingInterleavedDataInterface',
+    sampleDataSlot: 'metagenome_sequencing_interleaved_data',
+    status: 'mixin',
+  },
+  [DATA_MT]: {
+    displayName: 'MetaT Data',
+    schemaClass: 'MetatranscriptomeSequencingNonInterleavedDataInterface',
+    sampleDataSlot: 'metatranscriptome_sequencing_non_interleaved_data',
+    status: 'mixin',
+  },
+  [DATA_MT_INTERLEAVED]: {
+    displayName: 'MetaT Data (Interleaved)',
+    schemaClass: 'MetatranscriptomeSequencingInterleavedDataInterface',
+    sampleDataSlot: 'metatranscriptome_sequencing_interleaved_data',
     status: 'mixin',
   },
 };


### PR DESCRIPTION
Re: #1513 (will keep that issue open until #1512 is completed as these changes are going into that branch)

### Summary

Currently the logic to determine which tabs should be shown in the final Submission Portal screen is encapsulated in the `getVariants` function in `web/src/views/SubmissionPortal/harmonizerApi.ts`. There's really no reason for that logic to live there; it is unrelated to the `HarmonizerApi` class. These changes:

* Move the logic of selecting which tabs to display (`templateList`) to `web/src/views/SubmissionPortal/store/index.ts`.
* Expand the logic to take into account the new questions asked by the combined submission context / multi-omics form.
* Make `HarmonizerApi` the default export of `web/src/views/SubmissionPortal/harmonizerApi.ts` and update existing imports accordingly.

The following changes were also made:

* Add information about the new schema classes to the `HARMONIZER_TEMPLATES` lookup object
* Add logic to `web/src/views/SubmissionPortal/HarmonizerView.vue` to control which data rows are displayed when the new tabs are selected