### PR TITLE
Add fix for data harmonizer column visibility bug

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -154,6 +154,7 @@ export default defineComponent({
       }
       harmonizerApi.loadData(activeTemplateData.value);
       harmonizerApi.setInvalidCells(invalidCells.value[activeTemplateKey.value] || {});
+      harmonizerApi.changeVisibility(columnVisibility.value);
     });
 
     const validationErrors = computed(() => {
@@ -532,7 +533,6 @@ export default defineComponent({
       // When changing templates we may need to populate the common columns
       // from the environment tabs
       synchronizeTabData(nextTemplateKey);
-
       activeTemplateKey.value = nextTemplateKey;
       activeTemplate.value = nextTemplate;
       harmonizerApi.useTemplate(nextTemplate.schemaClass);


### PR DESCRIPTION
Resolves https://github.com/microbiomedata/nmdc-server/issues/935

This PR makes a small change to the data harmonizer to fix the above bug.
The screenshots below show the effect, the choice of column visibility is preserved through tab swap.

<img width="1760" alt="Screenshot 2025-04-15 at 12 19 43 PM" src="https://github.com/user-attachments/assets/7765e0fb-6a8f-41c7-b032-84b21bf8d0ad" />
<img width="1786" alt="Screenshot 2025-04-15 at 12 19 31 PM" src="https://github.com/user-attachments/assets/0cfccae1-0109-4afc-a8d7-bf36d8ebf2ae" />

The only change was adding another call to `harmonizerApi.changeVisibility`, the hard part was figuring out where to add it.