### PR TITLE
1683 fix name filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ __pycache__/
 vetur.config.js
 **.local**
 build/**
-data/
+data/**

--- a/web/src/data/protobuf-descriptor.json
+++ b/web/src/data/protobuf-descriptor.json
@@ -81,7 +81,9 @@
                 "env_local_scale": 19,
                 "env_medium": 20,
                 "multiomics": 21,
-                "name": 22
+                "name": 22,
+                "description": 23,
+                "title": 24
               }
             }
           }

--- a/web/src/data/protobuf-descriptor.json
+++ b/web/src/data/protobuf-descriptor.json
@@ -40,7 +40,8 @@
                 ">": 4,
                 ">=": 5,
                 "!=": 6,
-                "has": 7
+                "has": 7,
+                "like": 8
               }
             },
             "Table": {
@@ -79,7 +80,8 @@
                 "env_broad_scale": 18,
                 "env_local_scale": 19,
                 "env_medium": 20,
-                "multiomics": 21
+                "multiomics": 21,
+                "name": 22
               }
             }
           }


### PR DESCRIPTION
fixes #1683 
To fix the issue found in #1683 the field 'name' and the operator 'like' needed to be added to the protobuf descriptor. 
While testing I realized the 'description' and 'title' fields were both missing as well. It appears as though all other operators are accounted for.