### PR TITLE
Ms protocol fix

### DIFF
--- a/web/src/views/SubmissionPortal/Components/DataTypes.vue
+++ b/web/src/views/SubmissionPortal/Components/DataTypes.vue
@@ -266,7 +266,7 @@ export default defineComponent({
     />
     <ExternalProtocolForm
       v-if="multiOmicsForm.omicsProcessingTypes.includes('mp')"
-      :data-type="'mp'"
+      :data-type="'mpProtocols'"
     />
     <v-checkbox
       v-model="multiOmicsForm.omicsProcessingTypes"
@@ -276,7 +276,7 @@ export default defineComponent({
     />
     <ExternalProtocolForm
       v-if="multiOmicsForm.omicsProcessingTypes.includes('mb')"
-      :data-type="'mb'"
+      :data-type="'mbProtocols'"
     />
     <v-checkbox
       v-model="multiOmicsForm.omicsProcessingTypes"
@@ -286,7 +286,7 @@ export default defineComponent({
     />
     <ExternalProtocolForm
       v-if="multiOmicsForm.omicsProcessingTypes.includes('nom')"
-      :data-type="'nom'"
+      :data-type="'nomProtocols'"
     />
     <v-checkbox
       v-model="multiOmicsForm.omicsProcessingTypes"
@@ -296,7 +296,7 @@ export default defineComponent({
     />
     <ExternalProtocolForm
       v-if="multiOmicsForm.omicsProcessingTypes.includes('lipidome-emsl')"
-      :data-type="'lip'"
+      :data-type="'lipProtocols'"
     />
   </div>
 </template>

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -123,7 +123,7 @@ export default defineComponent({
               </v-icon>
             </template>
             <span>
-              For samples with metaproteomics data, this protocol should describe how those samples were extracted, digested (including which proteolytic enzyme was used), and/or cleaned prior to analysis on an instrument.
+              This protocol should describe how samples were extracted, digested (including which proteolytic enzyme was used), and/or cleaned prior to analysis on an instrument.
             </span>
           </v-tooltip>
         </div>
@@ -489,7 +489,7 @@ export default defineComponent({
               </v-icon>
             </template>
             <span>
-              Provide the location of the publically available proteomics data. This can be a direct URL or a DOI or an identifier.
+              Provide the location of the publically available data. This can be a direct URL or a DOI or an identifier.
             </span>
           </v-tooltip>
         </div>
@@ -527,7 +527,8 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.              </span>
+                      Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.
+                    </span>
                   </v-tooltip>
                 </template>
               </v-text-field>

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -60,9 +60,11 @@ export default defineComponent({
         (value: string) => {
           if (!value) return true;
 
-          const isValidDoi = checkDoiFormat(value);
+          // Split by comma and validate each DOI
+          const dois = value.split(',').map((doi) => doi.trim());
+          const allValid = dois.every((doi) => checkDoiFormat(doi));
 
-          return isValidDoi || 'Must be a valid DOI';
+          return allValid || 'All DOIs must be valid (comma-separated if multiple)';
         },
       ]
     );
@@ -72,10 +74,12 @@ export default defineComponent({
         (value: string) => {
           if (!value) return true;
 
+          // Split by comma and validate each URL
+          const urls = value.split(',').map((url) => url.trim());
           const urlRegex = /^https?:\/\//i;
-          const isValidUrl = urlRegex.test(value);
+          const allValid = urls.every((url) => urlRegex.test(url));
 
-          return isValidUrl || 'Must be a valid URL';
+          return allValid || 'All URLs must be valid (comma-separated if multiple)';
         },
       ]
     );
@@ -218,7 +222,7 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.              </span>
+                      Provide a DOI for the protocol. This is a DOI for publicly available documentation that describes the experimental protocol in detail, not for the research study publication. Multiple DOIs can be provided.              </span>
                   </v-tooltip>
                 </template>
               </v-text-field>
@@ -251,7 +255,7 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a URL for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs can be provided.
+                      Provide a URL for the protocol. This is a URL for publicly available documentation that describes the experimental protocol in detail, not for the research study publication. Multiple URLs can be provided.
                     </span>
                   </v-tooltip>
                 </template>
@@ -372,7 +376,7 @@ export default defineComponent({
                     </v-icon>
                   </template>
                   <span>
-                    Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.
+                    Provide a DOI for the protocol. This is a DOI for publicly available documentation that describes the experimental protocol in detail, not for the research study publication. Multiple DOIs can be provided.
                   </span>
                 </v-tooltip>
               </template>
@@ -406,7 +410,7 @@ export default defineComponent({
                     </v-icon>
                   </template>
                   <span>
-                    Provide a URL for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs can be provided.
+                    Provide a URL for the protocol. This is a URL for publicly available documentation that describes the experimental protocol in detail, not for the research study publication. Multiple URLs can be provided.
                   </span>
                 </v-tooltip>
               </template>
@@ -527,7 +531,7 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.
+                      Provide a DOI for the protocol. This is a DOI for publicly available documentation that describes the experimental protocol in detail, not for the research study publication. Multiple DOIs can be provided.
                     </span>
                   </v-tooltip>
                 </template>
@@ -561,7 +565,7 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a URL for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs can be provided.
+                      Provide a URL for the protocol. This is a URL for publicly available documentation that describes the experimental protocol in detail, not for the research study publication. Multiple URLs can be provided.
                     </span>
                   </v-tooltip>
                 </template>

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -44,8 +44,24 @@ export default defineComponent({
     const doiValueRules = () => (
       [
         (value: string) => {
-          const valid = !value || checkDoiFormat(value);
-          return valid || 'DOI must be in the correct format.';
+          if (!value) return true;
+
+          const isValidDoi = checkDoiFormat(value);
+
+          return isValidDoi || 'Must be a valid DOI';
+        },
+      ]
+    );
+
+    const urlValueRules = () => (
+      [
+        (value: string) => {
+          if (!value) return true;
+
+          const urlRegex = /^https?:\/\//i;
+          const isValidUrl = urlRegex.test(value);
+
+          return isValidUrl || 'Must be a valid URL';
         },
       ]
     );
@@ -55,6 +71,7 @@ export default defineComponent({
       multiOmicsForm,
       protocolNames,
       doiValueRules,
+      urlValueRules,
       updateMultiOmicsForm,
     };
   },
@@ -165,7 +182,7 @@ export default defineComponent({
             >
               <v-text-field
                 v-model="currentProtocol.doi"
-                label="URL/DOI"
+                label="DOI"
                 outlined
                 dense
                 :rules="doiValueRules()"
@@ -187,7 +204,40 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a URL or DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs or DOIs can be provided.              </span>
+                      Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.              </span>
+                  </v-tooltip>
+                </template>
+              </v-text-field>
+            </v-col>
+            <v-col
+              cols="5"
+            >
+              <v-text-field
+                v-model="currentProtocol.url"
+                label="URL"
+                outlined
+                dense
+                :rules="urlValueRules()"
+                @blur="updateMultiOmicsForm('sampleProtocol')"
+              >
+                <template #append-outer>
+                  <v-tooltip
+                    right
+                    class="x-2"
+                    max-width="500"
+                  >
+                    <template #activator="{ on, attrs }">
+                      <v-icon
+                        v-bind="attrs"
+                        dense
+                        v-on="on"
+                      >
+                        mdi-help-circle
+                      </v-icon>
+                    </template>
+                    <span>
+                      Provide a URL for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs can be provided.
+                    </span>
                   </v-tooltip>
                 </template>
               </v-text-field>
@@ -285,7 +335,7 @@ export default defineComponent({
           >
             <v-text-field
               v-model="currentProtocol.doi"
-              label="URL/DOI"
+              label="DOI"
               outlined
               dense
               :rules="doiValueRules()"
@@ -307,7 +357,41 @@ export default defineComponent({
                     </v-icon>
                   </template>
                   <span>
-                    Provide a URL or DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs or DOIs can be provided.              </span>
+                    Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.
+                  </span>
+                </v-tooltip>
+              </template>
+            </v-text-field>
+          </v-col>
+          <v-col
+            cols="5"
+          >
+            <v-text-field
+              v-model="currentProtocol.url"
+              label="URL"
+              outlined
+              dense
+              :rules="urlValueRules()"
+              @blur="updateMultiOmicsForm('acquisitionProtocol')"
+            >
+              <template #append-outer>
+                <v-tooltip
+                  right
+                  class="x-2"
+                  max-width="500"
+                >
+                  <template #activator="{ on, attrs }">
+                    <v-icon
+                      v-bind="attrs"
+                      dense
+                      v-on="on"
+                    >
+                      mdi-help-circle
+                    </v-icon>
+                  </template>
+                  <span>
+                    Provide a URL for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs can be provided.
+                  </span>
                 </v-tooltip>
               </template>
             </v-text-field>
@@ -405,9 +489,10 @@ export default defineComponent({
             >
               <v-text-field
                 v-model="currentProtocol.doi"
-                label="URL/DOI"
+                label="DOI"
                 outlined
                 dense
+                :rules="doiValueRules()"
                 @blur="updateMultiOmicsForm('dataProtocol')"
               >
                 <template #append-outer>
@@ -426,7 +511,40 @@ export default defineComponent({
                       </v-icon>
                     </template>
                     <span>
-                      Provide a URL or DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs or DOIs can be provided.              </span>
+                      Provide a DOI for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple DOIs can be provided.              </span>
+                  </v-tooltip>
+                </template>
+              </v-text-field>
+            </v-col>
+            <v-col
+              cols="5"
+            >
+              <v-text-field
+                v-model="currentProtocol.url"
+                label="URL"
+                outlined
+                dense
+                :rules="urlValueRules()"
+                @blur="updateMultiOmicsForm('dataProtocol')"
+              >
+                <template #append-outer>
+                  <v-tooltip
+                    right
+                    class="x-2"
+                    max-width="500"
+                  >
+                    <template #activator="{ on, attrs }">
+                      <v-icon
+                        v-bind="attrs"
+                        dense
+                        v-on="on"
+                      >
+                        mdi-help-circle
+                      </v-icon>
+                    </template>
+                    <span>
+                      Provide a URL for the protocol. This is not for the study publication, but a public protocol that explains the protocol in detail. Multiple URLs can be provided.
+                    </span>
                   </v-tooltip>
                 </template>
               </v-text-field>

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -225,6 +225,7 @@ export default defineComponent({
             </v-col>
             <v-col
               cols="5"
+              class="ml-4"
             >
               <v-text-field
                 v-model="currentProtocol.sampleProtocol.url"
@@ -379,6 +380,7 @@ export default defineComponent({
           </v-col>
           <v-col
             cols="5"
+            class="ml-4"
           >
             <v-text-field
               v-model="currentProtocol.acquisitionProtocol.url"
@@ -532,6 +534,7 @@ export default defineComponent({
             </v-col>
             <v-col
               cols="5"
+              class="ml-4"
             >
               <v-text-field
                 v-model="currentProtocol.dataProtocol.url"

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -28,17 +28,31 @@ export default defineComponent({
       return Array.from(names);
     });
 
+    const existingProtocols = computed(() => (multiOmicsForm as Record<'mpProtocols' | 'mbProtocols' | 'nomProtocols' | 'lipProtocols', any>)[props.dataType]);
+
     const currentProtocol = ref({
-      name: '',
-      description: '',
-      doi: '',
-      url: '',
-      sharedData: false,
-      sharedDataName: '',
+      sampleProtocol: {
+        name: existingProtocols.value?.sampleProtocol.name || '',
+        description: existingProtocols.value?.sampleProtocol.description || '',
+        doi: existingProtocols.value?.sampleProtocol.doi || '',
+        url: existingProtocols.value?.sampleProtocol.url || '',
+        sharedData: existingProtocols.value?.sampleProtocol.sharedData || false,
+        sharedDataName: existingProtocols.value?.sampleProtocol.sharedDataName || '',
+      },
+      acquisitionProtocol: {
+        doi: existingProtocols.value?.acquisitionProtocol.doi || '',
+        url: existingProtocols.value?.acquisitionProtocol.url || '',
+        name: existingProtocols.value?.acquisitionProtocol.name || '',
+        description: existingProtocols.value?.acquisitionProtocol.description || '',
+      },
+      dataProtocol: {
+        doi: existingProtocols.value?.dataProtocol.doi || '',
+        url: existingProtocols.value?.dataProtocol.url || '',
+      },
     });
 
-    function updateMultiOmicsForm(protocolType: string) {
-      (multiOmicsForm as Record<'mpProtocols' | 'mbProtocols' | 'nomProtocols' | 'lipProtocols', any>)[props.dataType][protocolType] = currentProtocol.value;
+    function updateMultiOmicsForm() {
+      (multiOmicsForm as Record<'mpProtocols' | 'mbProtocols' | 'nomProtocols' | 'lipProtocols', any>)[props.dataType] = currentProtocol.value;
     }
 
     const doiValueRules = () => (
@@ -119,10 +133,10 @@ export default defineComponent({
           no-gutters
         >
           <template
-            v-if="protocolNames.length > 0 && multiOmicsForm[`${dataType}`].sampleProtocol.name === ''"
+            v-if="protocolNames.length > 0 && !currentProtocol.sampleProtocol.name"
           >
             <v-checkbox
-              v-model="multiOmicsForm[`${dataType}`].sampleProtocol.sharedData"
+              v-model="currentProtocol.sampleProtocol.sharedData"
               label="Protocol shared across data types"
               class="mx-2"
               color="primary"
@@ -150,7 +164,7 @@ export default defineComponent({
             </v-checkbox>
           </template>
           <template
-            v-if="multiOmicsForm[`${dataType}`].sampleProtocol.sharedData && protocolNames.length > 0"
+            v-if="currentProtocol.sampleProtocol.sharedData && protocolNames.length > 0"
           >
             <v-col
               cols="1"
@@ -159,19 +173,19 @@ export default defineComponent({
               cols="4"
             >
               <v-select
-                v-model="currentProtocol.sharedDataName"
+                v-model="currentProtocol.sampleProtocol.sharedDataName"
                 :items="protocolNames"
                 label="Select Protocol Name"
                 outlined
                 dense
                 class="mx-2"
-                @change="updateMultiOmicsForm('sampleProtocol')"
+                @change="updateMultiOmicsForm()"
               />
             </v-col>
           </template>
         </v-row>
         <template
-          v-if="!multiOmicsForm[`${dataType}`].sampleProtocol.sharedData"
+          v-if="!currentProtocol.sampleProtocol.sharedData"
         >
           <v-row
             class="mx-8 "
@@ -181,12 +195,12 @@ export default defineComponent({
               cols="5"
             >
               <v-text-field
-                v-model="currentProtocol.doi"
+                v-model="currentProtocol.sampleProtocol.doi"
                 label="DOI"
                 outlined
                 dense
                 :rules="doiValueRules()"
-                @blur="updateMultiOmicsForm('sampleProtocol')"
+                @blur="updateMultiOmicsForm()"
               >
                 <template #append-outer>
                   <v-tooltip
@@ -213,12 +227,12 @@ export default defineComponent({
               cols="5"
             >
               <v-text-field
-                v-model="currentProtocol.url"
+                v-model="currentProtocol.sampleProtocol.url"
                 label="URL"
                 outlined
                 dense
                 :rules="urlValueRules()"
-                @blur="updateMultiOmicsForm('sampleProtocol')"
+                @blur="updateMultiOmicsForm()"
               >
                 <template #append-outer>
                   <v-tooltip
@@ -256,11 +270,11 @@ export default defineComponent({
               cols="5"
             >
               <v-text-field
-                v-model="currentProtocol.name"
+                v-model="currentProtocol.sampleProtocol.name"
                 label="Protocol Name"
                 outlined
                 dense
-                @blur="updateMultiOmicsForm('sampleProtocol')"
+                @blur="updateMultiOmicsForm()"
               >
                 <template #append-outer>
                   <v-tooltip
@@ -289,12 +303,12 @@ export default defineComponent({
             no-gutters
           >
             <v-textarea
-              v-model="currentProtocol.description"
+              v-model="currentProtocol.sampleProtocol.description"
               label="Protocol Description"
               outlined
               dense
               rows="3"
-              @blur="updateMultiOmicsForm('sampleProtocol')"
+              @blur="updateMultiOmicsForm()"
             />
           </v-row>
         </template>
@@ -334,12 +348,12 @@ export default defineComponent({
             cols="5"
           >
             <v-text-field
-              v-model="currentProtocol.doi"
+              v-model="currentProtocol.acquisitionProtocol.doi"
               label="DOI"
               outlined
               dense
               :rules="doiValueRules()"
-              @blur="updateMultiOmicsForm('acquisitionProtocol')"
+              @blur="updateMultiOmicsForm()"
             >
               <template #append-outer>
                 <v-tooltip
@@ -367,12 +381,12 @@ export default defineComponent({
             cols="5"
           >
             <v-text-field
-              v-model="currentProtocol.url"
+              v-model="currentProtocol.acquisitionProtocol.url"
               label="URL"
               outlined
               dense
               :rules="urlValueRules()"
-              @blur="updateMultiOmicsForm('acquisitionProtocol')"
+              @blur="updateMultiOmicsForm()"
             >
               <template #append-outer>
                 <v-tooltip
@@ -410,11 +424,11 @@ export default defineComponent({
             cols="5"
           >
             <v-text-field
-              v-model="currentProtocol.name"
+              v-model="currentProtocol.acquisitionProtocol.name"
               label="Protocol Name"
               outlined
               dense
-              @blur="updateMultiOmicsForm('acquisitionProtocol')"
+              @blur="updateMultiOmicsForm()"
             >
               <template #append-outer>
                 <v-tooltip
@@ -443,12 +457,12 @@ export default defineComponent({
           no-gutters
         >
           <v-textarea
-            v-model="currentProtocol.description"
+            v-model="currentProtocol.acquisitionProtocol.description"
             label="Protocol Description"
             outlined
             dense
             rows="3"
-            @blur="updateMultiOmicsForm('acquisitionProtocol')"
+            @blur="updateMultiOmicsForm()"
           />
         </v-row>
       </v-expansion-panel-content>
@@ -488,12 +502,12 @@ export default defineComponent({
               cols="5"
             >
               <v-text-field
-                v-model="currentProtocol.doi"
+                v-model="currentProtocol.dataProtocol.doi"
                 label="DOI"
                 outlined
                 dense
                 :rules="doiValueRules()"
-                @blur="updateMultiOmicsForm('dataProtocol')"
+                @blur="updateMultiOmicsForm()"
               >
                 <template #append-outer>
                   <v-tooltip
@@ -520,12 +534,12 @@ export default defineComponent({
               cols="5"
             >
               <v-text-field
-                v-model="currentProtocol.url"
+                v-model="currentProtocol.dataProtocol.url"
                 label="URL"
                 outlined
                 dense
                 :rules="urlValueRules()"
-                @blur="updateMultiOmicsForm('dataProtocol')"
+                @blur="updateMultiOmicsForm()"
               >
                 <template #append-outer>
                   <v-tooltip

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -120,6 +120,10 @@ export default defineComponent({
       multiOmicsForm.mtCompatible = undefined;
       multiOmicsForm.mtInterleaved = undefined;
       multiOmicsForm.facilities = [];
+      multiOmicsForm.lipProtocols = undefined;
+      multiOmicsForm.mbProtocols = undefined;
+      multiOmicsForm.nomProtocols = undefined;
+      multiOmicsForm.mpProtocols = undefined;
       revalidate();
     }
 

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -138,39 +138,6 @@ export default defineComponent({
       },
     );
 
-    const emptyProtocols = {
-      sampleProtocol: {
-        doi: undefined,
-        name: '',
-        url: '',
-        description: '',
-        sharedData: false,
-        sharedDataName: undefined,
-      },
-      dataProtocol: {
-        doi: undefined,
-        url: '',
-      },
-      acquisitionProtocol: {
-        doi: undefined,
-        name: '',
-        url: '',
-        description: '',
-      },
-    };
-    // Hydrate protocols if facilityGenerated is false
-    watch(() => multiOmicsForm.facilityGenerated, () => {
-      if (multiOmicsForm.facilityGenerated === false) {
-        Object.assign(multiOmicsForm, {
-          mpProtocols: { ...emptyProtocols },
-          lipProtocols: { ...emptyProtocols },
-          nomProtocols: { ...emptyProtocols },
-          mbProtocols: { ...emptyProtocols },
-        });
-      }
-      revalidate();
-    });
-
     onMounted(() => {
       formRef.value.validate();
     });

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -176,10 +176,10 @@ const multiOmicsFormDefault = {
   ship: undefined as undefined | boolean,
   studyNumber: '',
   unknownDoi: undefined as undefined | boolean,
-  mpProtocols: protocols,
-  mbProtocols: protocols,
-  lipProtocols: protocols,
-  nomProtocols: protocols,
+  mpProtocols: undefined as undefined | typeof protocols,
+  mbProtocols: undefined as undefined | typeof protocols,
+  lipProtocols: undefined as undefined | typeof protocols,
+  nomProtocols: undefined as undefined | typeof protocols,
 };
 const multiOmicsFormValid = ref(false);
 const multiOmicsForm = reactive(clone(multiOmicsFormDefault));


### PR DESCRIPTION
This fixes a state bug that was seen on dev. Also this splits out the `DOI/URL` field into two fields.
Testing steps:
1. Create a submission and proceed to the Multiomics Form.
2. Choose 'yes' to question 1 (Have data already been generated for your study?)
3. Choose 'non to question 2 (Was data generated at a DOE user facility (JGI, EMSL)? )
4. The External Protocol forms should appear as expansion panels for the following data types: Metaproteome, Metabolome, Natural Organic Matter (FT-ICR MS), Lipidome.

5. Fill out a couple of forms on different data types and ensure they update separately.

*Note*
- There are 3 types of External protocol; Sample Preparation Protocol, Data Acquistion Protocol and Data Access
- You should expect to see two fields for URL and DOI
- Sample Preparation Protocol is unique in that it can be shared across different data types. Once you have filled out the name field for a Sample Prep on one data type you chaould have the option to select 'Protocol shared across data types' on other data types. When that is selected a dropdown should populate with the name(s) you have entered on the other protocol(s).

<img width="3055" height="857" alt="Screenshot from 2025-09-19 16-31-56" src="https://github.com/user-attachments/assets/2c9fe645-f1bd-4b73-ac54-18e0826308fe" />

Enter different names for a couple of protocols:
<img width="3051" height="1879" alt="Screenshot from 2025-09-19 16-32-38" src="https://github.com/user-attachments/assets/fd43152e-cfd8-473c-9343-bed96343cff8" />


<img width="2452" height="556" alt="Screenshot from 2025-09-19 16-33-00" src="https://github.com/user-attachments/assets/27ce3938-3af0-4592-98fc-cdb0f813a31b" />


