### PR TITLE
Fix wrong sample list results from SQLAlchemy orm query

### DIFF
--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -846,7 +846,7 @@ class BiosampleQuerySchema(BaseQuerySchema):
         biosample_query = (
             db.query(model)
             .join(subquery, model.id == subquery.c.id)  # type: ignore
-            .order_by(desc(self.table.model.multiomics))  # type: ignore
+            .order_by(self.table.model.name, self.table.model.id)  # type: ignore
         )
 
         if prefetch_omics_processing_data:


### PR DESCRIPTION
Closes https://github.com/microbiomedata/issues/issues/1134

The problem is in Biosample query ORDER BY clause (order_by(desc(self.table.model.multiomics))). The 'multiomics' is not a unique column.

Solution:
Order by a unique column or a combination of columns that guarantees uniqueness.

Not sure ordering by name is better?
order_by(self.table.model.name, self.table.model.id)
