### PR TITLE
Fix multiomics form validation

### DIFF
--- a/web/src/views/SubmissionPortal/Components/DataTypes.vue
+++ b/web/src/views/SubmissionPortal/Components/DataTypes.vue
@@ -15,7 +15,7 @@ export default defineComponent({
       default: true,
     },
   },
-  setup(props, { emit }) {
+  setup(_, { emit }) {
     const dataCaveat = 'You may proceed with your submission for sample metadata capture. However, there will not be place to provide information about your existing sequencing data as the methods are not supported by NMDC Workflows';
 
     const handleMetagenomeChange = (value: string[]) => {

--- a/web/src/views/SubmissionPortal/Components/DataTypes.vue
+++ b/web/src/views/SubmissionPortal/Components/DataTypes.vue
@@ -11,13 +11,47 @@ export default defineComponent({
       default: 'Data Types',
     },
   },
-  setup() {
+  setup(props, { emit }) {
     const dataCaveat = 'You may proceed with your submission for sample metadata capture. However, there will not be place to provide information about your existing sequencing data as the methods are not supported by NMDC Workflows';
+
+    const handleMetagenomeChange = (value: string[]) => {
+      if (!value.includes('mg')) {
+        multiOmicsForm.mgCompatible = undefined;
+        multiOmicsForm.mgInterleaved = undefined;
+      }
+      emit('revalidate');
+    };
+
+    const handleMgCompatibleChange = (value: boolean) => {
+      if (!value) {
+        multiOmicsForm.mgInterleaved = undefined;
+      }
+      emit('revalidate');
+    };
+
+    const handleMetatranscriptomeChange = (value: string[]) => {
+      if (!value.includes('mt')) {
+        multiOmicsForm.mtCompatible = undefined;
+        multiOmicsForm.mtInterleaved = undefined;
+      }
+      emit('revalidate');
+    };
+
+    const handleMtCompatibleChange = (value: boolean) => {
+      if (!value) {
+        multiOmicsForm.mtInterleaved = undefined;
+      }
+      emit('revalidate');
+    };
 
     return {
       dataCaveat,
       multiOmicsForm,
       templateChoiceDisabled,
+      handleMetagenomeChange,
+      handleMgCompatibleChange,
+      handleMetatranscriptomeChange,
+      handleMtCompatibleChange,
     };
   },
 
@@ -42,6 +76,7 @@ export default defineComponent({
       value="mg"
       :disabled="templateChoiceDisabled"
       hide-details
+      @change="handleMetagenomeChange"
     />
     <div
       v-if="multiOmicsForm.omicsProcessingTypes.includes('mg')"
@@ -68,6 +103,8 @@ export default defineComponent({
       <v-radio-group
         v-model="multiOmicsForm.mgCompatible"
         label="Is the generated data compatible? *"
+        :rules="[v => v !== undefined || 'This field is required']"
+        @change="handleMgCompatibleChange"
       >
         <v-radio
           :value="false"
@@ -79,6 +116,7 @@ export default defineComponent({
             <v-tooltip
               right
               class="x-2"
+              max-width="500"
             >
               <template #activator="{ on }">
                 <v-icon
@@ -104,6 +142,7 @@ export default defineComponent({
         v-if="multiOmicsForm.mgCompatible"
         v-model="multiOmicsForm.mgInterleaved"
         label="Is the data in interleaved format? *"
+        :rules="[v => v !== undefined || 'This field is required']"
       >
         <v-radio
           label="No"
@@ -121,6 +160,7 @@ export default defineComponent({
       value="mt"
       :disabled="templateChoiceDisabled"
       hide-details
+      @change="handleMetatranscriptomeChange"
     />
     <div
       v-if="multiOmicsForm.omicsProcessingTypes.includes('mt')"
@@ -152,6 +192,8 @@ export default defineComponent({
       <v-radio-group
         v-model="multiOmicsForm.mtCompatible"
         label="Is the generated data compatible? *"
+        :rules="[v => v !== undefined || 'This field is required']"
+        @change="handleMtCompatibleChange"
       >
         <v-radio
           :value="false"
@@ -163,6 +205,7 @@ export default defineComponent({
             <v-tooltip
               right
               class="x-2"
+              max-width="500"
             >
               <template #activator="{ on }">
                 <v-icon
@@ -187,7 +230,8 @@ export default defineComponent({
       <v-radio-group
         v-if="multiOmicsForm.mtCompatible"
         v-model="multiOmicsForm.mtInterleaved"
-        label="Is the dasta in interleaved format? *"
+        label="Is the data in interleaved format? *"
+        :rules="[v => v !== undefined || 'This field is required']"
       >
         <v-radio
           label="No"

--- a/web/src/views/SubmissionPortal/Components/DataTypes.vue
+++ b/web/src/views/SubmissionPortal/Components/DataTypes.vue
@@ -10,6 +10,10 @@ export default defineComponent({
       type: String,
       default: 'Data Types',
     },
+    showDataCompatibilityQuestions: {
+      type: Boolean,
+      default: true,
+    },
   },
   setup(props, { emit }) {
     const dataCaveat = 'You may proceed with your submission for sample metadata capture. However, there will not be place to provide information about your existing sequencing data as the methods are not supported by NMDC Workflows';
@@ -62,7 +66,7 @@ export default defineComponent({
 <template>
   <div
 
-    class="text-h6 mt-4"
+    class="text-h6 my-4"
   >
     <legend
       class="v-label theme--light mb-2"
@@ -79,7 +83,7 @@ export default defineComponent({
       @change="handleMetagenomeChange"
     />
     <div
-      v-if="multiOmicsForm.omicsProcessingTypes.includes('mg')"
+      v-if="showDataCompatibilityQuestions && multiOmicsForm.omicsProcessingTypes.includes('mg')"
       class="v-label theme--light my-2 mx-8"
       style="font-size: 14px;"
     >
@@ -163,7 +167,7 @@ export default defineComponent({
       @change="handleMetatranscriptomeChange"
     />
     <div
-      v-if="multiOmicsForm.omicsProcessingTypes.includes('mt')"
+      v-if="showDataCompatibilityQuestions && multiOmicsForm.omicsProcessingTypes.includes('mt')"
       class="v-label theme--light my-2 mx-8"
       style="font-size: 14px;"
     >

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -314,11 +314,13 @@ export default defineComponent({
       <DataTypes
         v-if="multiOmicsForm.dataGenerated === false && multiOmicsForm.doe === false"
         legend="Which datatypes may be generated later?"
+        :show-data-compatibility-questions="false"
         @revalidate="revalidate"
       />
       <DataTypes
         v-if="multiOmicsForm.facilityGenerated === false"
         legend="Which datatypes were generated?"
+        :show-data-compatibility-questions="true"
         @revalidate="revalidate"
       />
       <div

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -18,6 +18,8 @@ import SubmissionPermissionBanner from './SubmissionPermissionBanner.vue';
 import DataTypes from './DataTypes.vue';
 import DoeFacility from './DoeFacility.vue';
 
+const OTHER = 'OTHER';
+
 export default defineComponent({
   components: {
     DataTypes,
@@ -32,23 +34,29 @@ export default defineComponent({
       formRef.value.validate();
     }
 
-    const projectAwardValidationRules = () => [(v: string) => {
-      const awardTypes = Object.values(AwardTypes) as string[];
-      const awardChosen = awardTypes.includes(v) || v === multiOmicsForm.otherAward;
-      const valid = awardChosen || multiOmicsForm.facilities.length === 0;
-      return valid || 'If submitting to a use facility, this field is required.';
-    }];
-    const otherAwardValidationRules = () => [(v: string | undefined) => {
-      if (v === undefined) {
-        return 'Please enter the kind of project award.';
-      }
-      const awardTypes = Object.values(AwardTypes) as string[];
-      if (multiOmicsForm.award && awardTypes.includes(multiOmicsForm.award)) {
+    const projectAwardValidationRules = () => [(v: string | undefined) => {
+      const facilityChosen = multiOmicsForm.facilities.length > 0;
+      if (!facilityChosen) {
         return true;
       }
-      const inputEmpty = v.trim().length === 0;
-      if (multiOmicsForm.facilities.length > 0) {
-        return !inputEmpty || 'Please enter the kind of project award.';
+      const awardChosen = v !== undefined;
+      if (!awardChosen) {
+        return 'If submitting to a use facility, this field is required.';
+      }
+      return true;
+    }];
+    const otherAwardValidationRules = () => [(v: string | undefined) => {
+      const facilityChosen = multiOmicsForm.facilities.length > 0;
+      const awardChosen = multiOmicsForm.award !== undefined;
+      if (!facilityChosen && !awardChosen) {
+        return true;
+      }
+      if (!awardChosen || multiOmicsForm.award !== OTHER) {
+        return true;
+      }
+      const inputEmpty = v === undefined || v.trim().length === 0;
+      if (inputEmpty) {
+        return 'Please enter the kind of project award.';
       }
       return true;
     }];
@@ -92,6 +100,7 @@ export default defineComponent({
     });
 
     return {
+      OTHER,
       addAwardDoi,
       removeAwardDoi,
       projectAwardValidationRules,
@@ -268,7 +277,7 @@ export default defineComponent({
         </div>
 
         <v-radio
-          :value="multiOmicsForm.otherAward"
+          :value="OTHER"
         >
           <template #label>
             <span class="mr-4">Other</span>
@@ -276,7 +285,7 @@ export default defineComponent({
               v-model="multiOmicsForm.otherAward"
               class="pa-0 ma-0"
               dense
-              hide-details
+              hide-details="auto"
               outlined
               :rules="otherAwardValidationRules()"
             />

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -305,10 +305,12 @@ export default defineComponent({
       <DataTypes
         v-if="multiOmicsForm.dataGenerated === false && multiOmicsForm.doe === false"
         legend="Which datatypes may be generated later?"
+        @revalidate="revalidate"
       />
       <DataTypes
         v-if="multiOmicsForm.facilityGenerated === false"
         legend="Which datatypes were generated?"
+        @revalidate="revalidate"
       />
       <div
         v-if="multiOmicsForm.facilities.includes('EMSL') || multiOmicsForm.facilities.includes('JGI')"


### PR DESCRIPTION
This is follow-on work to #1581 in order to finesse some of the validation logic of the multiomics form.

1. These changes ensure that we ask about non-user facility metagenome and metatranscriptome sequencing data, the compatibility questions are truly required. The gist of the fix is to add `:rules` to the relevant radio groups and to revalidate the form as new elements are added to it. I also updated the logic so that the answers the the "data compatible" and "data interleaved" questions are cleared when the related checkbox is unchecked.

| Before | After |
| --- | --- |
| <img width="1284" alt="image" src="https://github.com/user-attachments/assets/5a75dcad-469f-4aaa-a400-e8a1d12edc5b" /> | <img width="1284" alt="image" src="https://github.com/user-attachments/assets/857540d1-8b80-4908-a216-ad2a15dabb8e" /> |

2. These changes fix the validation logic around the "What kind of project have you been awarded?" question so that text field in the "Other" option is not in an error state by default. The fix involves disentangling the state attached to the text box and the checkbox (previously `multiOmicsForm.otherAward` was attached to _both_). 

| Before | After |
| --- | --- |
| <img width="1284" alt="image" src="https://github.com/user-attachments/assets/1c635580-05f3-47bc-912b-db230b4fa145" /> | <img width="1284" alt="image" src="https://github.com/user-attachments/assets/6261067d-7711-4db4-b97e-a158d55a7efa" /> |

3. These changes prevent the questions about data compatibility from being presented when the data have _not_ already been generated. This, at least, is what we said we'd do in the mockups.

| Before | After |
| --- | --- |
| <img width="1284" alt="image" src="https://github.com/user-attachments/assets/5393f6f9-e68a-48c8-a574-1384f1eabdfb" /> | <img width="1284" alt="image" src="https://github.com/user-attachments/assets/4c75c768-8a44-4695-8cd2-defccc30cb89" /> |

