### PR TITLE
Fix multiomics bitmask

### DIFF
--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -674,12 +674,13 @@ function getField(name: string, table?: entityType): FieldsData {
 }
 
 const MultiomicsValue = {
-  MB: 0b100000,
-  MG: 0b010000,
-  MP: 0b001000,
-  MT: 0b000100,
-  NOM: 0b000010,
-  LIP: 0b000001,
+  MB: 0b1000000,
+  MG: 0b0100000,
+  MP: 0b0010000,
+  MT: 0b0001000,
+  LIP: 0b0000100,
+  NOM: 0b0000010,
+  AMP: 0b0000001,
 };
 
 const metaproteomicCategoryEnumToDisplay = {


### PR DESCRIPTION
Fix #1739 

### Changes
Updates the `MultiomicsValue` object, which maps different data types (e.g. `MB` for metabolomics) to the corresponding bit in the `multiomics` bitmask used by the data portal for searching and displaying the upset plot.

This PR adds "Amplicon" and adjusts the bitmasks for the other data types accordingly.