### PR TITLE
Fix bug in UpSet plot causing incorrect values for LIP

### DIFF
--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -229,7 +229,7 @@ function makeSetsFromBitmask(mask_str: string) {
   const sets = [];
 
   /* eslint-disable no-bitwise */
-  if ((1 << 1) & mask) {
+  if ((1 << 2) & mask) {
     sets.push('NOM');
   }
   if ((1 << 6) & mask) {
@@ -244,7 +244,7 @@ function makeSetsFromBitmask(mask_str: string) {
   if ((1 << 5) & mask) {
     sets.push('MG');
   }
-  if ((1 << 2) & mask) {
+  if ((1 << 1) & mask) {
     sets.push('LIP');
   }
   if (1 & mask) {
@@ -678,8 +678,8 @@ const MultiomicsValue = {
   MG: 0b0100000,
   MP: 0b0010000,
   MT: 0b0001000,
-  LIP: 0b0000100,
-  NOM: 0b0000010,
+  NOM: 0b0000100,
+  LIP: 0b0000010,
   AMP: 0b0000001,
 };
 


### PR DESCRIPTION
After the amplicon data type was introduced, the NOM and LIP bitmap values got mixed up and did not match the encodings in [multiomics.py](https://github.com/microbiomedata/nmdc-server/blob/main/nmdc_server/multiomics.py). This change ensures that the encodings on the frontend match the encodings on the backend.

Below is the updated UpSet plot:

<img width="1099" height="303" alt="Screenshot 2025-10-02 at 12 22 50 PM" src="https://github.com/user-attachments/assets/2efd7842-b2c1-4b63-abcc-d80e7734f5c0" />
