### PR TITLE
Update link colors to use an array and adjust chart height for better visibility

### DIFF
--- a/web/src/components/EcosystemSankey.vue
+++ b/web/src/components/EcosystemSankey.vue
@@ -86,7 +86,7 @@ export default Vue.extend({
     sankeyOptions() {
       return {
         // Make the chart height dependent on the number of nodes with a minimum of 500px
-        height: (this.sankeyData.length * 4 > 500 ? this.sankeyData.length * 4 : 500),
+        height: Math.max(this.sankeyData.length * 4, 500),
         sankey: {
           link: {
             colorMode: 'source',
@@ -96,7 +96,7 @@ export default Vue.extend({
             interactivity: true,
             // Array needs to be of substantial length so the lines do not become too pale to see
             // Uses 'primary' and primary.darken2 alternatingly
-            colors: Array.from({ length: 50 }, (_, i) => (i % 2 === 0 ? colors.primary : '#1c104e')),
+            colors: Array.from({ length: this.sankeyData.length / 2 }, (_, i) => (i % 2 === 0 ? colors.primary : '#1c104e')),
           },
         },
       };

--- a/web/src/components/EcosystemSankey.vue
+++ b/web/src/components/EcosystemSankey.vue
@@ -85,7 +85,8 @@ export default Vue.extend({
   computed: {
     sankeyOptions() {
       return {
-        height: 400,
+        // Make the chart height dependent on the number of nodes with a minimum of 500px
+        height: (this.sankeyData.length * 4 > 500 ? this.sankeyData.length * 4 : 500),
         sankey: {
           link: {
             colorMode: 'source',
@@ -93,7 +94,9 @@ export default Vue.extend({
           },
           node: {
             interactivity: true,
-            colors: colors.primary,
+            // Array needs to be of substantial length so the lines do not become too pale to see
+            // Uses 'primary' and primary.darken2 alternatingly
+            colors: Array.from({ length: 50 }, (_, i) => (i % 2 === 0 ? colors.primary : '#1c104e')),
           },
         },
       };

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -30,11 +30,20 @@ export default defineComponent({
 <template>
   <v-row>
     <v-col :cols="12">
-      <EcosystemSankey
-        :conditions="conditions"
-        style="width: 100%"
-        @selected="toggleConditions($event.conditions)"
-      />
+      <div
+        class="pr-2 overflow-y-auto overflow-x-hidden"
+        style="
+            height: 700px;
+            width: 100%;
+            max-width: 100%;
+          "
+      >
+        <EcosystemSankey
+          :conditions="conditions"
+          style="width: 100%"
+          @selected="toggleConditions($event.conditions)"
+        />
+      </div>
     </v-col>
   </v-row>
 </template>


### PR DESCRIPTION
Fixes #1575 
There were two things causing this issue. 

1. The chart was not big enough to show all of the nodes and links of the data. 
  - Solved with a responsive chart height based on the amount of data and implemented a min height
3. The Sankey chart uses a diminishing color scheme for the data links and the links quickly become 'invisible'
  - Solved by creating a substantial array of colors to minimize the shade diminishing
 

![Screenshot from 2025-05-05 14-32-33](https://github.com/user-attachments/assets/e8f85327-1205-4aa8-aa5a-6bed2c68adb3)

![image](https://github.com/user-attachments/assets/75769307-9b21-4d5b-a3dc-7cf4c9f8e4ab)
