### PR TITLE
Skip bulk downloading data objects without file size info

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -502,6 +502,12 @@ def get_zip_download(db: Session, id: UUID) -> Optional[str]:
             logger.warning(f"Data object url for {file.path} was {data_object.url}")
             continue
 
+        if data_object.file_size_bytes is None:
+            logger.warning(
+                "Data object file_size_bytes for {file.path} was {data_object.file_size_bytes}"
+            )
+            continue
+
         # TODO: add crc checksums to support retries
         # TODO: add directory structure and metadata
         content.append(f"- {data_object.file_size_bytes} {url} {file.path}")


### PR DESCRIPTION
Fix #1584 

### Changes

When building the file list for `mod_zip`, we now skip including data objects whose value of `file_size_bytes` is `None`. These files result in lines in the file list that look like:

```
- None file://url/for/file path/for/file/in/zip/folder
```

This is invalid for `mod_zip`. We can't omit size information, as that is needed to create the zip archive, so we won't include the file, and we'll log a message to the `fastapi` server logs indicating that we've skipped the file.