### PR TITLE
Avoid nginx rebuild by basing nmdc-server/client image off static older image

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,61 +1,3 @@
-FROM nginx:1.22-alpine as nginx_builder
-
-ENV ENABLED_MODULES=modzip
-RUN set -ex \
-    && if [ "$ENABLED_MODULES" = "" ]; then \
-        echo "No additional modules enabled, exiting"; \
-        exit 1; \
-    fi
-
-COPY ./nginx/ /modules/
-
-RUN set -ex \
-    && apk update \
-    && apk add linux-headers openssl-dev pcre-dev zlib-dev openssl abuild \
-               musl-dev libxslt libxml2-utils make mercurial gcc unzip git \
-               xz g++ \
-    # allow abuild as a root user \
-    && printf "#!/bin/sh\\n/usr/bin/abuild -F \"\$@\"\\n" > /usr/local/bin/abuild \
-    && chmod +x /usr/local/bin/abuild \
-    && hg clone -r ${NGINX_VERSION}-${PKG_RELEASE} https://hg.nginx.org/pkg-oss/ \
-    && cd pkg-oss \
-    && mkdir /tmp/packages \
-    && for module in $ENABLED_MODULES; do \
-        echo "Building $module for nginx-$NGINX_VERSION"; \
-        if [ -d /modules/$module ]; then \
-            echo "Building $module from user-supplied sources"; \
-            # check if module sources file is there and not empty
-            if [ ! -s /modules/$module/source ]; then \
-                echo "No source file for $module in modules/$module/source, exiting"; \
-                exit 1; \
-            fi; \
-            # some modules require build dependencies
-            if [ -f /modules/$module/build-deps ]; then \
-                echo "Installing $module build dependencies"; \
-                apk update && apk add $(cat /modules/$module/build-deps | xargs); \
-            fi; \
-            # if a module has a build dependency that is not in a distro, provide a
-            # shell script to fetch/build/install those
-            # note that shared libraries produced as a result of this script will
-            # not be copied from the builder image to the main one so build static
-            if [ -x /modules/$module/prebuild ]; then \
-                echo "Running prebuild script for $module"; \
-                /modules/$module/prebuild; \
-            fi; \
-            /pkg-oss/build_module.sh -v $NGINX_VERSION -f -y -o /tmp/packages -n $module $(cat /modules/$module/source); \
-        elif make -C /pkg-oss/alpine list | grep -E "^$module\s+\d+" > /dev/null; then \
-            echo "Building $module from pkg-oss sources"; \
-            cd /pkg-oss/alpine; \
-            make abuild-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-            apk add $(. ./abuild-module-$module/APKBUILD; echo $makedepends;); \
-            make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-            find ~/packages -type f -name "*.apk" -exec mv -v {} /tmp/packages/ \;; \
-        else \
-            echo "Don't know how to build $module module, exiting"; \
-            exit 1; \
-        fi; \
-    done
-
 FROM node:lts as build-stage
 ENV NODE_OPTIONS=--openssl-legacy-provider
 WORKDIR /app
@@ -64,18 +6,18 @@ RUN yarn install
 COPY . .
 RUN yarn run build
 
-
-FROM nginx:1.22-alpine as production-stage
+# Previously, we rebuilt nginx from source to add the mod_zip module. This rebuild process stopped working when nginx
+# shut down their Mercurial repo (used when building versions of nginx before 1.27) on April 17, 2025. However, using
+# the mod_zip module requires us to stay on nginx 1.22.
+#
+# The long-term solution is to find an alternative to mod_zip.
+#
+# The short-term solution is to build the nmdc-server/client image off of the last stable version of the
+# nmdc-server/client image (1.5.0). It has nginx 1.22.1 built with mod_zip already. Then we drop in the new
+# frontend code.
+FROM ghcr.io/microbiomedata/nmdc-server/client:1.5.0 as production-stage
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
-ENV ENABLED_MODULES=modzip
-COPY --from=nginx_builder /tmp/packages /tmp/packages
-RUN set -ex \
-    && for module in $ENABLED_MODULES; do \
-           apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
-       done \
-    && rm -rf /tmp/packages
-RUN rm -v /etc/nginx/nginx.conf
 ADD nginx.conf.template /etc/nginx/
 ADD start.sh /app/start.sh
 RUN chmod +x /app/start.sh


### PR DESCRIPTION
These changes avoid the rebuild of nginx to add the mod_zip module. As noted in the comments, we lost the ability to rebuild nginx 1.22. That's because nginx decomissioned the Mercurial repo which was required for the build process. 

These changes implement a very short-term bandaid of basing the `nmdc-server/client` image off of the last stable `nmdc-server/client` version -- which already has nginx built with mod_zip.

Thanks for the suggestion @aclum! It's a wild one, but it works.