### PR TITLE
Implement `/api/admin/stats` endpoint that returns number of user accounts

### DIFF
--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -145,6 +145,21 @@ def get_aggregation_summary(db: Session):
     )
 
 
+def get_admin_stats(
+    db: Session,
+) -> schemas.AdminStats:
+    r"""
+    Compiles statistics designed to be consumed by Data Portal/Submission Portal administrators.
+    """
+
+    distinct_orcids_subquery = db.query(func.distinct(models.User.orcid)).subquery()
+    num_distinct_orcids = db.query(func.count()).select_from(distinct_orcids_subquery).scalar()
+
+    return schemas.AdminStats(
+        num_user_accounts=num_distinct_orcids,
+    )
+
+
 def get_sankey_aggregation(
     db: Session,
     biosample_query: query.BiosampleQuerySchema,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -153,6 +153,22 @@ async def get_aggregated_stats(db: Session = Depends(get_db)):
     return crud.get_aggregated_stats(db)
 
 
+@router.get(
+    "/admin/stats",
+    response_model=schemas.AdminStats,
+    tags=["aggregation"],
+)
+async def get_admin_stats(
+    db: Session = Depends(get_db),
+    user: models.User = Depends(admin_required),
+):
+    r"""
+    Get statistics designed to be consumed by Data Portal/Submission Portal administrators.
+    """
+
+    return crud.get_admin_stats(db)
+
+
 @router.post(
     "/environment/sankey",
     response_model=List[schemas.EnvironmentSankeyAggregation],

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -70,6 +70,10 @@ def get_database_summary(db: Session) -> schemas.DatabaseSummary:
     )
 
 
+def get_admin_stats(db: Session) -> schemas.AdminStats:
+    return aggregations.get_admin_stats(db)
+
+
 def get_aggregated_stats(db: Session) -> schemas.AggregationSummary:
     return aggregations.get_aggregation_summary(db)
 

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -166,6 +166,12 @@ class AggregationSummary(BaseModel):
     organic_matter_characterization: int
 
 
+class AdminStats(BaseModel):
+    """Statistics designed for consumption by Data Portal/Submission Portal administrators."""
+
+    num_user_accounts: int
+
+
 class EnvironmentSankeyAggregation(BaseModel):
     count: int
     ecosystem: Optional[str] = None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from httpx import Response
 from sqlalchemy.orm.session import Session
+from starlette import status as http_status
 
 import nmdc_server
 from nmdc_server import fakes
@@ -105,6 +106,28 @@ def test_api_summary(db: Session, client: TestClient):
     data = resp.json()
     assert data["studies"] == 13
     assert data["non_parent_studies"] == 11  # excludes studies A and B
+
+
+def test_get_admin_stats_authorization(db: Session, client: TestClient, logged_in_user):
+    """This test demonstrates that non-admin users cannot access the endpoint."""
+
+    resp = client.get("/api/admin/stats")
+    assert_status(resp, http_status.HTTP_403_FORBIDDEN)
+
+
+def test_get_admin_stats(db: Session, client: TestClient, logged_in_admin_user):
+    # Seed the database.
+    for _ in range(10):
+        fakes.UserFactory()
+    db.commit()
+
+    # Submit the HTTP request.
+    resp = client.get("/api/admin/stats")
+
+    # Assert that the response meets our expectations.
+    # Note: The `logged_in_admin_user` fixture also created 1 User in the database.
+    assert_status(resp, http_status.HTTP_200_OK)
+    assert resp.json()["num_user_accounts"] == 11
 
 
 def test_get_pi_image(db: Session, client: TestClient):


### PR DESCRIPTION
On this branch, I implemented a new API endpoint: `GET /api/admin/stats`. The API endpoint is accessible to admins only. It returns a JSON object that currently has a single property: `num_user_accounts`.

The API endpoint was designed to be used by people that gather metrics for reports (the process they currently use involves going to Rancher to determine which Postgres database is "active," and then using a SQL client to query that database). Here is the SQL query they currently run (it is equivalent to the one that this endpoint runs):

```sql
SELECT count(*)
FROM (
    SELECT DISTINCT(orcid)
    FROM user_logins
) as distinct_orcids;
```