### PR TITLE
Update doi regex to match schema

### DIFF
--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -195,7 +195,7 @@ function removeAwardDoi(i: number) {
 }
 
 function checkDoiFormat(v: string) {
-  const valid = /^(?:doi:)?10.\d{2,9}.*$/.test(v);
+  const valid = /^(?:doi:)?10.\d{2,9}\/.*$/.test(v);
   return valid;
 }
 


### PR DESCRIPTION
There was a small error in the regex enforcing the DOI rules
Previously it was `^(?:doi:)?10.\d{2,9}.*$` while the nmdc schema had the regex `^doi:10.\d{2,9}/.*$` (note the missing `/` after `{2,9}`)
This PR updates the doi to match the schema. The new version is `^(?:doi:)?10.\d{2,9}\/.*$`