### PR TITLE
Allow specifying a host for NERSC data

### DIFF
--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     # for zipstreamer
     zip_streamer_url: str = "http://zipstreamer:4008/download"
     zip_streamer_chunk_size_bytes: int = 2 * 1024 * 1024
+    zip_streamer_nersc_data_host: str = "https://data.microbiomedata.org/data"
 
     @property
     def orcid_openid_config_url(self) -> str:

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -44,7 +44,7 @@ class Settings(BaseSettings):
     # for zipstreamer
     zip_streamer_url: str = "http://zipstreamer:4008/download"
     zip_streamer_chunk_size_bytes: int = 2 * 1024 * 1024
-    zip_streamer_nersc_data_host: str = "https://data.microbiomedata.org/data"
+    zip_streamer_nersc_data_base_url: str = "https://data.microbiomedata.org/data"
 
     @property
     def orcid_openid_config_url(self) -> str:

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -486,7 +486,12 @@ def create_bulk_download(
         raise
 
 
-def replace_nersc_data_host(url: str):
+def replace_nersc_data_host(url: str) -> str:
+    """
+    Updates NERSC URLs so they have the custom prefix defined in
+    an environment variable. This can be used to optimize the URLs
+    for HTTP clients that have direct access to the NERSC network.
+    """
     host_to_replace = r"^https://data.microbiomedata.org/data"
     replacement_host = Settings().zip_streamer_nersc_data_host
     if re.match(host_to_replace, url):

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -493,7 +493,7 @@ def replace_nersc_data_host(url: str) -> str:
     for HTTP clients that have direct access to the NERSC network.
     """
     host_to_replace = r"^https://data.microbiomedata.org/data"
-    replacement_host = Settings().zip_streamer_nersc_data_host
+    replacement_host = Settings().zip_streamer_nersc_data_base_url
     if re.match(host_to_replace, url):
         return re.sub(host_to_replace, replacement_host, url)
     return url


### PR DESCRIPTION
cc @shreddd 

Here is my idea for specifying an alternative host for data hosted at NERSC. We can use this to see if it makes any difference with zip download performance with zipstreamer.