### PR TITLE
Update `nmdc-schema` and `nmdc-submission-schema` each to version `11.7.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,15 @@ dependencies = [
     "jsonschema==4.23.0",
     "jsonschema-specifications==2024.10.1",
     "kombu==5.4.2",
-    "linkml==1.8.5",
+    # Notes:
+    # - Updated from `==1.8.5` to `==1.9.1` to be compatible with `nmdc-schema` version `11.7.0`.
+    # - Chose version `==1.9.1`, specifically, because that is what `nmdc-runtime` currently uses.
+    "linkml==1.9.1",
     "linkml-dataops==0.1.0",
-    "linkml-runtime==1.8.3",
+    # Notes:
+    # - Updated from `==1.8.3` to `==1.9.2` to be compatible with `linkml` version `1.9.1`.
+    # - Chose version `==1.9.2`, specifically, because that is what `nmdc-runtime` currently uses.
+    "linkml-runtime==1.9.2",
     "mako==1.3.5",
     "markdown==3.7",
     "markupsafe==3.0.1",
@@ -90,8 +96,8 @@ dependencies = [
     "mkdocs-redirects==1.2.1",
     "mypy==1.11.2",
     "mypy-extensions==1.0.0",
-    "nmdc-schema==11.6.1",
-    "nmdc-submission-schema==11.6.0",
+    "nmdc-schema==11.7.0",
+    "nmdc-submission-schema==11.7.0",
     "nmdc-geoloc-tools==0.2.0",
     "openpyxl==3.1.5",
     "packaging==24.1",

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "linkify-it": "^4.0.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
-    "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v11.6.1",
+    "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v11.7.0",
     "popper.js": "1.16.1",
     "protobufjs": "^6.11.3",
     "serialize-javascript": "^6.0.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7762,9 +7762,9 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-"nmdc-schema@https://github.com/microbiomedata/nmdc-schema#v11.6.1":
+"nmdc-schema@https://github.com/microbiomedata/nmdc-schema#v11.7.0":
   version "0.0.0"
-  resolved "https://github.com/microbiomedata/nmdc-schema#f13b5faa909fb777541239c28d0e8d151578faef"
+  resolved "https://github.com/microbiomedata/nmdc-schema#527f77329b48c1f7360cec0c153e8a119accc3ab"
 
 no-case@^2.2.0:
   version "2.3.2"


### PR DESCRIPTION
On this branch, I updated the `nmdc-schema` and `nmdc-submission-schema` dependencies to version `11.7.0` (of each one). I also updated two LinkML-related dependencies to versions that are compatible with `nmdc-schema` version `11.7.0`.

Fixes #1636 