### PR TITLE
Update multiomics form merge migrator to account for all remaining and new fields

### DIFF
--- a/nmdc_server/migrations/versions/cf73ba2f0f85_merge_context_multiomics.py
+++ b/nmdc_server/migrations/versions/cf73ba2f0f85_merge_context_multiomics.py
@@ -84,14 +84,17 @@ def upgrade():
             # Remove the obsoleted contextForm
             metadata_submission.pop("contextForm", None)
 
-            # Infer the value of the new `doe` field on the multiOmicsForm. This field captures whether samples will be
-            # submitted to a DOE user facility, if data has not already been generated for them.
+            # Infer the value of the new `doe` field on the multiOmicsForm. This field captures
+            # whether samples will be submitted to a DOE user facility, if data has not already
+            # been generated for them.
             data_generated = multiomics_form.get("dataGenerated")
             facilities = multiomics_form.get("facilities", [])
             omics_processing_types = multiomics_form.get("omicsProcessingTypes", [])
-            if data_generated == False and len(facilities) > 0:
+            if data_generated is False and len(facilities) > 0:
                 multiomics_form["doe"] = True
-            elif data_generated == False and any(t in omics_processing_types for t in ["mg", "mt", "mp", "mb", "nom"]):
+            elif data_generated is False and any(
+                t in omics_processing_types for t in ["mg", "mt", "mp", "mb", "nom"]
+            ):
                 multiomics_form["doe"] = False
 
         if metadata_submission.get("multiOmicsForm", None):

--- a/nmdc_server/migrations/versions/cf73ba2f0f85_merge_context_multiomics.py
+++ b/nmdc_server/migrations/versions/cf73ba2f0f85_merge_context_multiomics.py
@@ -69,16 +69,31 @@ def upgrade():
             context_form = metadata_submission.get("contextForm", {})
             multiomics_form = metadata_submission.get("multiOmicsForm", {})
 
-            multiomics_form.setdefault("datasetDoi", context_form.get("datasetDoi", ""))
+            # Copy values of fields that moved from contextForm to multiOmicsForm
+            multiomics_form.setdefault("award", context_form.get("award", None))
+            multiomics_form.setdefault("awardDois", context_form.get("awardDois", None))
             multiomics_form.setdefault("dataGenerated", context_form.get("dataGenerated", None))
+            multiomics_form.setdefault("facilities", context_form.get("facilities", None))
             multiomics_form.setdefault(
                 "facilityGenerated", context_form.get("facilityGenerated", None)
             )
-            multiomics_form.setdefault("facilities", context_form.get("facilities", []))
-            multiomics_form.setdefault("award", context_form.get("award", None))
-            multiomics_form.setdefault("otherAward", context_form.get("otherAward", ""))
+            multiomics_form.setdefault("otherAward", context_form.get("otherAward", None))
+            multiomics_form.setdefault("ship", context_form.get("ship", None))
+            multiomics_form.setdefault("unknownDoi", context_form.get("unknownDoi", None))
 
+            # Remove the obsoleted contextForm
             metadata_submission.pop("contextForm", None)
+
+            # Infer the value of the new `doe` field on the multiOmicsForm. This field captures whether samples will be
+            # submitted to a DOE user facility, if data has not already been generated for them.
+            data_generated = multiomics_form.get("dataGenerated")
+            facilities = multiomics_form.get("facilities", [])
+            omics_processing_types = multiomics_form.get("omicsProcessingTypes", [])
+            if data_generated == False and len(facilities) > 0:
+                multiomics_form["doe"] = True
+            elif data_generated == False and any(t in omics_processing_types for t in ["mg", "mt", "mp", "mb", "nom"]):
+                multiomics_form["doe"] = False
+
         if metadata_submission.get("multiOmicsForm", None):
             multiomics_form = metadata_submission.get("multiOmicsForm", {})
             study_form = metadata_submission.get("studyForm", {})
@@ -107,15 +122,18 @@ def downgrade():
             multiomics_form = metadata_submission.get("multiOmicsForm", {})
             context_form = {}
 
-            context_form["datasetDoi"] = multiomics_form.get("datasetDoi", "")
-            context_form["dataGenerated"] = multiomics_form.get("dataGenerated", None)
-            context_form["facilityGenerated"] = multiomics_form.get("facilityGenerated", None)
-            context_form["facilities"] = multiomics_form.get("facilities", [])
             context_form["award"] = multiomics_form.get("award", None)
+            context_form["awardDois"] = multiomics_form.get("awardDois", None)
+            context_form["dataGenerated"] = multiomics_form.get("dataGenerated", None)
+            context_form["facilities"] = multiomics_form.get("facilities", [])
+            context_form["facilityGenerated"] = multiomics_form.get("facilityGenerated", None)
             context_form["otherAward"] = multiomics_form.get("otherAward", "")
+            context_form["ship"] = multiomics_form.get("ship", None)
+            context_form["unknownDoi"] = multiomics_form.get("unknownDoi", None)
 
             metadata_submission["contextForm"] = context_form
 
+            multiomics_form.pop("doe", None)
         if metadata_submission.get("studyForm", None):
             study_form = metadata_submission.get("studyForm", {})
             multiomics_form = metadata_submission.get("multiOmicsForm", {})

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -177,7 +177,7 @@ export default defineComponent({
         />
       </v-radio-group>
       <div
-        v-if="multiOmicsForm.facilityGenerated"
+        v-if="multiOmicsForm.dataGenerated === true && multiOmicsForm.facilityGenerated"
       >
         <DoeFacility />
       </div>
@@ -293,7 +293,7 @@ export default defineComponent({
         </v-radio>
       </v-radio-group>
       <div
-        v-if="multiOmicsForm.doe"
+        v-if="multiOmicsForm.dataGenerated === false && multiOmicsForm.doe"
         class="pb-4"
       >
         <DoeFacility


### PR DESCRIPTION
Fixes #1596 

In the original implementation of the migrator for the merger of the context form and multiomics form, a few existing fields got dropped in the process. 

These changes update the migrator to:

* Carry forward the `awardDois`, `ship`, and `unknownDoi` fields from context form to multiomics form.
* Remove the reference to `datasetDoi`, which was removed from the context form some time ago (and replaced by `awardDois`).
* Attempt to populate the new multiomics form field (`doi`) based on existing data. 

I am editing the existing migrator instead of creating a new one because a new migrator wouldn't be able to recover fields from the `pop`'d `contextForm` field if it ran after this one.

The changes in `web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue` are because the old context form did not clear dependent fields as you made changes to your answers. That means you can have combinations of answers in existing data that _seem_ like they shouldn't be possible (e.g. `dataGenerated = false` and `facilityGenerated = true`). Those bad combinations shouldn't be possible with new submissions going forward, but they are there in existing data. The additional conditions here prevent certain sections from appearing when they shouldn't.

I will take care of manually working on the dev Postgres database to get this migration re-run there after it is merged in.