### PR TITLE
1476 support amplicon data

### DIFF
--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -215,17 +215,20 @@ with m as (select
     bit_or(
         case
             when op.annotations->>'omics_type' = 'Metabolomics' then
-                b'{MultiomicsValue.mb.value:06b}'
+                b'{MultiomicsValue.mb.value:07b}'
             when op.annotations->>'omics_type' = 'Metagenome' then
-                b'{MultiomicsValue.mg.value:06b}'
+                b'{MultiomicsValue.mg.value:07b}'
             when op.annotations->>'omics_type' = 'Proteomics' then
-                b'{MultiomicsValue.mp.value:06b}'
+                b'{MultiomicsValue.mp.value:07b}'
             when op.annotations->>'omics_type' = 'Metatranscriptome' then
-                b'{MultiomicsValue.mt.value:06b}'
+                b'{MultiomicsValue.mt.value:07b}'
             when op.annotations->>'omics_type' = 'Organic Matter Characterization' then
-                b'{MultiomicsValue.om.value:06b}'
+                b'{MultiomicsValue.om.value:07b}'
             when op.annotations->>'omics_type' = 'Lipidomics' then
-                b'{MultiomicsValue.li.value:06b}'
+                b'{MultiomicsValue.li.value:07b}'
+            when op.annotations->>'omics_type' = 'Amplicon' then
+                b'{MultiomicsValue.am.value:07b}'
+
         end
     )::integer as multiomics
 from biosample b
@@ -241,17 +244,19 @@ with m as (select
     bit_or(
         case
             when op.annotations->>'omics_type' = 'Metabolomics' then
-                b'{MultiomicsValue.mb.value:06b}'
+                b'{MultiomicsValue.mb.value:07b}'
             when op.annotations->>'omics_type' = 'Metagenome' then
-                b'{MultiomicsValue.mg.value:06b}'
+                b'{MultiomicsValue.mg.value:07b}'
             when op.annotations->>'omics_type' = 'Proteomics' then
-                b'{MultiomicsValue.mp.value:06b}'
+                b'{MultiomicsValue.mp.value:07b}'
             when op.annotations->>'omics_type' = 'Metatranscriptome' then
-                b'{MultiomicsValue.mt.value:06b}'
+                b'{MultiomicsValue.mt.value:07b}'
             when op.annotations->>'omics_type' = 'Organic Matter Characterization' then
-                b'{MultiomicsValue.om.value:06b}'
+                b'{MultiomicsValue.om.value:07b}'
             when op.annotations->>'omics_type' = 'Lipidomics' then
-                b'{MultiomicsValue.li.value:06b}'
+                b'{MultiomicsValue.li.value:07b}'
+            when op.annotations->>'omics_type' = 'Amplicon' then
+                b'{MultiomicsValue.am.value:07b}'
         end
     )::integer as multiomics
 from study s

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -32,6 +32,8 @@ omics_types = {
     "nom": "Organic Matter Characterization",
     "lipidome": "Lipidomics",
     "lipidomics": "Lipidomics",
+    "amplicon_sequencing_assay": "Amplicon",
+    "amplicon": "Amplicon",
 }
 
 

--- a/nmdc_server/multiomics.py
+++ b/nmdc_server/multiomics.py
@@ -3,9 +3,10 @@ from enum import Enum
 
 #: Bitmasks for omics types (see database.update_multiomics_sql)
 class MultiomicsValue(Enum):
-    mb = 0b100000
-    mg = 0b010000
-    mp = 0b001000
-    mt = 0b000100
-    om = 0b000010
-    li = 0b000001
+    mb = 0b1000000
+    mg = 0b0100000
+    mp = 0b0010000
+    mt = 0b0001000
+    om = 0b0000100
+    li = 0b0000010
+    am = 0b0000001

--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -39,7 +39,7 @@ export default defineComponent({
     };
     const fontSize = 12;
 
-    const setOrder = ['MG', 'MT', 'MP', 'MB', 'NOM', 'LIP'];
+    const setOrder = ['MG', 'MT', 'MP', 'MB', 'NOM', 'LIP', 'AMP'];
     const Samples = 'Samples';
     const Studies = 'Studies';
     const seriesTitles = [Samples, Studies];

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -232,20 +232,23 @@ function makeSetsFromBitmask(mask_str: string) {
   if ((1 << 1) & mask) {
     sets.push('NOM');
   }
-  if ((1 << 5) & mask) {
+  if ((1 << 6) & mask) {
     sets.push('MB');
   }
-  if ((1 << 3) & mask) {
+  if ((1 << 4) & mask) {
     sets.push('MP');
   }
-  if ((1 << 2) & mask) {
+  if ((1 << 3) & mask) {
     sets.push('MT');
   }
-  if ((1 << 4) & mask) {
+  if ((1 << 5) & mask) {
     sets.push('MG');
   }
-  if (1 & mask) {
+  if ((1 << 2) & mask) {
     sets.push('LIP');
+  }
+  if (1 & mask) {
+    sets.push('AMP');
   }
   return sets;
 }

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -40,6 +40,7 @@ const staticUpsetTooltips = {
   MT: 'Metatranscriptomics',
   NOM: 'Natural Organic Matter',
   LIP: 'Lipidomics',
+  AMP: 'Amplicon',
 };
 
 export default defineComponent({


### PR DESCRIPTION
closes #1476
Adds support for Amplicon data. If ingesting from dev there should be 1 amplicon sample that appears in the box chart, upset plot and sample table.

<img width="1796" height="625" alt="image" src="https://github.com/user-attachments/assets/270c6158-d6d4-4066-ba4c-5944c5e73ba7" />
