### PR TITLE
Add EMSL lipidomics as a datatype

### DIFF
--- a/web/src/views/SubmissionPortal/Components/DoeFacility.vue
+++ b/web/src/views/SubmissionPortal/Components/DoeFacility.vue
@@ -109,6 +109,13 @@ export default defineComponent({
 
       <v-checkbox
         v-model="multiOmicsForm.omicsProcessingTypes"
+        label="Lipidome"
+        value="lipidome-emsl"
+        :disabled="templateChoiceDisabled"
+        hide-details
+      />
+      <v-checkbox
+        v-model="multiOmicsForm.omicsProcessingTypes"
         label="Metaproteome"
         value="mp-emsl"
         :disabled="templateChoiceDisabled"

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -343,7 +343,8 @@ export default defineComponent({
         return false;
       }
       if (templateKey === EMSL) {
-        return row_types.includes('metaproteomics')
+        return row_types.includes('lipidomics')
+          || row_types.includes('metaproteomics')
           || row_types.includes('metabolomics')
           || row_types.includes('natural organic matter');
       }

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -232,6 +232,10 @@ const templateList = computed(() => {
       // Are you submitting samples to a DOE user facility? Yes
       if (multiOmicsForm.facilities.includes('EMSL')) {
         // Which facility? EMSL
+        if (multiOmicsForm.omicsProcessingTypes.includes('lipidome-emsl')) {
+          // Data types? Lipidome
+          templates.add(EMSL);
+        }
         if (multiOmicsForm.omicsProcessingTypes.includes('mp-emsl')) {
           // Data types? Metaproteome
           templates.add(EMSL);


### PR DESCRIPTION
Fixes #1602 

These changes:

1. Add a Lipidome checkbox to the EMSL section of the Multiomics form (`DoeFacility.vue`)
2. Show the EMSL tab when Lipidome is checked (`SubmissionPortal/store/index.ts`)
3. Show rows in the EMSL tab if they contain "lipidomics" in the analysis/data type column (`HarmonizerView.vue`)

Note that point 3 can't be tested until a version of `nmdc-submission-schema` that contains the `lipidomics` permissible value is released and integrated here. But that doesn't necessarily need to hold up getting these changes in.