### PR TITLE
Remove references to `nmdc-pilot` in configuration files and error messages

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nmdc-pilot",
+  "name": "nmdc-server",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -28,7 +28,7 @@
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but nmdc-pilot doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>This web application doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,5 +1,5 @@
 {
- "name": "App",
+ "name": "NMDC",
  "icons": [
   {
    "src": "\/android-icon-36x36.png",


### PR DESCRIPTION
I updated the JavaScript package name from `nmdc-pilot` to `nmdc-server` (to match the repo name). Other names that I'd be OK with include `nmdc-server-web-client` and `nmdc-portal-web-client`, for example.

I updated the `<noscript>` error message from saying `nmdc-pilot` to saying `this web application`. I also removed the "[We're sorry but](https://en.wikipedia.org/wiki/Non-apology_apology)."

Finally, I updated the PWA application name from `App` to `NMDC` (to match the HTML document title).

We can discuss with the product owner the topic of updating the HTML document title (and the PWA application name) to say something more descriptive than `NMDC` (I don't know the history of that string being used there).