### PR TITLE
Exclude data objects from the merge process

### DIFF
--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from sqlalchemy.orm import lazyload
 
 from nmdc_server import database, models
 from nmdc_server.celery_config import celery_app
@@ -92,7 +93,12 @@ def do_ingest(function_limit, skip_annotation):
             logger.info("Merging bulk_download")
             maybe_merge_download_artifact(ingest_db, prod_db.query(models.BulkDownload))
             logger.info("Merging bulk_download_data_object")
-            maybe_merge_download_artifact(ingest_db, prod_db.query(models.BulkDownloadDataObject))
+            maybe_merge_download_artifact(
+                ingest_db,
+                prod_db.query(models.BulkDownloadDataObject).options(
+                    lazyload(models.BulkDownloadDataObject.data_object)
+                ),
+            )
 
     logger.info("Ingest finished successfully")
 

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -881,7 +881,7 @@ class BulkDownloadDataObject(Base):
         BulkDownload, backref=backref("files", lazy="joined", cascade="all")
     )
     data_object = relationship(
-        DataObject, lazy="joined", cascade="all", backref="bulk_download_entities"
+        DataObject, lazy="joined", cascade="save-update,delete", backref="bulk_download_entities"
     )
 
 


### PR DESCRIPTION
Fix #1586 

### Background

Our postgres database contains tables that can be split into 2 main categories:
1. Tables populated via ingest (e.g. `biosample`)
2. Tables containing persistent data (e.g. `user_logins`)

This structure is non-trivial to support due to the fact that some of our persistent tables refer to rows (via foreign keys) in the "ingest" tables. These tables are important, because they track down load statistics. 

For a quick refresher on ingest, the first step is to call a custom function called `truncate`.

https://github.com/microbiomedata/nmdc-server/blob/55fe8daa6c7603244f6a382edde38aa937ddc0f7/nmdc_server/database.py#L177-L199

Then, tables in category (1) are populated using `pymongo`.

One of the last steps is to merge the active database with the ingest database.  We have an A/B database setup and perform a swap after ingest is complete. This merge step makes sure that any new persistent data (including downloads/bulk downloads) is kept up to date in the ingest database before the swap. Here is where we do the merging:

https://github.com/microbiomedata/nmdc-server/blob/55fe8daa6c7603244f6a382edde38aa937ddc0f7/nmdc_server/jobs.py#L89-L95

And here is the key function `maybe_merge_download_artifact`:

https://github.com/microbiomedata/nmdc-server/blob/55fe8daa6c7603244f6a382edde38aa937ddc0f7/nmdc_server/ingest/common.py#L66-L74

#### The problem
Calling `merge` on a `BulkDownloadDataObject` would CASCADE that merge to the related `DataObject`. This would not be a problem except that `DataObject`s can change from ingest to ingest. This default CASCADE behavior meant that changes to a `DataObject` with a particular ID would actually be reverted to the previous iteration during this reconciliation process. This also applies to deleted `DataObject`s. SQLAlchemy's `merge` would insert missing rows into the `data_object` table.

### Changes
All we need to do is make sure that we don't call `merge` with a loaded `DataObject`. To accomplish this, I've made two changes:
1. Update the `cascade` settings for the `data_object` relationship of `BulkDownloadDataObject`: I've removed `merge` from the list of operations that `cascade` applies to.
2. Update the query for `BulkDownloadDataObjects` at the end of ingest: This now passes an `option` to the query, forcing a `lazyload` of `BulkDownloadDataObject.data_object`. This prevents passing a `DataObject` to the `merge` call.
