### PR TITLE
Fix bar chart and search results containers border cutoff

### DIFF
--- a/web/src/components/Presentation/FacetBarChart.vue
+++ b/web/src/components/Presentation/FacetBarChart.vue
@@ -155,20 +155,12 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="bar-chart">
-    <GChart
-      ref="chartRef"
-      type="BarChart"
-      :data="chartData"
-      :options="barChartOptions"
-      :events="chartEvents"
-    />
-  </div>
+  <GChart
+    ref="chartRef"
+    type="BarChart"
+    class="rounded overflow-hidden"
+    :data="chartData"
+    :options="barChartOptions"
+    :events="chartEvents"
+  />
 </template>
-
-<style lang="scss" scoped>
-.bar-chart {
-  border-radius: 4px;
-  overflow: hidden;
-}
-</style>

--- a/web/src/components/Presentation/FacetBarChart.vue
+++ b/web/src/components/Presentation/FacetBarChart.vue
@@ -155,11 +155,20 @@ export default defineComponent({
 </script>
 
 <template>
-  <GChart
-    ref="chartRef"
-    type="BarChart"
-    :data="chartData"
-    :options="barChartOptions"
-    :events="chartEvents"
-  />
+  <div class="bar-chart">
+    <GChart
+      ref="chartRef"
+      type="BarChart"
+      :data="chartData"
+      :options="barChartOptions"
+      :events="chartEvents"
+    />
+  </div>
 </template>
+
+<style lang="scss" scoped>
+.bar-chart {
+  border-radius: 4px;
+  overflow: hidden;
+}
+</style>

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -144,3 +144,10 @@ export default defineComponent({
     </v-list>
   </div>
 </template>
+
+<style lang="scss" scoped>
+.v-sheet.v-list {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+</style>

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -78,7 +78,10 @@ export default defineComponent({
         @input="$emit('set-items-per-page', $event)"
       />
     </div>
-    <v-list dense>
+    <v-list
+      dense
+      class="rounded-b"
+    >
       <template
         v-for="(result, resultIndex) in results"
       >
@@ -144,10 +147,3 @@ export default defineComponent({
     </v-list>
   </div>
 </template>
-
-<style lang="scss" scoped>
-.v-sheet.v-list {
-  border-bottom-left-radius: 4px;
-  border-bottom-right-radius: 4px;
-}
-</style>


### PR DESCRIPTION
Fixes #1081 

This addresses an issue causing the border corners to be clipped by a pixel in the bar chart and search results. The bar chart issue is fixed by adding a wrapper element to the chart and hiding its overflow. The search result issue is fixed by ensuring the `v-list` bottom borders also have a border radius of 4px to match the wrapping panel.