### PR TITLE
Also log the ZIP file descriptor and chunk number (to help with debuging)

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -692,13 +692,19 @@ async def stream_zip_archive(zip_file_descriptor: Dict[str, Any]):
     a ZIP archive in response, which this function yields in chunks.
     """
     settings = Settings()
-    logger.warning("Using zip streamer service to stream zip archive...")
+
+    # TODO: Consider lowering the "severity" of these `logger.warning` statements to `logger.debug`.
+    # Note: We added these statements to help with debugging in the Spin-hosted development environment.
+    logger.warning(f"Processing ZIP file descriptor: {zip_file_descriptor=}")
+    logger.warning("Using ZipStreamer service to stream ZIP archive...")
+    num_chunks_received = 0
     async with (
         httpx.AsyncClient() as client,
         client.stream("POST", settings.zip_streamer_url, json=zip_file_descriptor) as response,
     ):
         async for chunk in response.aiter_bytes(chunk_size=settings.zip_streamer_chunk_size_bytes):
-            message = f"Recieved a chunk of size {len(chunk)} from zipstreamer"
+            num_chunks_received += 1
+            message = f"Received chunk {num_chunks_received} from ZipStreamer. Size: {len(chunk)}"
             logger.warning(message)
             yield chunk
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -694,7 +694,7 @@ async def stream_zip_archive(zip_file_descriptor: Dict[str, Any]):
     settings = Settings()
 
     # TODO: Consider lowering the "severity" of these `logger.warning` statements to `logger.debug`.
-    # Note: We added these statements to help with debugging in the Spin-hosted development environment.
+    # Note: We added these statements to help with debugging when this functionality was new.
     logger.warning(f"Processing ZIP file descriptor: {zip_file_descriptor=}")
     logger.warning("Using ZipStreamer service to stream ZIP archive...")
     num_chunks_received = 0


### PR DESCRIPTION
I added two pieces of information to the logs
- the ZIP file descriptor (so we know what the backend is asking of ZipStreamer)
- the chunk number (to help us communicate with one another)