### PR TITLE
Resize visualization components

### DIFF
--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -36,6 +36,10 @@ export default Vue.extend({
       type: String,
       required: true,
     },
+    height: {
+      type: Number,
+      default: 160,
+    },
   },
 
   data() {
@@ -133,8 +137,8 @@ export default Vue.extend({
 
 <template>
   <div class="histogram">
-    <ChartContainer>
-      <template #default="{ width, height }">
+    <ChartContainer :height="height">
+      <template #default="{ width }">
         <TimeHistogram
           ref="histogram"
           v-bind="{ width, height, selectedData: facetSummary, totalData: facetSummaryUnconditional, range: range || [] }"

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -179,7 +179,7 @@ export default defineComponent({
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="8">
+      <v-col cols="6">
         <TooltipCard
           :text="helpTimeline"
           class="py-2"
@@ -193,18 +193,19 @@ export default defineComponent({
             <template #default="props">
               <DateHistogram
                 v-bind="props"
+                :height="240"
                 @select="setUniqueCondition(['collection_date'], ['biosample'], $event.conditions)"
               />
             </template>
           </BinnedSummaryWrapper>
         </TooltipCard>
       </v-col>
-      <v-col cols="4">
+      <v-col cols="6">
         <TooltipCard
           :text="helpUpset"
           class="py-0 d-flex flex-column justify-center fill-height"
         >
-          <ChartContainer :height="160">
+          <ChartContainer :height="240">
             <template #default="{ width, height }">
               <UpSet
                 v-bind="{


### PR DESCRIPTION
Fix #1524 

### Changes
This is a simple and straightforward change that adjusts the height and width of the visualizations that appear underneath the map and data type bar chart on the data portal. The addition of new data types caused the upset plot to be difficult to read:
<img width="1590" height="223" alt="image" src="https://github.com/user-attachments/assets/66a5ecd2-2549-4303-a33e-3730acd652dc" />

Additionally, much of the collection date histogram is effectively whitespace (looking at pre-2014). To remedy the readability of the upset plot, the heights of these components has been increased (they also now match), and each component now takes up an equal amount of horizontal space:
<img width="1587" height="310" alt="image" src="https://github.com/user-attachments/assets/b4d288ee-7c3e-40a1-aa13-98018222bbea" />

Now each bar in the upset plot is given more space.