### PR TITLE
Fix validation checking for environment tabs

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -340,7 +340,6 @@ export default defineComponent({
           // If we found the template, synchronize the data
           // Make sure we carry the deletion through to the sampleData
           // The current tab's data needs to be updated first, then synchronized
-          //POSSIBLE CHANGE HERE
           synchronizeTabData(templateKey);
         }
       });

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -287,11 +287,15 @@ export default defineComponent({
               newRow[col] = row[col];
             });
             nextData[templateSlot].push(newRow);
+            //update validation status for the tab, if data changed it needs to be revalidated
+            tabsValidated.value[templateKey] = false;
           }
           if (existing) {
             COMMON_COLUMNS.forEach((col) => {
               existing[col] = row[col];
             });
+            //update validation status for the tab, if data changed it needs to be revalidated
+            tabsValidated.value[templateKey] = false;
           }
         });
       });
@@ -302,6 +306,8 @@ export default defineComponent({
           if (!rowIsVisibleForTemplate(row, templateKey)) {
             return false;
           }
+          //update validation status for the tab, if data changed it needs to be revalidated
+          tabsValidated.value[templateKey] = false;
           const rowId = row[SCHEMA_ID];
           return environmentSlots.some((environmentSlot) => {
             const environmentRow = nextData[environmentSlot as string].findIndex((r) => r[SCHEMA_ID] === rowId);
@@ -334,6 +340,7 @@ export default defineComponent({
           // If we found the template, synchronize the data
           // Make sure we carry the deletion through to the sampleData
           // The current tab's data needs to be updated first, then synchronized
+          //POSSIBLE CHANGE HERE
           synchronizeTabData(templateKey);
         }
       });


### PR DESCRIPTION
resolves https://github.com/microbiomedata/issues/issues/1209

To summarize the issue, currently if you validate a facility tab and then add data to another tab that populates those tabs their validation status doesn't update, even if the data added to those tabs is invalid, and you can submit.

This sets the validation status of facility tabs to false when a change is propagated to them from another tab.