### PR TITLE
Migrate to SQLAlchemy 2.0

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-plugins = pydantic.mypy
+plugins = pydantic.mypy, sqlmypy
 allow_redefinition = false
 check_untyped_defs = true
 ignore_errors = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-plugins = pydantic.mypy, sqlmypy
+plugins = pydantic.mypy
 allow_redefinition = false
 check_untyped_defs = true
 ignore_errors = false

--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -41,7 +41,7 @@ def get_table_summary(db: Session, model: models.ModelType) -> schemas.TableSumm
     if isinstance(model(), models.AnnotatedModel):
         attributes.update(get_annotation_summary(db, cast(Type[models.AnnotatedModel], model)))
 
-    for column in model.__table__.columns:  # type: ignore
+    for column in model.__table__.columns:
         if (
             column.name not in ["id", "annotations", "alternate_identifiers"]
             and "_id" not in column.name

--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -160,14 +160,14 @@ def get_aggregation_summary(db: Session):
         # `id`s. The result is the number of studies that are not parent studies.
         num_non_parent_studies = (
             q(models.Study)
-            .filter(models.Study.id.notin_(select(parent_ids_subquery.c.parent_id)))
+            .filter(models.Study.id.notin_(select(parent_ids_subquery.c.parent_id)))  # type: ignore
             .count()
         )
 
         return num_non_parent_studies
 
     wfe_outputs_subquery = make_all_wfe_outputs_subquery(db)
-    wfe_outputs_inner_query = select(wfe_outputs_subquery.c.id)
+    wfe_outputs_inner_query = select(wfe_outputs_subquery.c.id)  # type: ignore
     return schemas.AggregationSummary(
         studies=q(models.Study).count(),
         non_parent_studies=count_non_parent_studies(),

--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Type, cast
 
-from sqlalchemy import Column, func, or_, union_all
+from sqlalchemy import Column, func, or_, select, union_all
 from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql import Alias, Selectable
 
@@ -147,7 +147,11 @@ def get_aggregation_summary(db: Session):
         # and (b) selects the distinct `id`s that are in any of those arrays. The result is
         # a list of parent study `id`s.
         parent_ids_subquery = (
-            q(func.distinct(func.jsonb_array_elements_text(models.Study.part_of)))
+            q(
+                func.distinct(func.jsonb_array_elements_text(models.Study.part_of)).label(
+                    "parent_id"
+                )
+            )
             .filter(func.jsonb_typeof(models.Study.part_of) == "array")
             .subquery()
         )
@@ -155,11 +159,15 @@ def get_aggregation_summary(db: Session):
         # Count the number of studies whose `id`s are _not_ in that list of parent study
         # `id`s. The result is the number of studies that are not parent studies.
         num_non_parent_studies = (
-            q(models.Study).filter(models.Study.id.notin_(parent_ids_subquery)).count()
+            q(models.Study)
+            .filter(models.Study.id.notin_(select(parent_ids_subquery.c.parent_id)))
+            .count()
         )
 
         return num_non_parent_studies
 
+    wfe_outputs_subquery = make_all_wfe_outputs_subquery(db)
+    wfe_outputs_inner_query = select(wfe_outputs_subquery.c.id)
     return schemas.AggregationSummary(
         studies=q(models.Study).count(),
         non_parent_studies=count_non_parent_studies(),
@@ -168,7 +176,7 @@ def get_aggregation_summary(db: Session):
         data_size=q(func.sum(func.coalesce(models.DataObject.file_size_bytes, 0))).scalar(),
         wfe_output_data_size_bytes=(
             q(func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)))
-            .filter(models.DataObject.id.in_(make_all_wfe_outputs_subquery(db)))
+            .filter(models.DataObject.id.in_(wfe_outputs_inner_query))
             .scalar()
             or 0
         ),

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1558,11 +1558,7 @@ async def delete_submission_image(
 
         # Find the specific image in the study_images collection
         image_to_delete = next(
-            (
-                image
-                for image in submission.study_images
-                if image.name == image_name
-            ),
+            (image for image in submission.study_images if image.name == image_name),
             None,
         )
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1309,7 +1309,7 @@ async def delete_submission(
             detail="This submission is currently being edited by a different user.",
         )
 
-    for role in submission.roles:  # type: ignore
+    for role in submission.roles:
         db.delete(role)
     db.delete(submission)
     db.commit()
@@ -1520,7 +1520,7 @@ async def set_submission_image(
 
     if image_type == ImageType.STUDY_IMAGES:
         # For study_images, add to the collection
-        submission.study_images.append(new_image)  # type: ignore
+        submission.study_images.append(new_image)
     else:
         # For single image fields (pi_image, primary_study_image), replace existing
         current_image = getattr(submission, image_type)
@@ -1560,7 +1560,7 @@ async def delete_submission_image(
         image_to_delete = next(
             (
                 image
-                for image in submission.study_images  # type: ignore
+                for image in submission.study_images
                 if image.name == image_name
             ),
             None,
@@ -1574,7 +1574,7 @@ async def delete_submission_image(
         # Delete the image from the storage bucket
         storage.delete_object(BucketName.SUBMISSION_IMAGES, image_to_delete.name)
         # Remove the image from the collection
-        submission.study_images.remove(image_to_delete)  # type: ignore
+        submission.study_images.remove(image_to_delete)
         db.delete(image_to_delete)
     else:
         # For single image fields (pi_image, primary_study_image)

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1094,7 +1094,7 @@ async def get_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    submission: Optional[models.SubmissionMetadata] = db.query(SubmissionMetadata).get(id)
+    submission: Optional[models.SubmissionMetadata] = db.get(SubmissionMetadata, id)
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
 
@@ -1162,7 +1162,7 @@ async def update_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    submission = db.query(SubmissionMetadata).get(id)
+    submission = db.get(SubmissionMetadata, id)
     body_dict = body.dict(exclude_unset=True)
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
@@ -1295,7 +1295,7 @@ async def delete_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    submission = db.query(SubmissionMetadata).get(id)
+    submission = db.get(SubmissionMetadata, id)
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
 
@@ -1323,7 +1323,7 @@ async def lock_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ) -> schemas.LockOperationResult:
-    submission: Optional[SubmissionMetadata] = db.query(SubmissionMetadata).get(id)
+    submission: Optional[SubmissionMetadata] = db.get(SubmissionMetadata, id)
     if not submission:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
 
@@ -1353,7 +1353,7 @@ async def unlock_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ) -> schemas.LockOperationResult:
-    submission = db.query(SubmissionMetadata).get(id)
+    submission = db.get(SubmissionMetadata, id)
     if not submission:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1094,7 +1094,7 @@ async def get_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    submission: Optional[models.SubmissionMetadata] = db.get(SubmissionMetadata, id)
+    submission: Optional[models.SubmissionMetadata] = db.get(SubmissionMetadata, id)  # type: ignore
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
 
@@ -1162,7 +1162,7 @@ async def update_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    submission = db.get(SubmissionMetadata, id)
+    submission = db.get(SubmissionMetadata, id)  # type: ignore
     body_dict = body.dict(exclude_unset=True)
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
@@ -1295,7 +1295,7 @@ async def delete_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ):
-    submission = db.get(SubmissionMetadata, id)
+    submission = db.get(SubmissionMetadata, id)  # type: ignore
     if submission is None:
         raise HTTPException(status_code=404, detail="Submission not found")
 
@@ -1323,7 +1323,7 @@ async def lock_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ) -> schemas.LockOperationResult:
-    submission: Optional[SubmissionMetadata] = db.get(SubmissionMetadata, id)
+    submission: Optional[SubmissionMetadata] = db.get(SubmissionMetadata, id)  # type: ignore
     if not submission:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
 
@@ -1353,7 +1353,7 @@ async def unlock_submission(
     db: Session = Depends(get_db),
     user: models.User = Depends(get_current_user),
 ) -> schemas.LockOperationResult:
-    submission = db.get(SubmissionMetadata, id)
+    submission = db.get(SubmissionMetadata, id)  # type: ignore
     if not submission:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
 

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 import click
 import requests
+from sqlalchemy import text
 
 from nmdc_server import jobs
 from nmdc_server.config import settings
@@ -78,12 +79,13 @@ def truncate():
     """Remove all existing data from the ingest database."""
     with SessionLocalIngest() as db:
         try:
-            db.execute("select truncate_tables()").all()
+            db.execute(text("select truncate_tables()")).all()
             db.commit()
         except Exception:
             db.rollback()
             db.execute(
-                """
+                text(
+                    """
                 DO $$ DECLARE
                      r RECORD;
                  BEGIN
@@ -93,6 +95,7 @@ def truncate():
                      END LOOP;
                  END $$;
             """
+                )
             )
             db.commit()
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -717,7 +717,9 @@ def get_submission_for_user(
     :param allowed_roles: A list of allowed roles that the user must have on the submission. If
         None, no role check is performed.
     """
-    submission: Optional[models.SubmissionMetadata] = db.get(models.SubmissionMetadata, submission_id)
+    submission: Optional[models.SubmissionMetadata] = db.get(
+        models.SubmissionMetadata, submission_id
+    )
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     if allowed_roles and not requester.is_admin:
@@ -759,7 +761,9 @@ def can_read_submission(db: Session, submission_id: str, user_orcid: str) -> Opt
         )
         .first()
     )
-    submission: Optional[models.SubmissionMetadata] = db.get(models.SubmissionMetadata, submission_id)
+    submission: Optional[models.SubmissionMetadata] = db.get(
+        models.SubmissionMetadata, submission_id
+    )
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     return (role and models.SubmissionEditorRole(role.role) in read_roles) is True
@@ -776,7 +780,9 @@ def can_edit_entire_submission(db: Session, submission_id: str, user_orcid: str)
         )
         .first()
     )
