### PR TITLE
Fix name and subtext in submission stepper

### DIFF
--- a/web/src/plugins/router.ts
+++ b/web/src/plugins/router.ts
@@ -77,7 +77,7 @@ const router = new VueRouter({
               component: MultiOmicsDataForm,
             },
             {
-              name: 'Environment Package',
+              name: 'Sample Environment',
               component: TemplateChooser,
               path: ':id/templates',
             },

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -395,7 +395,7 @@ export default defineComponent({
         color="primary"
         depressed
         :disabled="(!multiOmicsFormValid)"
-        :to="{ name: 'Environment Package' }"
+        :to="{ name: 'Sample Environment' }"
       >
         Go to next step
         <v-icon class="pl-1">

--- a/web/src/views/SubmissionPortal/Components/SubmissionStepper.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionStepper.vue
@@ -13,8 +13,8 @@ const StepperMap: Record<string | number, number | string> = {
   'Multiomics Form': 3,
   3: 'Multiomics Form',
 
-  'Environment Package': 4,
-  4: 'Environment Package',
+  'Sample Environment': 4,
+  4: 'Sample Environment',
 
   'Submission Sample Editor': 5,
   5: 'Submission Sample Editor',
@@ -85,8 +85,8 @@ export default defineComponent({
         :complete="4 < step"
         @click="gotoStep(4)"
       >
-        Environment Package
-        <small>Choose package type</small>
+        Sample Environment
+        <small>Choose MIxS Extension</small>
       </v-stepper-step>
       <v-divider />
       <v-stepper-step

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -928,7 +928,7 @@ export default defineComponent({
       <v-btn
         color="gray"
         depressed
-        :to="{ name: 'Environment Package' }"
+        :to="{ name: 'Sample Environment' }"
       >
         <v-icon class="pr-1">
           mdi-arrow-left-circle

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -189,7 +189,7 @@ function removeAwardDoi(i: number) {
 }
 
 /**
- * Environment Package Step
+ * Environmental Package Step
  */
 const packageName = ref([] as (keyof typeof HARMONIZER_TEMPLATES)[]);
 const templateList = computed(() => {


### PR DESCRIPTION
Currently step 4 on the stepper is labeled 'Environment package' with the subtext 'choose package type'.
This no longer matches the page's heading and subtext, so this PR changes the text in the stepper to match.
There is no related issue for this change.

Before:
<img width="230" alt="Screenshot 2025-05-14 at 10 29 15 AM" src="https://github.com/user-attachments/assets/ef0354e8-37da-4292-b73c-a3f5abbc5dc2" />

After:
<img width="224" alt="Screenshot 2025-05-14 at 10 26 52 AM" src="https://github.com/user-attachments/assets/807eddd3-f61e-421a-9b3d-71fd043fb6ba" />
