### PR TITLE
Make Krona plots viewable in data portal

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -616,6 +616,25 @@ async def download_data_object(
     }
 
 
+@router.get("/data_object/{data_object_id}/get_html_content_url")
+async def get_data_object_html_content(data_object_id: str, db: Session = Depends(get_db)):
+    data_object = crud.get_data_object(db, data_object_id)
+    if data_object is None:
+        raise HTTPException(status_code=404, detail="DataObject not found")
+    url = data_object.url
+    if url is None:
+        raise HTTPException(status_code=404, detail="DataObject has no url reference")
+    if data_object.file_type in [
+        "Kraken2 Krona Plot",
+        "GOTTCHA2 Krona Plot",
+        "Centrifuge Krona Plot",
+    ]:
+        return {
+            "url": url,
+        }
+    return HTTPException(status_code=400, detail="DataObject has no relevant HTML content")
+
+
 @router.post(
     "/data_object/workflow_summary",
     response_model=schemas.DataObjectAggregation,

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -632,7 +632,7 @@ async def get_data_object_html_content(data_object_id: str, db: Session = Depend
         return {
             "url": url,
         }
-    return HTTPException(status_code=400, detail="DataObject has no relevant HTML content")
+    raise HTTPException(status_code=400, detail="DataObject has no relevant HTML content")
 
 
 @router.post(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm.session import Session
 
@@ -130,3 +131,42 @@ def test_generate_bulk_download_filtered(
     # Verify that the bulk download cannot be accessed a second time
     resp = client.get(f"/api/bulk_download/{id_}")
     assert resp.status_code == 410
+
+
+@pytest.mark.parametrize(
+    ("data_object_type", "expected_status_code"), [("Kraken2 Krona Plot", 200), ("foo", 400)]
+)
+def test_get_url_for_html_content_unauthenticated(
+    db: Session,
+    client: TestClient,
+    data_object_type: str,
+    expected_status_code: int,
+):
+    data_object = fakes.DataObjectFactory(
+        url="https://data.microbiomedata.org/data/dob",
+        workflow_type=WorkflowActivityTypeEnum.metagenome_assembly.value,
+        file_type=data_object_type,
+    )
+    db.commit()
+    resp = client.get(f"/api/data_object/{data_object.id}/get_html_content_url")
+    assert resp.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    ("data_object_type", "expected_status_code"), [("Kraken2 Krona Plot", 200), ("foo", 400)]
+)
+def test_get_url_for_html_content_authenticated(
+    db: Session,
+    client: TestClient,
+    logged_in_user,
+    data_object_type: str,
+    expected_status_code: int,
+):
+    data_object = fakes.DataObjectFactory(
+        url="https://data.microbiomedata.org/data/dob",
+        workflow_type=WorkflowActivityTypeEnum.metagenome_assembly.value,
+        file_type=data_object_type,
+    )
+    db.commit()
+    resp = client.get(f"/api/data_object/{data_object.id}/get_html_content_url")
+    assert resp.status_code == expected_status_code

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -106,7 +106,7 @@ export default defineComponent({
     async function openHtmlDataModal(item: any) {
       iframeLoading.value = true;
       dataModal.value = true;
-      iframeDataSource.value = await api.getDataObjectUrl(item.id);
+      iframeDataSource.value = await api.getDataObjectHtmlContentUrl(item.id);
       selectedHtmlDataObject.value = item;
     }
     watch(dataModal, () => {
@@ -269,7 +269,9 @@ export default defineComponent({
             class="d-flex align-center justify-center flex-grow-1"
           >
             <v-progress-circular
+              class="mr-2"
               color="primary"
+              size="24"
               indeterminate
             />
             Loading...
@@ -282,10 +284,6 @@ export default defineComponent({
             class="pa-4"
             loading="lazy"
             @load="onIframeLoaded"
-          />
-          <div
-            class="iframe-blocker"
-            :style="{ position: 'absolute', height: '100%', width: '100%'}"
           />
         </v-card-text>
         <v-card-actions class="flex-row">

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -641,6 +641,11 @@ async function createBulkDownload(conditions: Condition[], dataObjectFilter: Dat
   };
 }
 
+async function getDataObjectUrl(dataObjectId: string): Promise<string> {
+  const { data } = await client.get<{ url: string }>(`data_object/${dataObjectId}/download`);
+  return data.url;
+}
+
 export interface KeggTermSearchResponse {
   term: string;
   text: string;
@@ -846,6 +851,7 @@ client.interceptors.response.use(undefined, async (error: AxiosError) => {
 
 const api = {
   createBulkDownload,
+  getDataObjectUrl,
   getBinnedFacet,
   getBulkDownloadSummary,
   getBulkDownloadAggregateSummary,

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -641,8 +641,8 @@ async function createBulkDownload(conditions: Condition[], dataObjectFilter: Dat
   };
 }
 
-async function getDataObjectUrl(dataObjectId: string): Promise<string> {
-  const { data } = await client.get<{ url: string }>(`data_object/${dataObjectId}/download`);
+async function getDataObjectHtmlContentUrl(dataObjectId: string): Promise<string> {
+  const { data } = await client.get<{ url: string }>(`data_object/${dataObjectId}/get_html_content_url`);
   return data.url;
 }
 
@@ -851,7 +851,7 @@ client.interceptors.response.use(undefined, async (error: AxiosError) => {
 
 const api = {
   createBulkDownload,
-  getDataObjectUrl,
+  getDataObjectHtmlContentUrl,
   getBinnedFacet,
   getBulkDownloadSummary,
   getBulkDownloadAggregateSummary,


### PR DESCRIPTION
Fix #1707 

### Changes

#### Backend
A new API endpoint has been added to allow a client to obtain the URL for specific types of data objects. This is necessary because the existing endpoint is only accessible to authenticated (i.e. _logged in_) users. The Krona plot's HTML needs to be accessible for all users. Being logged in should not be required to view these data objects. 

This endpoint accepts a `data_object_id` and returns the URL for the HTML for that data object only if the data object has a specific `file_type`. If this endpoint is used to try and obtain the download URL for a non-Krona plot data object, it return a `400`. Tests have been added for this endpoint.

#### Frontend
Krona plots are now viewable on the data portal without the need to log in or click the download button. They are accessible by clicking the magnifying glass icon in the corresponding row:
<img width="1323" height="46" alt="image" src="https://github.com/user-attachments/assets/2279cdae-8376-4e47-813c-6027e80d7c22" />

Clicking will bring up a modal (implemented with a `v-dialog` component) containing an [iframe](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/iframe).
<img width="1537" height="693" alt="image" src="https://github.com/user-attachments/assets/2c30da58-1273-48eb-9d94-ac34496c1ca9" />
