### PR TITLE
1024 add env context term links

### DIFF
--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -86,9 +86,6 @@ export default defineComponent({
       ) {
         const item = props.item as BiosampleSearchResult;
         const env = item[field];
-        if (!env.id) {
-          return undefined;
-        }
         const request = `http://purl.obolibrary.org/obo/${env.id.replace(':', '_')}`;
         let apiUrl = '';
         if (env.id.startsWith('ENVO')) {
@@ -98,7 +95,7 @@ export default defineComponent({
         } else if (env.id.startsWith('UBERON')) {
           apiUrl = 'https://www.ebi.ac.uk/ols4/ontologies/uberon/classes/';
         }
-        return apiUrl ? `${apiUrl}${encodeURIComponent(request)}` : undefined;
+        return `${apiUrl}${encodeURIComponent(request)}`;
       }
       return undefined;
     }

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -86,8 +86,19 @@ export default defineComponent({
       ) {
         const item = props.item as BiosampleSearchResult;
         const env = item[field];
+        if (!env.id) {
+          return undefined;
+        }
         const request = `http://purl.obolibrary.org/obo/${env.id.replace(':', '_')}`;
-        return env.id ? `https://www.ebi.ac.uk/ols4/ontologies/envo/classes/${encodeURIComponent(request)}` : undefined;
+        let apiUrl = '';
+        if (env.id.startsWith('ENVO')) {
+          apiUrl = 'https://www.ebi.ac.uk/ols4/ontologies/envo/classes/';
+        } else if (env.id.startsWith('PO')) {
+          apiUrl = 'https://www.ebi.ac.uk/ols4/ontologies/po/classes/';
+        } else if (env.id.startsWith('UBERON')) {
+          apiUrl = 'https://www.ebi.ac.uk/ols4/ontologies/uberon/classes/';
+        }
+        return apiUrl ? `${apiUrl}${encodeURIComponent(request)}` : undefined;
       }
       return undefined;
     }

--- a/web/src/components/Presentation/AttributeItem.vue
+++ b/web/src/components/Presentation/AttributeItem.vue
@@ -79,6 +79,16 @@ export default defineComponent({
       if (field === 'study_id') {
         return `/details/study/${props.item.study_id}`;
       }
+      if (
+        field === 'env_broad_scale'
+          || field === 'env_local_scale'
+          || field === 'env_medium'
+      ) {
+        const item = props.item as BiosampleSearchResult;
+        const env = item[field];
+        const request = `http://purl.obolibrary.org/obo/${env.id.replace(':', '_')}`;
+        return env.id ? `https://www.ebi.ac.uk/ols4/ontologies/envo/classes/${encodeURIComponent(request)}` : undefined;
+      }
       return undefined;
     }
 

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -501,22 +501,22 @@ const fields: Record<string, FieldsData> = {
   /* END GOLD ecosystem type */
   /* MIxS Environmental Triad terms */
   env_broad_scale: {
+    icon: 'mdi-link',
     name: 'Broad-scale Environmental Context',
     group: 'MIxS Environmental Triad',
     sortKey: 1,
-    icon: 'mdi-link',
   },
   env_local_scale: {
+    icon: 'mdi-link',
     name: 'Local Environmental Context',
     group: 'MIxS Environmental Triad',
     sortKey: 2,
-    icon: 'mdi-link',
   },
   env_medium: {
+    icon: 'mdi-link',
     name: 'Environmental Medium',
     group: 'MIxS Environmental Triad',
     sortKey: 3,
-    icon: 'mdi-link',
   },
   open_in_gold: {
     icon: 'mdi-link',

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -504,16 +504,19 @@ const fields: Record<string, FieldsData> = {
     name: 'Broad-scale Environmental Context',
     group: 'MIxS Environmental Triad',
     sortKey: 1,
+    icon: 'mdi-link',
   },
   env_local_scale: {
     name: 'Local Environmental Context',
     group: 'MIxS Environmental Triad',
     sortKey: 2,
+    icon: 'mdi-link',
   },
   env_medium: {
     name: 'Environmental Medium',
     group: 'MIxS Environmental Triad',
     sortKey: 3,
+    icon: 'mdi-link',
   },
   open_in_gold: {
     icon: 'mdi-link',


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-server/issues/1024

Add hyperlinks to environmental context terms on the biosample pages.
Change the environmental context term icons from 'mdi-text' to 'mdi-link'.

Examples:
https://data.microbiomedata.org/details/sample/nmdc:bsm-11-6qgwc522
https://data.microbiomedata.org/details/sample/nmdc:bsm-11-jxa03j76

hyperlink for ENVO:00000446
https://www.ebi.ac.uk/ols4/ontologies/envo/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FENVO_00000446
hyperlink for PO:0025025
https://www.ebi.ac.uk/ols4/ontologies/po/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FPO_0025025
hyperlink for UBERON:0035118
https://www.ebi.ac.uk/ols4/ontologies/uberon/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FUBERON_0035118
