### PR TITLE
Use zipstreamer for bulk downloads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,11 @@ services:
     ports:
       - "8080:80"
 
+  zipstreamer:
+    image: ghcr.io/scosman/packages/zipstreamer:stable
+    ports:
+      - "4008:4008"
+
 volumes:
   app-db-data:
   app-db-ingest:

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -684,13 +684,12 @@ async def get_data_object_aggregation(
 
 
 async def stream_zip_archive(zip_file_descriptor: Dict[str, Any]):
-    zip_streamer_url = "http://zipstreamer:4008/download"
-    chunk_size = 100
+    settings = Settings()
     async with httpx.AsyncClient() as client:
         async with client.stream(
-            "POST", zip_streamer_url, json=zip_file_descriptor
+            "POST", settings.zip_streamer_url, json=zip_file_descriptor
         ) as response:
-            async for chunk in response.aiter_bytes(chunk_size=chunk_size):
+            async for chunk in response.aiter_bytes(chunk_size=settings.zip_streamer_chunk_size):
                 yield chunk
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -689,14 +689,12 @@ async def stream_zip_archive(zip_file_descriptor: Dict[str, Any]):
     a ZIP archive in response, which this function yields in chunks.
     """
     settings = Settings()
-    async with httpx.AsyncClient() as client:
-        async with client.stream(
-            "POST", settings.zip_streamer_url, json=zip_file_descriptor
-        ) as response:
-            async for chunk in response.aiter_bytes(
-                chunk_size=settings.zip_streamer_chunk_size_bytes
-            ):
-                yield chunk
+    async with (
+        httpx.AsyncClient() as client,
+        client.stream("POST", settings.zip_streamer_url, json=zip_file_descriptor) as response,
+    ):
+        async for chunk in response.aiter_bytes(chunk_size=settings.zip_streamer_chunk_size_bytes):
+            yield chunk
 
 
 @router.get(

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -693,7 +693,9 @@ async def stream_zip_archive(zip_file_descriptor: Dict[str, Any]):
         async with client.stream(
             "POST", settings.zip_streamer_url, json=zip_file_descriptor
         ) as response:
-            async for chunk in response.aiter_bytes(chunk_size=settings.zip_streamer_chunk_size):
+            async for chunk in response.aiter_bytes(
+                chunk_size=settings.zip_streamer_chunk_size_bytes
+            ):
                 yield chunk
 
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -684,6 +684,10 @@ async def get_data_object_aggregation(
 
 
 async def stream_zip_archive(zip_file_descriptor: Dict[str, Any]):
+    r"""
+    Sends the specified `zip_file_descriptor` to ZipStreamer and receives
+    a ZIP archive in response, which this function yields in chunks.
+    """
     settings = Settings()
     async with httpx.AsyncClient() as client:
         async with client.stream(

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
 
     # for zipstreamer
     zip_streamer_url: str = "http://zipstreamer:4008/download"
-    zip_streamer_chunk_size: int = 512
+    zip_streamer_chunk_size_bytes: int = 2 * 1024 * 1024
 
     @property
     def orcid_openid_config_url(self) -> str:

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -41,6 +41,10 @@ class Settings(BaseSettings):
     orcid_client_secret: str = "oauth secret key"
     orcid_authorize_scope: str = "/authenticate"
 
+    # for zipstreamer
+    zip_streamer_url: str = "http://zipstreamer:4008/download"
+    zip_streamer_chunk_size: int = 512
+
     @property
     def orcid_openid_config_url(self) -> str:
         r"""

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -486,7 +486,7 @@ def create_bulk_download(
 
 
 def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
-    """Return a download table compatible with mod_zip."""
+    """Return a zip file descriptor compatible with zipstreamer."""
     bulk_download = db.query(models.BulkDownload).get(id)
     if bulk_download is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bulk download not found")

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -493,7 +493,7 @@ def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
     if bulk_download.expired:
         raise HTTPException(status_code=status.HTTP_410_GONE, detail="Bulk download expired")
     zip_file_descriptor: Dict[str, Any] = {"suggestedFilename": "archive.zip"}
-    files = []
+    file_descriptions: List[Dict[str, str]] = []
 
     for file in bulk_download.files:  # type: ignore
         data_object = file.data_object
@@ -501,9 +501,9 @@ def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
             logger.warning(f"Data object url for {file.path} was {data_object.url}")
             continue
 
-        files.append({"url": data_object.url, "zipPath": file.path})
+        file_descriptions.append({"url": data_object.url, "zipPath": file.path})
 
-    zip_file_descriptor["files"] = files
+    zip_file_descriptor["files"] = file_descriptions
 
     bulk_download.expired = True
     db.commit()

--- a/nmdc_server/data_object_filters.py
+++ b/nmdc_server/data_object_filters.py
@@ -1,32 +1,9 @@
-import re
 from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel
 
 from nmdc_server import models
-
-# Nginx's mod_zip can only server local files.  To get arround this limitation,
-# we set up local proxies to all remote hosts.
-#   https://www.nginx.com/resources/wiki/modules/zip/#remote-upstreams
-# This means that we can only handle known prefixes.  This must be checked
-# on ingest and any additional hosts added to the nginx config.
-# TODO: There is probably a way to automate this using nginx pattern matching.
-data_url_hosts = [
-    (re.compile("^https://data.microbiomedata.org(/data)?"), "/data"),
-    (re.compile("^https://nmdcdemo.emsl.pnnl.gov"), "/nmdcdemo"),
-    (re.compile("^https://portal.nersc.gov"), "/nerscportal"),
-    (re.compile("^https://storage.neonscience.org"), "/neonscience"),
-]
-
-
-def get_local_data_url(url: Optional[str]) -> Optional[str]:
-    if not url:
-        return None
-    for r, v in data_url_hosts:
-        if r.match(url):
-            return r.sub(v, url)
-    return None
 
 
 class WorkflowActivityTypeEnum(Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from factory import random
 from starlette.testclient import TestClient
 
+import nmdc_server.api
 from nmdc_server import database, schemas
 from nmdc_server.app import create_app
 from nmdc_server.auth import create_token_response
@@ -37,6 +38,14 @@ def patch_geo_engine(monkeypatch):
     monkeypatch.setattr(nmdc_geoloc_tools, "fao_soil_type", mock_not_implemented)
     monkeypatch.setattr(nmdc_geoloc_tools, "landuse", mock_not_implemented)
     monkeypatch.setattr(nmdc_geoloc_tools, "landuse_dates", mock_not_implemented)
+
+
+@pytest.fixture()
+def patch_zip_stream_service(monkeypatch):
+    def mock_zip_streamer(*args, **kwargs):
+        yield b"foo"
+
+    monkeypatch.setattr(nmdc_server.api, "stream_zip_archive", mock_zip_streamer)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -83,7 +83,9 @@ def test_generate_bulk_download(db: Session, client: TestClient, logged_in_user)
     assert resp.json()["count"] == 0
 
 
-def test_generate_bulk_download_filtered(db: Session, client: TestClient, logged_in_user):
+def test_generate_bulk_download_filtered(
+    db: Session, client: TestClient, logged_in_user, patch_zip_stream_service
+):
     sample = fakes.BiosampleFactory()
     op1 = fakes.OmicsProcessingFactory(biosample_inputs=[sample])
     fakes.OmicsProcessingFactory(biosample_inputs=[sample])
@@ -123,7 +125,6 @@ def test_generate_bulk_download_filtered(db: Session, client: TestClient, logged
     resp = client.get(f"/api/bulk_download/{id_}")
     del client.headers["Authorization"]
     assert resp.status_code == 200
-    assert b"/raw" not in resp.content and b"/metag" in resp.content
 
     # Verify that the bulk download cannot be accessed a second time
     resp = client.get(f"/api/bulk_download/{id_}")

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,61 +1,3 @@
-FROM nginx:1.22-alpine as nginx_builder
-
-ENV ENABLED_MODULES=modzip
-RUN set -ex \
-    && if [ "$ENABLED_MODULES" = "" ]; then \
-        echo "No additional modules enabled, exiting"; \
-        exit 1; \
-    fi
-
-COPY ./nginx/ /modules/
-
-RUN set -ex \
-    && apk update \
-    && apk add linux-headers openssl-dev pcre-dev zlib-dev openssl abuild \
-               musl-dev libxslt libxml2-utils make mercurial gcc unzip git \
-               xz g++ \
-    # allow abuild as a root user \
-    && printf "#!/bin/sh\\n/usr/bin/abuild -F \"\$@\"\\n" > /usr/local/bin/abuild \
-    && chmod +x /usr/local/bin/abuild \
-    && hg clone -r ${NGINX_VERSION}-${PKG_RELEASE} https://hg.nginx.org/pkg-oss/ \
-    && cd pkg-oss \
-    && mkdir /tmp/packages \
-    && for module in $ENABLED_MODULES; do \
-        echo "Building $module for nginx-$NGINX_VERSION"; \
-        if [ -d /modules/$module ]; then \
-            echo "Building $module from user-supplied sources"; \
-            # check if module sources file is there and not empty
-            if [ ! -s /modules/$module/source ]; then \
-                echo "No source file for $module in modules/$module/source, exiting"; \
-                exit 1; \
-            fi; \
-            # some modules require build dependencies
-            if [ -f /modules/$module/build-deps ]; then \
-                echo "Installing $module build dependencies"; \
-                apk update && apk add $(cat /modules/$module/build-deps | xargs); \
-            fi; \
-            # if a module has a build dependency that is not in a distro, provide a
-            # shell script to fetch/build/install those
-            # note that shared libraries produced as a result of this script will
-            # not be copied from the builder image to the main one so build static
-            if [ -x /modules/$module/prebuild ]; then \
-                echo "Running prebuild script for $module"; \
-                /modules/$module/prebuild; \
-            fi; \
-            /pkg-oss/build_module.sh -v $NGINX_VERSION -f -y -o /tmp/packages -n $module $(cat /modules/$module/source); \
-        elif make -C /pkg-oss/alpine list | grep -E "^$module\s+\d+" > /dev/null; then \
-            echo "Building $module from pkg-oss sources"; \
-            cd /pkg-oss/alpine; \
-            make abuild-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-            apk add $(. ./abuild-module-$module/APKBUILD; echo $makedepends;); \
-            make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
-            find ~/packages -type f -name "*.apk" -exec mv -v {} /tmp/packages/ \;; \
-        else \
-            echo "Don't know how to build $module module, exiting"; \
-            exit 1; \
-        fi; \
-    done
-
 FROM node:lts as build-stage
 ENV NODE_OPTIONS=--openssl-legacy-provider
 WORKDIR /app
@@ -65,16 +7,9 @@ COPY . .
 RUN yarn run build
 
 
-FROM nginx:1.22-alpine as production-stage
+FROM nginx:1.28-alpine as production-stage
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
-ENV ENABLED_MODULES=modzip
-COPY --from=nginx_builder /tmp/packages /tmp/packages
-RUN set -ex \
-    && for module in $ENABLED_MODULES; do \
-           apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
-       done \
-    && rm -rf /tmp/packages
 RUN rm -v /etc/nginx/nginx.conf
 ADD nginx.conf.template /etc/nginx/
 ADD start.sh /app/start.sh

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,3 +1,61 @@
+FROM nginx:1.22-alpine as nginx_builder
+
+ENV ENABLED_MODULES=modzip
+RUN set -ex \
+    && if [ "$ENABLED_MODULES" = "" ]; then \
+        echo "No additional modules enabled, exiting"; \
+        exit 1; \
+    fi
+
+COPY ./nginx/ /modules/
+
+RUN set -ex \
+    && apk update \
+    && apk add linux-headers openssl-dev pcre-dev zlib-dev openssl abuild \
+               musl-dev libxslt libxml2-utils make mercurial gcc unzip git \
+               xz g++ \
+    # allow abuild as a root user \
+    && printf "#!/bin/sh\\n/usr/bin/abuild -F \"\$@\"\\n" > /usr/local/bin/abuild \
+    && chmod +x /usr/local/bin/abuild \
+    && hg clone -r ${NGINX_VERSION}-${PKG_RELEASE} https://hg.nginx.org/pkg-oss/ \
+    && cd pkg-oss \
+    && mkdir /tmp/packages \
+    && for module in $ENABLED_MODULES; do \
+        echo "Building $module for nginx-$NGINX_VERSION"; \
+        if [ -d /modules/$module ]; then \
+            echo "Building $module from user-supplied sources"; \
+            # check if module sources file is there and not empty
+            if [ ! -s /modules/$module/source ]; then \
+                echo "No source file for $module in modules/$module/source, exiting"; \
+                exit 1; \
+            fi; \
+            # some modules require build dependencies
+            if [ -f /modules/$module/build-deps ]; then \
+                echo "Installing $module build dependencies"; \
+                apk update && apk add $(cat /modules/$module/build-deps | xargs); \
+            fi; \
+            # if a module has a build dependency that is not in a distro, provide a
+            # shell script to fetch/build/install those
+            # note that shared libraries produced as a result of this script will
+            # not be copied from the builder image to the main one so build static
+            if [ -x /modules/$module/prebuild ]; then \
+                echo "Running prebuild script for $module"; \
+                /modules/$module/prebuild; \
+            fi; \
+            /pkg-oss/build_module.sh -v $NGINX_VERSION -f -y -o /tmp/packages -n $module $(cat /modules/$module/source); \
+        elif make -C /pkg-oss/alpine list | grep -E "^$module\s+\d+" > /dev/null; then \
+            echo "Building $module from pkg-oss sources"; \
+            cd /pkg-oss/alpine; \
+            make abuild-module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
+            apk add $(. ./abuild-module-$module/APKBUILD; echo $makedepends;); \
+            make module-$module BASE_VERSION=$NGINX_VERSION NGINX_VERSION=$NGINX_VERSION; \
+            find ~/packages -type f -name "*.apk" -exec mv -v {} /tmp/packages/ \;; \
+        else \
+            echo "Don't know how to build $module module, exiting"; \
+            exit 1; \
+        fi; \
+    done
+
 FROM node:lts as build-stage
 ENV NODE_OPTIONS=--openssl-legacy-provider
 WORKDIR /app
@@ -6,18 +64,18 @@ RUN yarn install
 COPY . .
 RUN yarn run build
 
-# Previously, we rebuilt nginx from source to add the mod_zip module. This rebuild process stopped working when nginx
-# shut down their Mercurial repo (used when building versions of nginx before 1.27) on April 17, 2025. However, using
-# the mod_zip module requires us to stay on nginx 1.22.
-#
-# The long-term solution is to find an alternative to mod_zip.
-#
-# The short-term solution is to build the nmdc-server/client image off of the last stable version of the
-# nmdc-server/client image (1.5.0). It has nginx 1.22.1 built with mod_zip already. Then we drop in the new
-# frontend code.
-FROM ghcr.io/microbiomedata/nmdc-server/client:1.5.0 as production-stage
+
+FROM nginx:1.22-alpine as production-stage
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
+ENV ENABLED_MODULES=modzip
+COPY --from=nginx_builder /tmp/packages /tmp/packages
+RUN set -ex \
+    && for module in $ENABLED_MODULES; do \
+           apk add --no-cache --allow-untrusted /tmp/packages/nginx-module-${module}-${NGINX_VERSION}*.apk; \
+       done \
+    && rm -rf /tmp/packages
+RUN rm -v /etc/nginx/nginx.conf
 ADD nginx.conf.template /etc/nginx/
 ADD start.sh /app/start.sh
 RUN chmod +x /app/start.sh

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -1,4 +1,3 @@
-load_module modules/ngx_http_zip_module.so;
 worker_processes 1;
 
 events {
@@ -32,23 +31,6 @@ http {
             proxy_set_header Host ${DOLLAR}host;
             proxy_set_header X-Real-IP ${DOLLAR}remote_addr;
             proxy_set_header X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
-        }
-
-        location /data/ {
-            proxy_pass http://data:8080/;
-            proxy_buffering off;
-        }
-
-        location /nmdcdemo/ {
-            proxy_pass https://nmdcdemo.emsl.pnnl.gov/;
-        }
-
-        location /nerscportal {
-            proxy_pass https://portal.nersc.gov/;
-        }
-
-        location /neonscience {
-            proxy_pass https://storage.neonscience.org/;
         }
     }
 }


### PR DESCRIPTION
Fix #1587 

## Changes

### New service

Previously, our bulk download feature relied on an nginx plugin called [mod_zip](https://github.com/evanmiller/mod_zip). We have decided to try and move away from mod_zip, due to its need for file size information and trouble building with newer nginx releases. Due to previous experience with [zipstreamer](https://github.com/scosman/zipstreamer), we have decided to try using that as a replacement.

The default `docker-compose.yml` file has an additional service: zipstreamer. It is a microservice written in Go that can be used to build and stream a zip file given a list of URLs. Note that we will need to update the Rancher deployments to include this new service so that zip download works when this PR lands.

### Removal of `mod_zip`

Replacing mod_zip with zipstreamer was fairly plug-and-play. The major changes are that:

1. zipstreamer wants a manifest of files in a different format. Instead of a list, it wants a json blob
2. zipstreamer does not need all files to appear local. mod_zip needed the files to be from a single origin, and we had proxy configuration and string replacement logic to accommodate. this code has been removed
3. We now proxy the download through the `backend` service. Instead of returning a response with a special header that had meaning for mod_zip, we now reach to the `zipstreamer` service directly from `backend`, and stream the response to the client. Zipstreamer can also be configured to stream directly to the client, but that requires it to be exposed to the internet. The current implementation means it only needs to be accessible by the `backend` service. Since our application is running in an async manner with many workers, this proxying shouldn't be too much of an issue. If needed, we can move to the other model in the future.

The URL used by the backend, as well as the chunk size for streaming, are both configurable as environment variables. We should make sure to set:

`NMDC_ZIP_STREAMER_URL` and `NMDC_ZIP_STREAMER_CHUNK_SIZE_BYTES`

### Other changes
Since zipstreamer doesn't care about file size information, we can remove the warnings during ingest about missing file sizes. We can also remove the safeguards when building the manifest for the streaming service.

We no longer need to do an ouroborus-like build for our client image. We can go back to using a base nginx image - now updated (`1.22 -> 1.28`).

The function that actually does the request to zipstreamer during the bulk download process is mocked during testing.

Todo:

- [x] Update nginx base image version
- [x] Update ingest to no longer transform data object URLs (they don't need to be relative anymore)
- [x] Update ingest to no longer warn that data objects without a size can't be downloaded
- [x] Remove check for no size when building the zip streamer json blob (we can download those data objects now)