### PR TITLE
Allow v-pagination to grow to necessary space

### DIFF
--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -55,38 +55,29 @@ export default defineComponent({
 
 <template>
   <div>
-    <v-col
+    <div
       v-if="!disablePagination"
-      cols="12"
-      class="pb-0"
+      class="d-flex pt-2 pb-0 align-end justify-center"
     >
-      <v-row
-        no-gutters
-        justify="center"
-      >
-        <v-col
-          cols="3"
-        >
-          <v-pagination
-            :value="page"
-            :length="Math.ceil(count / rows)"
-            :total-visible="7"
-            class="pt-3"
-            depressed
-            @input="$emit('set-page', $event)"
-          />
-        </v-col>
-        <v-col cols="1">
-          <v-select
-            v-model="rows"
-            :items="[5, 10, 15, 20]"
-            label="Items per page"
-            class="px-4"
-            @input="$emit('set-items-per-page', $event)"
-          />
-        </v-col>
-      </v-row>
-    </v-col>
+      <v-pagination
+        :value="page"
+        :length="Math.ceil(count / rows)"
+        :total-visible="7"
+        depressed
+        @input="$emit('set-page', $event)"
+      />
+      <!-- flex-basis is based on the "Items per page" label. Since it is absolutely
+           positioned it doesn't count towards the `auto` width -->
+      <v-select
+        v-model="rows"
+        :items="[5, 10, 15, 20]"
+        label="Items per page"
+        class="ml-4 flex-grow-0"
+        :style="{ 'flex-basis': '6rem' }"
+        hide-details
+        @input="$emit('set-items-per-page', $event)"
+      />
+    </div>
     <v-list dense>
       <template
         v-for="(result, resultIndex) in results"


### PR DESCRIPTION
Fixes #1221. As a tall-and-narrow-browser-window person, it was driving me nuts.

The issue was that we were putting the `v-pagination` component into a `v-col` that was fixed at 3 columns. That isn't guaranteed to be enough space for the `v-pagination` component to fully display everything.

The fix is to eschew the `v-row` and `v-col` setup in favor of a plain `div` and flexbox utilities. This allows the `v-pagination` component to expand to as much space as it needs.

Before:
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/ebc9363e-20a0-432b-b62c-50c598288348" />

After:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/59b51290-e0b9-4d2a-8cbd-19656db9f52a" />
