### PR TITLE
Add tooltip to disabled omics buttons

### DIFF
--- a/web/src/components/SampleListExpansion.vue
+++ b/web/src/components/SampleListExpansion.vue
@@ -44,9 +44,6 @@ export default defineComponent({
     function isDisabled(omicsType: string, projects: any[]) {
       // TODO this is a temporary fix for the amplicon button
       // until we have a proper way to handle amplicon data.
-      if (projects[0].omics_data.length === 0) {
-        console.log('Disabling button for', omicsType, projects);
-      }
       return projects[0].omics_data.length === 0 && omicsType !== 'Amplicon';
     }
 

--- a/web/src/components/SampleListExpansion.vue
+++ b/web/src/components/SampleListExpansion.vue
@@ -44,6 +44,9 @@ export default defineComponent({
     function isDisabled(omicsType: string, projects: any[]) {
       // TODO this is a temporary fix for the amplicon button
       // until we have a proper way to handle amplicon data.
+      if (projects[0].omics_data.length === 0) {
+        console.log('Disabling button for', omicsType, projects);
+      }
       return projects[0].omics_data.length === 0 && omicsType !== 'Amplicon';
     }
 
@@ -71,20 +74,43 @@ export default defineComponent({
     class="d-flex flex-column mb-2"
   >
     <div class="d-flex flex-row flex-wrap">
-      <v-btn
+      <v-tooltip
         v-for="[omicsType, projects] in filteredOmicsProcessing"
         :key="projects[0].id"
-        x-small
-        :outlined="!isOpen(projects[0].id)"
-        :color="isOpen(projects[0].id) ? 'primary' : 'default'"
-        :disabled="isDisabled(omicsType, projects)"
-        class="mr-2 mt-2"
-
-        @click="() => $emit('open-details', projects[0].id)"
+        max-width="350"
+        bottom
+        content-class="clickable-tooltip"
+        close-delay="1000"
       >
-        {{ fieldDisplayName(omicsType) }}
-        <v-icon>mdi-chevron-down</v-icon>
-      </v-btn>
+        <template #activator="{ on, attrs }">
+          <span
+            v-bind="attrs"
+            v-on="isDisabled(omicsType, projects) ? on : ''"
+          >
+            <v-btn
+              x-small
+              :outlined="!isOpen(projects[0].id)"
+              :color="isOpen(projects[0].id) ? 'primary' : 'default'"
+              :disabled="isDisabled(omicsType, projects)"
+              class="mr-2 mt-2"
+              @click="() => $emit('open-details', projects[0].id)"
+            >
+              {{ fieldDisplayName(omicsType) }}
+              <v-icon>mdi-chevron-down</v-icon>
+            </v-btn>
+          </span>
+        </template>
+        <span>
+          Workflows have not been processed yet. Please contact
+          <a
+            class="blue--text text--lighten-2"
+            href="mailto:support@microbiomedata.org"
+          >
+            support@microbiomedata.org
+          </a>
+          if you have questions.
+        </span>
+      </v-tooltip>
     </div>
     <template v-for="[omicsType, projects] in filteredOmicsProcessing">
       <DataObjectTable
@@ -108,3 +134,9 @@ export default defineComponent({
     </template>
   </div>
 </template>
+
+<style scoped>
+.clickable-tooltip {
+  pointer-events: all;
+}
+</style>


### PR DESCRIPTION
Resolves #1023 

Adds a tooltip to the disabled omics buttons (buttons where `omics_data` is empty) that explains why the button is disabled. The tooltip displays:

> Workflows have not been processed yet. Please contact [support@microbiomedata.org](mailto:support@microbiomedata.org) if you have questions.

It is implemented to close with a delay so that a user can hover outside of the button to click the email link inside the tooltip. 

<img width="601" height="272" alt="Screenshot 2025-09-10 at 3 45 32 PM" src="https://github.com/user-attachments/assets/b3f2aa90-f252-4fc8-9037-2050d4daa525" />
