### PR TITLE
Update api/stats/ endpoint to sum file byte size if the DataObject is a WorkflowExecution ouput

### DIFF
--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -133,21 +133,72 @@ def get_aggregation_summary(db: Session):
     def count_wfe_output_data_size_bytes() -> int:
         r"""Returns the total size of WFE output data objects in bytes."""
         doj_outputs = set()
-        for t in table.workflow_execution_tables:
-            associated_table = models.output_association(t)
-            # Query output associations
-            print(associated_table.c[f"{t}_id"])
-            output_query = db.query(
-                associated_table.c["data_object_id"],
-            )
-            print(output_query)
-            doj_outputs.update(output_query)
-            print(doj_outputs)
+        
+        # Use the existing model relationships to get data objects
+        # Each workflow model has an 'outputs' relationship that links to DataObject
+        
+        # ReadsQC outputs
+        for reads_qc in db.query(models.ReadsQC).all():
+            for data_obj in reads_qc.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MetagenomeAssembly outputs
+        for mg_assembly in db.query(models.MetagenomeAssembly).all():
+            for data_obj in mg_assembly.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MetagenomeAnnotation outputs
+        for mg_annotation in db.query(models.MetagenomeAnnotation).all():
+            for data_obj in mg_annotation.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MetatranscriptomeAssembly outputs
+        for mt_assembly in db.query(models.MetatranscriptomeAssembly).all():
+            for data_obj in mt_assembly.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MetatranscriptomeAnnotation outputs
+        for mt_annotation in db.query(models.MetatranscriptomeAnnotation).all():
+            for data_obj in mt_annotation.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MetaproteomicAnalysis outputs
+        for mp_analysis in db.query(models.MetaproteomicAnalysis).all():
+            for data_obj in mp_analysis.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MAGsAnalysis outputs
+        for mags_analysis in db.query(models.MAGsAnalysis).all():
+            for data_obj in mags_analysis.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # NOMAnalysis outputs
+        for nom_analysis in db.query(models.NOMAnalysis).all():
+            for data_obj in nom_analysis.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # ReadBasedAnalysis outputs
+        for rb_analysis in db.query(models.ReadBasedAnalysis).all():
+            for data_obj in rb_analysis.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # MetabolomicsAnalysis outputs
+        for metabolomics in db.query(models.MetabolomicsAnalysis).all():
+            for data_obj in metabolomics.outputs:
+                doj_outputs.add(data_obj.id)
+        
+        # Metatranscriptome outputs
+        for metatranscriptome in db.query(models.Metatranscriptome).all():
+            for data_obj in metatranscriptome.outputs:
+                doj_outputs.add(data_obj.id)
+                
+        # Calculate the total size of all data objects
         sum = (
             q(func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)))
             .filter(models.DataObject.id.in_(doj_outputs))
             .scalar() or 0
-            )
+        )
+        
         return sum
 
     return schemas.AggregationSummary(

--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -134,8 +134,15 @@ def get_aggregation_summary(db: Session):
         r"""Returns the total size of WFE output data objects in bytes."""
         doj_outputs = set()
         for t in table.workflow_execution_tables:
-            t.model()  # Ensure the model is loaded
-            doj_outputs.update(t.model.has_outputs)
+            associated_table = models.output_association(t)
+            # Query output associations
+            print(associated_table.c[f"{t}_id"])
+            output_query = db.query(
+                associated_table.c["data_object_id"],
+            )
+            print(output_query)
+            doj_outputs.update(output_query)
+            print(doj_outputs)
         sum = (
             q(func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)))
             .filter(models.DataObject.id.in_(doj_outputs))

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -488,6 +488,7 @@ class DataObject(Base):
 
 # This is a base class for all workflow processing activities.
 # https://microbiomedata.github.io/nmdc-schema/WorkflowExecutionActivity.html
+# TODO : does this exist anymore?
 class PipelineStep:
     __tablename__ = "base_pipeline_step"
 
@@ -1015,3 +1016,8 @@ class InvalidatedToken(Base):
     __tablename__ = "invalidated_token"
 
     token = Column(String, primary_key=True)
+    
+    
+
+    
+

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1016,8 +1016,3 @@ class InvalidatedToken(Base):
     __tablename__ = "invalidated_token"
 
     token = Column(String, primary_key=True)
-    
-    
-
-    
-

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -164,7 +164,7 @@ class AggregationSummary(BaseModel):
     metabolomics: int
     lipodomics: int
     organic_matter_characterization: int
-
+    wfe_output_data_size_bytes: int
 
 class AdminStats(BaseModel):
     """Statistics designed for consumption by Data Portal/Submission Portal administrators."""

--- a/nmdc_server/schemas.py
+++ b/nmdc_server/schemas.py
@@ -166,6 +166,7 @@ class AggregationSummary(BaseModel):
     organic_matter_characterization: int
     wfe_output_data_size_bytes: int
 
+
 class AdminStats(BaseModel):
     """Statistics designed for consumption by Data Portal/Submission Portal administrators."""
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -10,7 +10,6 @@ from starlette import status as http_status
 
 import nmdc_server
 from nmdc_server import fakes
-from nmdc_server import table
 
 
 def assert_status(response: Response, status: int = 200):
@@ -90,9 +89,12 @@ def test_api_summary(db: Session, client: TestClient):
     wfe data size bytes test case:
     - here we test that the WFE data size is calculated correctly
     - we create 10 data objects with increasing file sizes (1 byte to 10 bytes)
-    - we associate these data objects with various workflow execution processes - this tests that data object from different processes are accounted for.
-    - we check that data object are not double counted through connecting the same data object to multiple processes
-    - we then check that the total size of the WFE output data is 55 bytes. this is the sum of the first 10 natural numbers (1 + 2 + ... + 10 = 55).
+    - we associate these data objects with various workflow execution processes
+        this tests that data object from different processes are accounted for.
+    - we check that data object are not double counted through connecting the
+        same data object to multiple processes
+    - we then check that the total size of the WFE output data is 55 bytes.
+        this is the sum of the first 10 natural numbers (1 + 2 + ... + 10 = 55).
     """
     # TODO: This would be better queried against the real data
     for i in range(10):
@@ -106,7 +108,7 @@ def test_api_summary(db: Session, client: TestClient):
         fake_meta_annotation.outputs = [data_object]
         fake_meta_assembly.outputs = [data_object]
         fake_meta_pro.outputs = [data_object]
-    
+
     # Create some additional, interrelated studies.
     # Note: The database already contains 10 studies at this point, created elsewhere.
     study_a = fakes.StudyFactory()


### PR DESCRIPTION
Added a slot in the response JSON called wfe_output_data_size_bytes that is the summed value of all DataObjects that come from WorkflowExecution processes. Incorporated tests associated with this process. 