### PR TITLE
 Empty Data Sheet Validation/Warning

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -136,6 +136,7 @@ export default defineComponent({
     const snackbar = ref(false);
     const importErrorSnackbar = ref(false);
     const notImportedWorksheetNames = ref([] as string[]);
+    const emptySheetSnackbar = ref(false);
 
     watch(activeTemplate, () => {
       // WARNING: It's important to do the column settings update /before/ data. Otherwise,
@@ -259,7 +260,7 @@ export default defineComponent({
 
     async function validate() {
       const data = harmonizerApi.exportJson(); // Gets data from harmonizer API
-      
+
       // Check if the spreadsheet is empty
       const isEmpty = Object.keys(data).length === 0;
       // Update invalid cells if empty
@@ -273,7 +274,8 @@ export default defineComponent({
           [activeTemplateKey.value]: false,
         };
         snackbar.value = Object.values(tabsValidated.value).every((value) => value);
-        // maybe return message here?
+        emptySheetSnackbar.value = true;
+
         return;
       }
 
@@ -578,6 +580,7 @@ export default defineComponent({
       schemaLoading,
       importErrorSnackbar,
       notImportedWorksheetNames,
+      emptySheetSnackbar,
       isTestSubmission,
       /* methods */
       doSubmit,
@@ -630,6 +633,13 @@ export default defineComponent({
           timeout="5000"
         >
           The following worksheet names were not recognized: {{ notImportedWorksheetNames.join(', ') }}
+        </v-snackbar>
+        <v-snackbar
+          v-model="emptySheetSnackbar"
+          color="error"
+          timeout="5000"
+        >
+          The spreadsheet is empty. Please add data.
         </v-snackbar>
         <v-card
           v-if="validationErrorGroups.length"

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -258,7 +258,25 @@ export default defineComponent({
     }
 
     async function validate() {
-      const data = harmonizerApi.exportJson();
+      const data = harmonizerApi.exportJson(); // Gets data from harmonizer API
+      
+      // Check if the spreadsheet is empty
+      const isEmpty = Object.keys(data).length === 0;
+      // Update invalid cells if empty
+      if (isEmpty) {
+        invalidCells.value = {
+          ...invalidCells.value,
+          [activeTemplateKey.value]: data,
+        };
+        tabsValidated.value = {
+          ...tabsValidated.value,
+          [activeTemplateKey.value]: false,
+        };
+        snackbar.value = Object.values(tabsValidated.value).every((value) => value);
+        // maybe return message here?
+        return;
+      }
+
       mergeSampleData(activeTemplate.value.sampleDataSlot, data);
       const result = await harmonizerApi.validate();
       const valid = Object.keys(result).length === 0;


### PR DESCRIPTION
Closes #946 

Add to existing data sheet validation code to also check for an empty data sheet. If the data sheet is empty, a warning now flashes at the bottom of the screen warning the user that the submission sheet is empty. The 'Submit' button is also grayed-out until this is resolved. 

![image](https://github.com/user-attachments/assets/9e3c7a07-5c76-41f3-af0b-ec992afdf96c)
