### PR TITLE
Let long numbers overflow instead of wrap in map markers

### DIFF
--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -179,6 +179,7 @@ export default defineComponent({
         height: `${height}px`,
         width: '100%',
         zIndex: 1,
+        overflowWrap: 'normal',
       }"
       @update:bounds="mapProps.bounds = $event"
     >


### PR DESCRIPTION
Fix #1605 

Map with fix applied:

<img width="659" height="394" alt="image" src="https://github.com/user-attachments/assets/1675ddaa-784b-46a3-95f4-8b127555e3f3" />
