### PR TITLE
Explicitly host the postgreSQL database on localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # Our MGA ingest makes some *very* large transactions
       - "max_wal_size=2GB"
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
 
   worker:
     image: ghcr.io/microbiomedata/nmdc-server/worker:main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       # Our MGA ingest makes some *very* large transactions
       - "max_wal_size=2GB"
     ports:
+      # We specify `127.0.0.1` here so that other computers on the same LAN cannot
+      # access the container, even when the host's firewall is configured to allow
+      # incoming connections to Docker.
+      # Reference: https://github.com/compose-spec/compose-spec/blob/main/spec.md#short-syntax-3
       - "127.0.0.1:5432:5432"
 
   worker:


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/nmdc-server/issues/1676

I believe this should fix the issue causing the PostgreSQL database to be exposed on the LBNL network when spinning up the docker stack onsite at LBNL. Can confirm the stack still works as expected with this change.