-    submission: Optional[models.SubmissionMetadata] = db.get(models.SubmissionMetadata, submission_id)
+    submission: Optional[models.SubmissionMetadata] = db.get(
+        models.SubmissionMetadata, submission_id
+    )
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     return (role and models.SubmissionEditorRole(role.role) in contributors_edit_roles) is True

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -142,7 +142,7 @@ def create_study(db: Session, study: schemas.StudyCreate) -> models.Study:
     for url in websites:
         website, _ = get_or_create(db, models.Website, url=url)
         study_website = models.StudyWebsite(website=website)
-        db_study.principal_investigator_websites.append(study_website)  # type: ignore
+        db_study.principal_investigator_websites.append(study_website)
 
     db.add(db_study)
     db.commit()
@@ -528,7 +528,7 @@ def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
     zip_file_descriptor: Dict[str, Any] = {"suggestedFilename": "archive.zip"}
     file_descriptions: List[Dict[str, str]] = []
 
-    for file in bulk_download.files:  # type: ignore
+    for file in bulk_download.files:
         data_object = file.data_object
         if data_object.url is None:
             logger.warning(f"Data object url for {file.path} was {data_object.url}")
@@ -668,7 +668,7 @@ def release_submission_lock(db: Session, submission_id: str):
     submission = db.get(models.SubmissionMetadata, submission_id)
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
-    submission.locked_by = None  # type: ignore
+    submission.locked_by = None
     db.commit()
 
 

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -121,14 +121,14 @@ def get_study(db: Session, study_id: str) -> Optional[models.Study]:
 
 
 def get_study_image(db: Session, study_id: str) -> Optional[bytes]:
-    study = db.query(models.Study).get(study_id)
+    study = db.get(models.Study, study_id)
     if study is not None:
         return study.image
     return None
 
 
 def get_doi(db: Session, doi_id: str) -> Optional[models.DOIInfo]:
-    doi = db.query(models.DOIInfo).get(doi_id)
+    doi = db.get(models.DOIInfo, doi_id)
     return doi
 
 
