### PR TITLE
Remove third party postgresql-action from CI workflow

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -25,18 +25,24 @@ jobs:
 
   server:
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        # This version is duplicated in the root docker-compose.yml
+        image: postgres:13
+        env:
+          POSTGRES_USER: nmdc
+          POSTGRES_PASSWORD: nmdc
+          POSTGRES_DB: nmdc
+        ports:
+          - 5432:5432
+
     strategy:
       max-parallel: 4
       matrix:
         python-version: [3.12]
 
     steps:
-    - uses: harmon758/postgresql-action@v1
-      with:
-        postgresql version: '12'
-        postgresql db: 'nmdc'
-        postgresql user: 'nmdc'
-        postgresql password: 'nmdc'
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: nginx
 
   db:
+    # This version is duplicated in the GitHub Actions workflow
     image: postgres:13
     volumes:
       - app-db-data:/var/lib/postgresql/data/pgdata


### PR DESCRIPTION
The official postgres docker image can be run with the first class services feature. See also
https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers.

This PR also upgrades CI to use postgres 13 to match the docker-compose setup.