### PR TITLE
Add search functionality for users table

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1475,7 +1475,7 @@ async def get_users(
     search_filter: Optional[str] = None,
 ):
     users = db.query(User)
-    if type(search_filter) is str:
+    if search_filter:
         users = users.filter(
             (
                 models.User.name.ilike(f"%{search_filter}%")

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1,7 +1,6 @@
 import csv
 import json
 import logging
-import re
 import time
 from importlib import resources
 from io import BytesIO, StringIO
@@ -1477,12 +1476,12 @@ async def get_users(
 ):
     users = db.query(User)
     if type(search_filter) is str:
-        if re.match(
-            r"^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$", search_filter
-        ):  # if search_filter is patterned like an ORCID then filter on that
-            users = users.filter(models.User.orcid == search_filter)
-        else:  # otherwise filter by name
-            users = users.filter(models.User.name.ilike(f"%{search_filter}%"))
+        users = users.filter(
+            (
+                models.User.name.ilike(f"%{search_filter}%")
+                | models.User.orcid.ilike(f"%{search_filter}%")
+            )
+        )
 
     return pagination.response(users)
 

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -685,11 +685,12 @@ async function me(): Promise<User | null> {
   }
 }
 
-async function getAllUsers(params: SearchParams) {
+async function getAllUsers(params: SearchParams, input_search_filter: String | null) {
   const { data } = await client.get<SearchResponse<User>>('users', {
     params: {
       limit: params.limit,
       offset: params.offset,
+      search_filter: input_search_filter,
     },
   });
   return data;

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -685,12 +685,12 @@ async function me(): Promise<User | null> {
   }
 }
 
-async function getAllUsers(params: SearchParams, input_search_filter: String | null) {
+async function getAllUsers(params: SearchParams, searchFilter: string) {
   const { data } = await client.get<SearchResponse<User>>('users', {
     params: {
       limit: params.limit,
       offset: params.offset,
-      search_filter: input_search_filter,
+      search_filter: searchFilter,
     },
   });
   return data;

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -246,7 +246,10 @@ export default defineComponent({
               class="my-3"
             >
               <v-tab-item key="omics">
-                <BiosampleVisGroup :conditions="gatedOmicsVisConditions" :vistab="vistab" />
+                <BiosampleVisGroup
+                  :conditions="gatedOmicsVisConditions"
+                  :vistab="vistab"
+                />
               </v-tab-item>
               <v-tab-item key="environments">
                 <EnvironmentVisGroup :conditions="gatedEnvironmentVisConditions" />

--- a/web/src/views/User/UserPage.vue
+++ b/web/src/views/User/UserPage.vue
@@ -18,7 +18,7 @@ export default defineComponent({
       page: 1,
       itemsPerPage,
     });
-    const search_filter = ref(null);
+    const searchFilter = ref('');
     const headers : DataTableHeader[] = [
       {
         text: 'ORCID',
@@ -31,12 +31,12 @@ export default defineComponent({
     ];
 
     async function getUsers(params: SearchParams): Promise<SearchResponse<User>> {
-      return api.getAllUsers(params, search_filter.value);
+      return api.getAllUsers(params, searchFilter.value);
     }
 
     const users = usePaginatedResults(ref([]), getUsers, ref([]), itemsPerPage);
     watch(options, () => users.setPage(options.value.page), { deep: true });
-    watch(search_filter, () => users.setPage(options.value.page), { deep: true });
+    watch(searchFilter, () => users.setPage(options.value.page), { deep: true });
 
     async function updateAdminStatus(item: User) {
       await api.updateUser(item.id, item);
@@ -48,7 +48,7 @@ export default defineComponent({
       updateAdminStatus,
       options,
       currentUser,
-      search_filter,
+      searchFilter,
     };
   },
 });
@@ -63,7 +63,7 @@ export default defineComponent({
           Users
         </v-card-title>
         <v-text-field
-          v-model="search_filter"
+          v-model="searchFilter"
           label="Search Users"
           class="mb-2"
           outlined

--- a/web/src/views/User/UserPage.vue
+++ b/web/src/views/User/UserPage.vue
@@ -36,7 +36,10 @@ export default defineComponent({
 
     const users = usePaginatedResults(ref([]), getUsers, ref([]), itemsPerPage);
     watch(options, () => users.setPage(options.value.page), { deep: true });
-    watch(searchFilter, () => { options.value.page = 1; users.setPage(options.value.page); }, { deep: true });
+    watch(searchFilter, () => {
+      options.value.page = 1;
+      users.setPage(options.value.page);
+    }, { deep: true });
 
     async function updateAdminStatus(item: User) {
       await api.updateUser(item.id, item);

--- a/web/src/views/User/UserPage.vue
+++ b/web/src/views/User/UserPage.vue
@@ -36,7 +36,7 @@ export default defineComponent({
 
     const users = usePaginatedResults(ref([]), getUsers, ref([]), itemsPerPage);
     watch(options, () => users.setPage(options.value.page), { deep: true });
-    watch(searchFilter, () => users.setPage(options.value.page), { deep: true });
+    watch(searchFilter, () => { options.value.page = 1; users.setPage(options.value.page); }, { deep: true });
 
     async function updateAdminStatus(item: User) {
       await api.updateUser(item.id, item);


### PR DESCRIPTION
This PR resolves https://github.com/microbiomedata/nmdc-server/issues/1673

New code here adds a search box to the Users page to allow filtering based on name or ORCID.
If something matching the ORCID RE pattern is entered into the box then it will search for that, otherwise it defaults to user name.

@naglepuff I haven't done any real formatting on the search box to make it look nice, I was hoping for an initial bit of feedback on functionality before that. Mostly I was wondering if we wanted something like a toggle button to filter based on admin status.

Examples:
<img width="1237" height="348" alt="Screenshot 2025-08-04 at 12 28 53 PM" src="https://github.com/user-attachments/assets/888bab2e-13d7-4a81-b868-e21537994307" />
<img width="1262" height="341" alt="Screenshot 2025-08-04 at 12 28 37 PM" src="https://github.com/user-attachments/assets/8a34ac81-510b-4bc8-a751-39a3080fe784" />
<img width="1269" height="311" alt="Screenshot 2025-08-04 at 12 28 28 PM" src="https://github.com/user-attachments/assets/e7e04df0-2bf0-4efb-8aa2-8202e33ce4b5" />