@@ -416,7 +416,7 @@ def aggregate_data_object_by_workflow(
 
 # principal investigator
 def get_pi_image(db: Session, principal_investigator_id: UUID) -> Optional[bytes]:
-    pi = db.query(models.PrincipalInvestigator).get(principal_investigator_id)
+    pi = db.get(models.PrincipalInvestigator, principal_investigator_id)
     if pi is not None:
         return pi.image
     return None
@@ -520,7 +520,7 @@ def replace_nersc_data_host(url: str) -> str:
 
 def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
     """Return a zip file descriptor compatible with zipstreamer."""
-    bulk_download = db.query(models.BulkDownload).get(id)
+    bulk_download = db.get(models.BulkDownload, id)
     if bulk_download is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bulk download not found")
     if bulk_download.expired:
@@ -547,7 +547,7 @@ def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
 
 def get_user(db: Session, user_id: str) -> Optional[models.User]:
     """Get a user by ID."""
-    return db.query(models.User).get(user_id)
+    return db.get(models.User, user_id)
 
 
 def get_or_create_user(db: Session, user: schemas.User) -> models.User:
@@ -559,7 +559,7 @@ def get_or_create_user(db: Session, user: schemas.User) -> models.User:
 
 
 def update_user(db: Session, user: schemas.User) -> Optional[models.User]:
-    db_user = db.query(models.User).get(user.id)
+    db_user = db.get(models.User, user.id)
     if db_user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -580,7 +580,7 @@ def add_invalidated_token(db: Session, token: str) -> None:
 
 def get_invalidated_token(db: Session, token: str) -> Optional[models.InvalidatedToken]:
     """Get an invalidated token by token."""
-    return db.query(models.InvalidatedToken).get(token)
+    return db.get(models.InvalidatedToken, token)
 
 
 def create_authorization_code(
@@ -595,12 +595,12 @@ def create_authorization_code(
 
 def get_authorization_code(db: Session, code: str) -> Optional[models.AuthorizationCode]:
     """Get an authorization code by code."""
-    return db.query(models.AuthorizationCode).get(code)
+    return db.get(models.AuthorizationCode, code)
 
 
 def update_submission_lock(db: Session, submission_id: str):
     """Update the timestamp for a locked submission."""
-    submission_record = db.query(models.SubmissionMetadata).get(submission_id)
+    submission_record = db.get(models.SubmissionMetadata, submission_id)
     if not submission_record:
         # Throw a different error, or accept different params
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
@@ -618,10 +618,10 @@ def try_get_submission_lock(db: Session, submission_id: str, user_id: str) -> bo
     """
 
     # Ensure the requested records exist
-    submission_record = db.query(models.SubmissionMetadata).get(submission_id)
+    submission_record = db.get(models.SubmissionMetadata, submission_id)
     if not submission_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
-    user_record: Optional[models.User] = db.query(models.User).get(user_id)
+    user_record: Optional[models.User] = db.get(models.User, user_id)
     if not user_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
@@ -665,7 +665,7 @@ def try_get_submission_lock(db: Session, submission_id: str, user_id: str) -> bo
 
 
 def release_submission_lock(db: Session, submission_id: str):
-    submission = db.query(models.SubmissionMetadata).get(submission_id)
+    submission = db.get(models.SubmissionMetadata, submission_id)
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     submission.locked_by = None  # type: ignore
@@ -717,9 +717,7 @@ def get_submission_for_user(
     :param allowed_roles: A list of allowed roles that the user must have on the submission. If
         None, no role check is performed.
     """
-    submission: Optional[models.SubmissionMetadata] = db.query(models.SubmissionMetadata).get(
-        submission_id
-    )
+    submission: Optional[models.SubmissionMetadata] = db.get(models.SubmissionMetadata, submission_id)
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     if allowed_roles and not requester.is_admin:
@@ -761,9 +759,7 @@ def can_read_submission(db: Session, submission_id: str, user_orcid: str) -> Opt
         )
         .first()
     )
-    submission: Optional[models.SubmissionMetadata] = db.query(models.SubmissionMetadata).get(
-        submission_id
-    )
+    submission: Optional[models.SubmissionMetadata] = db.get(models.SubmissionMetadata, submission_id)
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     return (role and models.SubmissionEditorRole(role.role) in read_roles) is True
@@ -780,9 +776,7 @@ def can_edit_entire_submission(db: Session, submission_id: str, user_orcid: str)
         )
         .first()
     )
-    submission: Optional[models.SubmissionMetadata] = db.query(models.SubmissionMetadata).get(
-        submission_id
-    )
+    submission: Optional[models.SubmissionMetadata] = db.get(models.SubmissionMetadata, submission_id)
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     return (role and models.SubmissionEditorRole(role.role) in contributors_edit_roles) is True

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -121,14 +121,14 @@ def get_study(db: Session, study_id: str) -> Optional[models.Study]:
 
 
 def get_study_image(db: Session, study_id: str) -> Optional[bytes]:
-    study = db.get(models.Study, study_id)
+    study = db.get(models.Study, study_id)  # type: ignore  # type: ignore
     if study is not None:
         return study.image
     return None
 
 
 def get_doi(db: Session, doi_id: str) -> Optional[models.DOIInfo]:
-    doi = db.get(models.DOIInfo, doi_id)
+    doi = db.get(models.DOIInfo, doi_id)  # type: ignore
     return doi
 
 
