### PR TITLE
Refrain from trying to redeploy nonexistent deployment (`nmdc-sandbox`)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,12 +88,3 @@ jobs:
           method: POST
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
-
-      - name: Redeploy nmdc-sandbox:${{ matrix.deployment }}
-        if: ${{ env.IS_PROD_RELEASE == 'true' && env.IS_ORIGINAL_REPO == 'true' }}
-        uses: fjogeleit/http-request-action@v1
-        with:
-          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc-sandbox:${{ matrix.deployment }}?action=redeploy
-          method: POST
-          username: ${{ secrets.SPIN_USER }}
-          password: ${{ secrets.SPIN_PASSWORD }}


### PR DESCRIPTION
On this branch, I removed the part of the GHA workflow that tries to redeploy the data portal container images to the `nmdc-sandbox` namespace, which [doesn't exist anymore](https://github.com/microbiomedata/infra-admin/issues/185). Having this code snippet in place causes the GHA workflow to [fail](https://github.com/microbiomedata/nmdc-server/actions/runs/14717494539).