@@ -416,7 +416,7 @@ def aggregate_data_object_by_workflow(
 
 # principal investigator
 def get_pi_image(db: Session, principal_investigator_id: UUID) -> Optional[bytes]:
-    pi = db.get(models.PrincipalInvestigator, principal_investigator_id)
+    pi = db.get(models.PrincipalInvestigator, principal_investigator_id)  # type: ignore
     if pi is not None:
         return pi.image
     return None
@@ -520,7 +520,7 @@ def replace_nersc_data_host(url: str) -> str:
 
 def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
     """Return a zip file descriptor compatible with zipstreamer."""
-    bulk_download = db.get(models.BulkDownload, id)
+    bulk_download = db.get(models.BulkDownload, id)  # type: ignore
     if bulk_download is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Bulk download not found")
     if bulk_download.expired:
@@ -547,7 +547,7 @@ def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
 
 def get_user(db: Session, user_id: str) -> Optional[models.User]:
     """Get a user by ID."""
-    return db.get(models.User, user_id)
+    return db.get(models.User, user_id)  # type: ignore
 
 
 def get_or_create_user(db: Session, user: schemas.User) -> models.User:
@@ -559,7 +559,7 @@ def get_or_create_user(db: Session, user: schemas.User) -> models.User:
 
 
 def update_user(db: Session, user: schemas.User) -> Optional[models.User]:
-    db_user = db.get(models.User, user.id)
+    db_user = db.get(models.User, user.id)  # type: ignore
     if db_user is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -580,7 +580,7 @@ def add_invalidated_token(db: Session, token: str) -> None:
 
 def get_invalidated_token(db: Session, token: str) -> Optional[models.InvalidatedToken]:
     """Get an invalidated token by token."""
-    return db.get(models.InvalidatedToken, token)
+    return db.get(models.InvalidatedToken, token)  # type: ignore
 
 
 def create_authorization_code(
@@ -595,12 +595,12 @@ def create_authorization_code(
 
 def get_authorization_code(db: Session, code: str) -> Optional[models.AuthorizationCode]:
     """Get an authorization code by code."""
-    return db.get(models.AuthorizationCode, code)
+    return db.get(models.AuthorizationCode, code)  # type: ignore
 
 
 def update_submission_lock(db: Session, submission_id: str):
     """Update the timestamp for a locked submission."""
-    submission_record = db.get(models.SubmissionMetadata, submission_id)
+    submission_record = db.get(models.SubmissionMetadata, submission_id)  # type: ignore
     if not submission_record:
         # Throw a different error, or accept different params
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
@@ -618,10 +618,10 @@ def try_get_submission_lock(db: Session, submission_id: str, user_id: str) -> bo
     """
 
     # Ensure the requested records exist
-    submission_record = db.get(models.SubmissionMetadata, submission_id)
+    submission_record = db.get(models.SubmissionMetadata, submission_id)  # type: ignore
     if not submission_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
-    user_record: Optional[models.User] = db.get(models.User, user_id)
+    user_record: Optional[models.User] = db.get(models.User, user_id)  # type: ignore
     if not user_record:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
@@ -665,7 +665,7 @@ def try_get_submission_lock(db: Session, submission_id: str, user_id: str) -> bo
 
 
 def release_submission_lock(db: Session, submission_id: str):
-    submission = db.get(models.SubmissionMetadata, submission_id)
+    submission = db.get(models.SubmissionMetadata, submission_id)  # type: ignore
     if submission is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Submission not found")
     submission.locked_by = None
@@ -717,7 +717,7 @@ def get_submission_for_user(
     :param allowed_roles: A list of allowed roles that the user must have on the submission. If
         None, no role check is performed.
     """
-    submission: Optional[models.SubmissionMetadata] = db.get(
+    submission: Optional[models.SubmissionMetadata] = db.get(  # type: ignore
         models.SubmissionMetadata, submission_id
     )
     if submission is None:
@@ -761,7 +761,7 @@ def can_read_submission(db: Session, submission_id: str, user_orcid: str) -> Opt
         )
         .first()
     )
-    submission: Optional[models.SubmissionMetadata] = db.get(
+    submission: Optional[models.SubmissionMetadata] = db.get(  # type: ignore
         models.SubmissionMetadata, submission_id
     )
     if submission is None:
@@ -780,7 +780,7 @@ def can_edit_entire_submission(db: Session, submission_id: str, user_orcid: str)
         )
         .first()
     )
-    submission: Optional[models.SubmissionMetadata] = db.get(
+    submission: Optional[models.SubmissionMetadata] = db.get(  # type: ignore
         models.SubmissionMetadata, submission_id
     )
     if submission is None:

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -76,6 +76,7 @@ _engine_kwargs = {
     "json_serializer": json_serializer,
     "pool_size": settings.db_pool_size,
     "max_overflow": settings.db_pool_max_overflow,
+    "future": True,
 }
 engine = create_engine(settings.current_db_uri, **_engine_kwargs)
 engine_ingest = create_engine(settings.ingest_database_uri, **_engine_kwargs)

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -91,7 +91,6 @@ class SQLAlchemyPanel(BasePanel):
 # This is to avoid having to manually name all constraints
 # See: http://alembic.zzzcomputing.com/en/latest/naming.html
 metadata = MetaData(
-    bind=engine,
     naming_convention={
         "pk": "pk_%(table_name)s",
         "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -10,8 +10,7 @@ from pygments.formatters import TerminalFormatter
 from pygments.lexers import SqlLexer
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.schema import DDL, MetaData
 
 from nmdc_server.config import settings

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -101,7 +101,13 @@ metadata = MetaData(
     },
 )
 
-Base = declarative_base(metadata=metadata)
+
+class UnmappedBase:
+    __allow_unmapped__ = True
+
+
+Base = declarative_base(cls=UnmappedBase, metadata=metadata)
+
 
 update_nmdc_functions_sql = DDL(
     """

--- a/nmdc_server/database.py
+++ b/nmdc_server/database.py
@@ -10,7 +10,7 @@ from pygments.formatters import TerminalFormatter
 from pygments.lexers import SqlLexer
 from sqlalchemy import create_engine
 from sqlalchemy.event import listen
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker  # type: ignore
 from sqlalchemy.schema import DDL, MetaData
 
 from nmdc_server.config import settings

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -268,9 +268,7 @@ class WorkflowExecutionFilter(OmicsProcessingFilter):
         q = query.join(
             association_table,
             association_table.c.data_generation_id == models.OmicsProcessing.id,
-        ).join(
-            model, model.id == association_table.c[f"{self.table.value}_id"]
-        )
+        ).join(model, model.id == association_table.c[f"{self.table.value}_id"])
         return q
 
 

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -79,7 +79,7 @@ class BaseFilter:
         target_table: Table,
     ) -> Query:
         """Get a query representing unique id's of the target table matching the conditions."""
-        query = db.query(func.distinct(target_table.model.id).label("id"))  # type: ignore
+        query = db.query(func.distinct(target_table.model.id).label("id"))
         return self._apply_conditions(query, target_table)
 
     def _apply_conditions(
@@ -269,7 +269,7 @@ class WorkflowExecutionFilter(OmicsProcessingFilter):
             association_table,
             association_table.c.data_generation_id == models.OmicsProcessing.id,
         ).join(
-            model, model.id == association_table.c[f"{self.table.value}_id"]  # type: ignore
+            model, model.id == association_table.c[f"{self.table.value}_id"]
         )
         return q
 

--- a/nmdc_server/ingest/envo.py
+++ b/nmdc_server/ingest/envo.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Set
 from urllib import request
 
+from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -120,7 +121,7 @@ def build_envo_trees(db: Session) -> None:
 
     This should only be called after biosamples have been ingested.
     """
-    db.execute(f"truncate table {EnvoTree.__tablename__}")
+    db.execute(text(f"truncate table {EnvoTree.__tablename__}"))
 
     roots = get_biosample_roots(db)
     root_set = set(itertools.chain(*roots.values()))
@@ -257,7 +258,7 @@ def nested_envo_trees() -> Dict[str, List[EnvoTreeNode]]:
 
 
 def load(db: Session):
-    db.execute(f"truncate table {EnvoAncestor.__tablename__}")
+    db.execute(text(f"truncate table {EnvoAncestor.__tablename__}"))
 
     with request.urlopen(envo_url) as r:
         envo_data = json.load(r)

--- a/nmdc_server/ingest/kegg.py
+++ b/nmdc_server/ingest/kegg.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 import requests
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from nmdc_server.ingest.errors import errors
@@ -47,9 +48,9 @@ def load(db: Session) -> None:
 
 
 def ingest_ko_search(db: Session) -> None:
-    db.execute(f"truncate table {KoTermText.__tablename__}")
-    db.execute(f"truncate table {CogTermText.__tablename__}")
-    db.execute(f"truncate table {PfamTermText.__tablename__}")
+    db.execute(text(f"truncate table {KoTermText.__tablename__}"))
+    db.execute(text(f"truncate table {CogTermText.__tablename__}"))
+    db.execute(text(f"truncate table {PfamTermText.__tablename__}"))
     records = get_search_records()
     db.bulk_save_objects([KoTermText(term=term, text=text) for term, text in records["ko"].items()])
     db.bulk_save_objects(
@@ -198,7 +199,7 @@ def get_search_records():
 
 def ingest_ko_module_map(db: Session) -> None:
     """Ingest a mapping of KEGG modules to terms and COG functions to terms."""
-    db.execute(f"truncate table {KoTermToModule.__tablename__}")
+    db.execute(text(f"truncate table {KoTermToModule.__tablename__}"))
 
     datafile = Path(__file__).parent / "data" / "kegg_module_ko_terms.tab.txt"
     with open(datafile) as fd:
@@ -227,7 +228,7 @@ def ingest_ko_module_map(db: Session) -> None:
 
 def ingest_ko_pathway_map(db: Session) -> None:
     """Ingest a mapping of KEGG pathways to terms and COG pathways to COG terms."""
-    db.execute(f"truncate table {KoTermToPathway.__tablename__}")
+    db.execute(text(f"truncate table {KoTermToPathway.__tablename__}"))
 
     datafile = Path(__file__).parent / "data" / "ko_term_pathways.tab.txt"
     with open(datafile) as fd:
@@ -248,7 +249,7 @@ def ingest_ko_pathway_map(db: Session) -> None:
 
 def ingest_pfam_clan_map(db: Session) -> None:
     """Ingest a mapping of Pfam entries to clans"""
-    db.execute(f"truncate table {PfamEntryToClan.__tablename__}")
+    db.execute(text(f"truncate table {PfamEntryToClan.__tablename__}"))
     with open(PFAM_CLAN_DEFS) as fd:
         reader = csv.DictReader(fd, fieldnames=pfam_headers, delimiter="\t")
         mappings = set([(row[pfam_headers[0]], row[pfam_headers[1]]) for row in reader])
@@ -266,7 +267,7 @@ def ingest_go_search_records(db: Session) -> None:
     terms, we will only concern ourselves with the "nodes." Building out the
     hierarchy could be done as follow-up work.
     """
-    db.execute(f"truncate table {GoTermText.__tablename__}")
+    db.execute(text(f"truncate table {GoTermText.__tablename__}"))
     resp = requests.get(GO_URL)
     resp.raise_for_status()
     data = resp.json()
@@ -306,7 +307,7 @@ def ingest_go_pfam_map(db: Session) -> None:
     Of the lines we do care about, they are formatted as follows:
         Pfam:PF00001 7tm_1 > GO:G protein-coupled receptor activity ; GO:0004930
     """
-    db.execute(f"truncate table {GoTermToPfamEntry.__tablename__}")
+    db.execute(text(f"truncate table {GoTermToPfamEntry.__tablename__}"))
     pfam_go_mappings = "/data/ingest/go/pfam_go_mappings.txt"
     mappings = []
     with open(pfam_go_mappings) as fd:
@@ -324,7 +325,7 @@ def ingest_go_pfam_map(db: Session) -> None:
 
 
 def ingest_go_kegg_map(db: Session) -> None:
-    db.execute(f"truncate table {GoTermToKegg.__tablename__}")
+    db.execute(text(f"truncate table {GoTermToKegg.__tablename__}"))
     # TSV file with headers '#KO' and 'GO'
     kegg_go_mappings = "/data/ingest/go/ko2go.tsv"
     mappings = []

--- a/nmdc_server/ingest/omics_processing.py
+++ b/nmdc_server/ingest/omics_processing.py
@@ -222,7 +222,7 @@ def load_omics_processing(  # noqa: C901
     omics_processing = models.OmicsProcessing(**OmicsProcessing(**obj).dict())
     for biosample_object in biosample_input_objects:
         # mypy thinks that omics_processing.biosample_inputs is of type Biosample
-        omics_processing.biosample_inputs.append(biosample_object)  # type: ignore
+        omics_processing.biosample_inputs.append(biosample_object)
 
     manifest_id: str = omics_processing.id
     for data_object_id in data_objects:
@@ -238,7 +238,7 @@ def load_omics_processing(  # noqa: C901
         # output of an omics_processing)
         data_object.workflow_type = WorkflowActivityTypeEnum.raw_data.value
         db.add(data_object)
-        omics_processing.outputs.append(data_object)  # type: ignore
+        omics_processing.outputs.append(data_object)
 
         manifest_id = get_poolable_replicate_manifest(omics_processing.id, data_object_id, mongodb)
 

--- a/nmdc_server/ingest/search_index.py
+++ b/nmdc_server/ingest/search_index.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from sqlalchemy import text
 from sqlalchemy.orm.session import Session
 
 from nmdc_server import crud, models
@@ -26,7 +27,7 @@ search_fields = [
 
 
 def load(db: Session):
-    db.execute(f"TRUNCATE TABLE {models.SearchIndex.__tablename__}")
+    db.execute(text(f"TRUNCATE TABLE {models.SearchIndex.__tablename__}"))
 
     for table, field in search_fields:
         values: Optional[FacetResponse] = None

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -96,4 +96,4 @@ def load(db: Session, cursor: Cursor):
             for doi in dois:
                 doi_object = get_doi(db, doi["doi_value"])
                 if doi_object:
-                    new_study.dois.append(doi_object)  # type: ignore
+                    new_study.dois.append(doi_object)

--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from sqlalchemy import text
 from sqlalchemy.orm import lazyload
 
 from nmdc_server import database, models
@@ -56,7 +57,7 @@ def do_ingest(function_limit, skip_annotation):
 
     with database.SessionLocalIngest() as ingest_db:
         try:
-            ingest_db.execute("select truncate_tables()").all()
+            ingest_db.execute(text("select truncate_tables()")).all()
         except Exception:
             # eat the exception, we'll truncate after migration
             ingest_db.rollback()
@@ -65,7 +66,7 @@ def do_ingest(function_limit, skip_annotation):
 
     with database.SessionLocalIngest() as ingest_db, database.SessionLocal() as prod_db:
         with ingest_lock(prod_db):
-            ingest_db.execute("select truncate_tables()").all()
+            ingest_db.execute(text("select truncate_tables()")).all()
 
             # Copy persistent data that does not depend on ingest FK
             merge_download_artifact(ingest_db, prod_db.query(models.User))

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -357,7 +357,7 @@ class Study(Base, AnnotatedModel):
     @property
     def doi_map(self) -> Dict[str, Any]:
         doi_info = dict()
-        for doi in self.dois:  # type: ignore
+        for doi in self.dois:
             doi_info[doi.id] = {
                 "info": doi.info,
                 "category": doi.doi_type,
@@ -796,17 +796,17 @@ class OmicsProcessing(Base, AnnotatedModel):
     @property
     def omics_data(self) -> Iterator["PipelineStep"]:
         return chain(
-            self.reads_qc,  # type: ignore
-            self.metatranscriptome_annotation,  # type: ignore
-            self.metaproteomic_analysis,  # type: ignore
-            self.mags_analysis,  # type: ignore
-            self.read_based_analysis,  # type: ignore
-            self.nom_analysis,  # type: ignore
-            self.metabolomics_analysis,  # type: ignore
-            self.metatranscriptome,  # type: ignore
-            self.metagenome_assembly,  # type: ignore
-            self.metatranscriptome_assembly,  # type: ignore
-            self.metagenome_annotation,  # type: ignore
+            self.reads_qc,
+            self.metatranscriptome_annotation,
+            self.metaproteomic_analysis,
+            self.mags_analysis,
+            self.read_based_analysis,
+            self.nom_analysis,
+            self.metabolomics_analysis,
+            self.metatranscriptome,
+            self.metagenome_assembly,
+            self.metatranscriptome_assembly,
+            self.metagenome_annotation,
         )
 
 
@@ -850,7 +850,7 @@ class DataObject(Base):
     def downloads(self) -> int:
         # TODO: This can probably be done with a more efficient aggregation
         if self._download_count is None:
-            return len(self.download_entities) + len(self.bulk_download_entities)  # type: ignore
+            return len(self.download_entities) + len(self.bulk_download_entities)
         return self._download_count
 
 
@@ -1169,7 +1169,7 @@ class SubmissionMetadata(Base):
     def editors(self) -> list[str]:
         return [
             role.user_orcid
-            for role in self.roles  # type: ignore
+            for role in self.roles
             if role.role == SubmissionEditorRole.editor
         ]
 
@@ -1177,7 +1177,7 @@ class SubmissionMetadata(Base):
     def viewers(self) -> list[str]:
         return [
             role.user_orcid
-            for role in self.roles  # type: ignore
+            for role in self.roles
             if role.role == SubmissionEditorRole.viewer
         ]
 
@@ -1185,7 +1185,7 @@ class SubmissionMetadata(Base):
     def metadata_contributors(self) -> list[str]:
         return [
             role.user_orcid
-            for role in self.roles  # type: ignore
+            for role in self.roles
             if role.role == SubmissionEditorRole.metadata_contributor
         ]
 
@@ -1193,7 +1193,7 @@ class SubmissionMetadata(Base):
     def owners(self) -> list[str]:
         return [
             role.user_orcid
-            for role in self.roles  # type: ignore
+            for role in self.roles
             if role.role == SubmissionEditorRole.owner
         ]
 
@@ -1202,7 +1202,7 @@ class SubmissionMetadata(Base):
         """Calculate the total size (in bytes) of all study images associated with this
         submission."""
         return (
-            sum(image.size for image in self.study_images)  # type: ignore
+            sum(image.size for image in self.study_images)
             if self.study_images
             else 0
         )

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -393,7 +393,10 @@ class Biosample(Base, AnnotatedModel):
     multiomics = Column(Integer, nullable=False, default=0)
     emsl_biosample_identifiers = Column(JSONB, nullable=True)
     omics_processing = relationship(
-        "OmicsProcessing", secondary=biosample_input_association, back_populates="biosample_inputs"
+        "OmicsProcessing",
+        secondary=biosample_input_association,
+        back_populates="biosample_inputs",
+        cascade_backrefs=False,
     )
 
     # gold terms
@@ -403,7 +406,7 @@ class Biosample(Base, AnnotatedModel):
     ecosystem_subtype = Column(String, nullable=True)
     specific_ecosystem = Column(String, nullable=True)
 
-    study = relationship(Study, backref="biosamples")
+    study = relationship(Study, backref=backref("biosamples", cascade_backrefs=False))
     env_broad_scale = relationship(EnvoTerm, foreign_keys=[env_broad_scale_id], lazy="joined")
     env_local_scale = relationship(EnvoTerm, foreign_keys=[env_local_scale_id], lazy="joined")
     env_medium = relationship(EnvoTerm, foreign_keys=[env_medium_id], lazy="joined")
@@ -710,10 +713,13 @@ class OmicsProcessing(Base, AnnotatedModel):
     add_date = Column(DateTime, nullable=True)
     mod_date = Column(DateTime, nullable=True)
     biosample_inputs = relationship(
-        "Biosample", secondary=biosample_input_association, back_populates="omics_processing"
+        "Biosample",
+        secondary=biosample_input_association,
+        back_populates="omics_processing",
+        cascade_backrefs=False,
     )
     study_id = Column(String, ForeignKey("study.id"), nullable=True)
-    study = relationship("Study", backref="omics_processing")
+    study = relationship("Study", backref=backref("omics_processing", cascade_backrefs=False))
 
     outputs = output_relationship(omics_processing_output_association)
     has_outputs = association_proxy("outputs", "id")
@@ -1010,10 +1016,13 @@ class BulkDownloadDataObject(Base):
     path = Column(String, nullable=False)
 
     bulk_download = relationship(
-        BulkDownload, backref=backref("files", lazy="joined", cascade="all")
+        BulkDownload, backref=backref("files", lazy="joined", cascade="all", cascade_backrefs=False)
     )
     data_object = relationship(
-        DataObject, lazy="joined", cascade="save-update,delete", backref="bulk_download_entities"
+        DataObject,
+        lazy="joined",
+        cascade="save-update,delete",
+        backref=backref("bulk_download_entities", cascade_backrefs=False),
     )
 
 
@@ -1131,7 +1140,7 @@ class SubmissionMetadata(Base):
     lock_updated = Column(DateTime, nullable=True, default=lambda: datetime.now(UTC))
 
     # Roles
-    roles = relationship("SubmissionRole", back_populates="submission")
+    roles = relationship("SubmissionRole", back_populates="submission", cascade_backrefs=False)
 
     # Images
     pi_image_name = Column(String, ForeignKey(SubmissionImagesObject.name), nullable=True)
@@ -1223,7 +1232,7 @@ class SubmissionRole(Base):
     user_orcid = Column(String, primary_key=True)
     role = Column(Enum(SubmissionEditorRole))
 
-    submission = relationship("SubmissionMetadata", back_populates="roles")
+    submission = relationship("SubmissionMetadata", back_populates="roles", cascade_backrefs=False)
 
 
 class AuthorizationCode(Base):

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1167,19 +1167,11 @@ class SubmissionMetadata(Base):
 
     @property
     def editors(self) -> list[str]:
-        return [
-            role.user_orcid
-            for role in self.roles
-            if role.role == SubmissionEditorRole.editor
-        ]
+        return [role.user_orcid for role in self.roles if role.role == SubmissionEditorRole.editor]
 
     @property
     def viewers(self) -> list[str]:
-        return [
-            role.user_orcid
-            for role in self.roles
-            if role.role == SubmissionEditorRole.viewer
-        ]
+        return [role.user_orcid for role in self.roles if role.role == SubmissionEditorRole.viewer]
 
     @property
     def metadata_contributors(self) -> list[str]:
@@ -1191,21 +1183,13 @@ class SubmissionMetadata(Base):
 
     @property
     def owners(self) -> list[str]:
-        return [
-            role.user_orcid
-            for role in self.roles
-            if role.role == SubmissionEditorRole.owner
-        ]
+        return [role.user_orcid for role in self.roles if role.role == SubmissionEditorRole.owner]
 
     @property
     def study_images_total_size(self) -> int:
         """Calculate the total size (in bytes) of all study images associated with this
         submission."""
-        return (
-            sum(image.size for image in self.study_images)
-            if self.study_images
-            else 0
-        )
+        return sum(image.size for image in self.study_images) if self.study_images else 0
 
     @property
     def sample_count(self) -> int:

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -864,7 +864,9 @@ class BiosampleQuerySchema(BaseQuerySchema):
             for model in workflow_activity_types:
                 biosample_query = biosample_query.options(
                     selectinload(models.Biosample.omics_processing)
-                    .selectinload(getattr(models.OmicsProcessing, model.__tablename__))  # noqa: E501
+                    .selectinload(
+                        getattr(models.OmicsProcessing, model.__tablename__)
+                    )  # noqa: E501
                     .selectinload(model.outputs)
                 )
 
@@ -872,7 +874,9 @@ class BiosampleQuerySchema(BaseQuerySchema):
                 if model == models.MAGsAnalysis:
                     biosample_query = biosample_query.options(
                         selectinload(models.Biosample.omics_processing)
-                        .selectinload(getattr(models.OmicsProcessing, model.__tablename__))  # noqa: E501
+                        .selectinload(
+                            getattr(models.OmicsProcessing, model.__tablename__)
+                        )  # noqa: E501
                         .selectinload(model.mags_list)
                     )
 

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -867,7 +867,7 @@ class BiosampleQuerySchema(BaseQuerySchema):
                     .selectinload(
                         getattr(models.OmicsProcessing, model.__tablename__)
                     )  # noqa: E501
-                    .selectinload(model.outputs)
+                    .selectinload(model.outputs)  # type: ignore
                 )
 
                 # The MAGsAnalysis specifically needs to also prefetch the mags_list
@@ -877,7 +877,7 @@ class BiosampleQuerySchema(BaseQuerySchema):
                         .selectinload(
                             getattr(models.OmicsProcessing, model.__tablename__)
                         )  # noqa: E501
-                        .selectinload(model.mags_list)
+                        .selectinload(model.mags_list)  # type: ignore
                     )
 
         return biosample_query

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -369,7 +369,7 @@ class BaseQuerySchema(BaseModel):
     def query(self, db) -> Query:
         """Generate a query selecting all matching id's from the target table."""
         table_re = re.compile(r"Table.(.*):.*")
-        matches = [db.query(self.table.model.id.label("id"))]  # type: ignore
+        matches = [db.query(self.table.model.id.label("id"))]
         has_filters = False
 
         for key, _conditions in self.groups:
@@ -424,12 +424,12 @@ class BaseQuerySchema(BaseModel):
             else:
                 matches.append(filter.matches(db, self.table))
 
-        query = db.query(self.table.model.id.label("id"))  # type: ignore
+        query = db.query(self.table.model.id.label("id"))
         if has_filters:
             matches_query = intersect(*matches).alias("intersect")
             query = query.join(
                 matches_query,
-                matches_query.c.id == self.table.model.id,  # type: ignore
+                matches_query.c.id == self.table.model.id,
             )
         return query
 
@@ -437,7 +437,7 @@ class BaseQuerySchema(BaseModel):
         """Search for entities in the target table."""
         model = self.table.model
         subquery = self.query(db).subquery().alias("id_filter")
-        return db.query(model).join(subquery, model.id == subquery.c.id)  # type: ignore
+        return db.query(model).join(subquery, model.id == subquery.c.id)
 
     def count(self, db: Session) -> int:
         """Return the number of matched entities for the query."""
@@ -459,7 +459,7 @@ class BaseQuerySchema(BaseModel):
         if None in [minimum, maximum]:
             row = (
                 db.query(func.min(column), func.max(column))
-                .join(subquery, self.table.model.id == subquery.c.id)  # type: ignore
+                .join(subquery, self.table.model.id == subquery.c.id)
                 .first()
             )
             if row is None:
@@ -613,7 +613,7 @@ class StudyQuerySchema(BaseQuerySchema):
         """Generate a query counting matching omics_processing types."""
         workflow_model = query_schema.table.model
         aliased_workflow_model = aliased(workflow_model)
-        table_name = workflow_model.__tablename__  # type: ignore
+        table_name = workflow_model.__tablename__
         was_informed_by_table = models.workflow_activity_to_data_generation_map[table_name]
 
         op_alias = aliased(models.OmicsProcessing)
@@ -678,7 +678,7 @@ class StudyQuerySchema(BaseQuerySchema):
         aggs = []
         for omics_class in workflow_search_classes:
             pipeline_model = omics_class().table.model
-            table_name = pipeline_model.__tablename__  # type: ignore
+            table_name = pipeline_model.__tablename__
             filter_conditions = [
                 c
                 for c in self.conditions
@@ -691,7 +691,7 @@ class StudyQuerySchema(BaseQuerySchema):
             study_id = getattr(omics_subquery.c, f"{table_name}_study_id")
             query = query.join(
                 omics_subquery,
-                self.table.model.id == study_id,  # type: ignore
+                self.table.model.id == study_id,
                 isouter=True,
             )
             aggs.append(
@@ -740,7 +740,7 @@ class StudyQuerySchema(BaseQuerySchema):
                 models.Biosample.study_id
             ).distinct()
             study_query = study_query.where(  # type: ignore
-                self.table.model.id.in_(studies_from_sample_query)  # type: ignore
+                self.table.model.id.in_(studies_from_sample_query)
             )
         elif omics_condition_exists:
             omics_query = OmicsProcessingQuerySchema(conditions=self.conditions).query(db)
@@ -748,7 +748,7 @@ class StudyQuerySchema(BaseQuerySchema):
                 models.OmicsProcessing.study_id
             ).distinct()
             study_query = study_query.where(  # type: ignore
-                self.table.model.id.in_(studies_from_omics_query)  # type: ignore
+                self.table.model.id.in_(studies_from_omics_query)
             )
         return study_query
 
@@ -767,8 +767,8 @@ class StudyQuerySchema(BaseQuerySchema):
         return self._inject_omics_data_summary(
             db,
             db.query(model)
-            .join(subquery, model.id == subquery.c.id)  # type: ignore
-            .join(sample_count, model.id == sample_count.c.study_id, isouter=True)  # type: ignore
+            .join(subquery, model.id == subquery.c.id)
+            .join(sample_count, model.id == sample_count.c.study_id, isouter=True)
             .order_by(models.Study.annotations["title"].astext)
             .options(with_expression(models.Study.sample_count, sample_count.c.sample_count)),
         )
@@ -836,7 +836,7 @@ class BiosampleQuerySchema(BaseQuerySchema):
                 .distinct()
             )
             sample_query = sample_query.where(  # type: ignore
-                self.table.model.id.in_(samples_from_omics_query)  # type: ignore
+                self.table.model.id.in_(samples_from_omics_query)
             )
         return sample_query
 
@@ -845,8 +845,8 @@ class BiosampleQuerySchema(BaseQuerySchema):
         subquery = self.query(db).subquery()
         biosample_query = (
             db.query(model)
-            .join(subquery, model.id == subquery.c.id)  # type: ignore
-            .order_by(self.table.model.multiomics.desc(), self.table.model.id)  # type: ignore
+            .join(subquery, model.id == subquery.c.id)
+            .order_by(self.table.model.multiomics.desc(), self.table.model.id)
         )
 
         if prefetch_omics_processing_data:
@@ -864,16 +864,16 @@ class BiosampleQuerySchema(BaseQuerySchema):
             for model in workflow_activity_types:
                 biosample_query = biosample_query.options(
                     selectinload(models.Biosample.omics_processing)
-                    .selectinload(getattr(models.OmicsProcessing, model.__tablename__))  # type: ignore[attr-defined] # noqa: E501
-                    .selectinload(model.outputs)  # type: ignore[attr-defined]
+                    .selectinload(getattr(models.OmicsProcessing, model.__tablename__))  # noqa: E501
+                    .selectinload(model.outputs)
                 )
 
                 # The MAGsAnalysis specifically needs to also prefetch the mags_list
                 if model == models.MAGsAnalysis:
                     biosample_query = biosample_query.options(
                         selectinload(models.Biosample.omics_processing)
-                        .selectinload(getattr(models.OmicsProcessing, model.__tablename__))  # type: ignore[attr-defined] # noqa: E501
-                        .selectinload(model.mags_list)  # type: ignore[attr-defined]
+                        .selectinload(getattr(models.OmicsProcessing, model.__tablename__))  # noqa: E501
+                        .selectinload(model.mags_list)
                     )
 
         return biosample_query

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ dependencies = [
     "soupsieve==2.6",
     "sparqlslurper==0.5.1",
     "sparqlwrapper==2.0.0",
-    "sqlalchemy<2",
+    "sqlalchemy>=2",
     "sqlparse==0.5.3",
     "stack-data==0.6.3",
     "starlette==0.38.6",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from nmdc_server import database, schemas
 from nmdc_server.app import create_app
 from nmdc_server.auth import create_token_response
 from nmdc_server.config import settings
+from nmdc_server.database import engine
 from nmdc_server.fakes import UserFactory
 from nmdc_server.fakes import db as _db
 from nmdc_server.storage import BucketName, storage
@@ -55,12 +56,12 @@ def patch_zip_stream_service(monkeypatch):
 def connection():
     assert settings.environment == "testing"
     try:
-        database.metadata.drop_all()
-        database.metadata.create_all()
+        database.metadata.drop_all(bind=engine)
+        database.metadata.create_all(bind=engine)
         yield _db
     finally:
         _db.rollback()
-        database.metadata.drop_all()
+        database.metadata.drop_all(bind=engine)
         _db.remove()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ base_python = 3.12
 deps =
   mypy
   pydantic
+  sqlalchemy-stubs>=0.4
   types-setuptools
   types-python-dateutil
   types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ setenv =
   NMDC_ENVIRONMENT = testing
   SQLALCHEMY_SILENCE_UBER_WARNING=1
   NMDC_GCS_USE_FAKE = true
+  # Catch issues that need to be addressed for 2.0 migration
+  SQLALCHEMY_WARN_20=1
 passenv =
   NMDC_TESTING_DATABASE_URI
   NMDC_GCS_FAKE_API_ENDPOINT
@@ -72,7 +74,10 @@ commands = black nmdc_server tests
 
 [pytest]
 addopts = --verbose --showlocals
-filterwarnings = ignore::pydantic.PydanticDeprecatedSince20
+filterwarnings =
+  ignore::pydantic.PydanticDeprecatedSince20
+  error:sqlalchemy.exc.SADeprecationWarning
+  error:sqlalchemy.exc.SAPendingDeprecationWarning
 
 [flake8]
 format = pylint

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,6 @@ base_python = 3.12
 deps =
   mypy
   pydantic
-  sqlalchemy-stubs>=0.4
   types-setuptools
   types-python-dateutil
   types-requests


### PR DESCRIPTION
Fixes #1697 

### Changes

To perform the migration from SQLAlchemy 1.4 to SQLAlchemy 2.0, I followed the official [migration guide](https://docs.sqlalchemy.org/en/21/changelog/migration_20.html). To briefly summarize the steps taken, see the "commits" tab of this PR. 

The bulk of the process involved turning on warnings for features that were added/removed/changed between v1.4 and v2.0, and addressing each of those warnings one at a time, until `tox -e py312` stopped logging SQLAlchemy-related warnings. This process has been preserved by the commit history of this branch, so it is recommended to review it sequentially.

There may be some confusion about the removal of the `mypy` plugin for `SQLAlchemy`, and the decision to revert that change. SQLAlchemy 2.0 now provides a [mapper](https://docs.sqlalchemy.org/en/21/orm/declarative_config.html#mapper-configuration-with-declarative), which changes the way model properties are typed.

Instead of overhauling the `models` classes to entirely convert them to use `Mapped`, I've set `__allow_unmapped__` on the base class. Conversion of the models is left as a follow-up and is tracked by #1755. Deferring this allows the package upgrade to happen in a minimal way at first, to get this in people's hands as soon as possible.

TODO:
- [x] Decide what to do about typing. SQLAlchemy 2.0 uses [Mapped](https://docs.sqlalchemy.org/en/21/orm/declarative_config.html). We can either update all our models now to be compliant, or rely on `__allow_unmapped__` and use the soon-to-be-deprecated [mypy sqlalchemy plugin](https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html) (which is currently emitting incorrect errors)
- [x] Verify ingest still works