### PR TITLE
Renenable Spin workload redeployment via GHA workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,36 +80,35 @@ jobs:
               )
             }}
 
-  # TEMPORARILY COMMENTED OUT IN ORDER TO NOT INTERFERE WITH NERSC'S 
-  # DEBUGGING OF SPIN STABILITY ISSUES
+  # Use the Rancher API to redeploy the specified deployments,
+  # causing them to use the newly-pushed container images.
+  redeploy:
+    needs: build
 
-  # redeploy:
-  #   needs: build
+    runs-on: ubuntu-latest
 
-  #   runs-on: ubuntu-latest
+    env:
+      WORKLOAD_API_BASE: https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads
 
-  #   env:
-  #     WORKLOAD_API_BASE: https://rancher2.spin.nersc.gov/v3/project/c-tmq7p:p-bkv45/workloads
+    strategy:
+      matrix:
+        deployment: [ backend, frontend ]
 
-  #   strategy:
-  #     matrix:
-  #       deployment: [ backend, frontend ]
+    steps:
+      - name: Redeploy nmdc-dev:portal-${{ matrix.deployment }}
+        if: ${{ env.IS_PROD_RELEASE == 'false' && env.IS_ORIGINAL_REPO == 'true' }}
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc-dev:portal-${{ matrix.deployment }}?action=redeploy
+          method: POST
+          username: ${{ secrets.SPIN_USER }}
+          password: ${{ secrets.SPIN_PASSWORD }}
 
-  #   steps:
-  #     - name: Redeploy nmdc-dev:portal-${{ matrix.deployment }}
-  #       if: ${{ env.IS_PROD_RELEASE == 'false' && env.IS_ORIGINAL_REPO == 'true' }}
-  #       uses: fjogeleit/http-request-action@v1
-  #       with:
-  #         url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc-dev:portal-${{ matrix.deployment }}?action=redeploy
-  #         method: POST
-  #         username: ${{ secrets.SPIN_USER }}
-  #         password: ${{ secrets.SPIN_PASSWORD }}
-
-  #     - name: Redeploy nmdc:portal-${{ matrix.deployment }}
-  #       if: ${{ env.IS_PROD_RELEASE == 'true' && env.IS_ORIGINAL_REPO == 'true' }}
-  #       uses: fjogeleit/http-request-action@v1
-  #       with:
-  #         url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc:portal-${{ matrix.deployment }}?action=redeploy
-  #         method: POST
-  #         username: ${{ secrets.SPIN_USER }}
-  #         password: ${{ secrets.SPIN_PASSWORD }}
+      - name: Redeploy nmdc:portal-${{ matrix.deployment }}
+        if: ${{ env.IS_PROD_RELEASE == 'true' && env.IS_ORIGINAL_REPO == 'true' }}
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ env.WORKLOAD_API_BASE }}/deployment:nmdc:portal-${{ matrix.deployment }}?action=redeploy
+          method: POST
+          username: ${{ secrets.SPIN_USER }}
+          password: ${{ secrets.SPIN_PASSWORD }}


### PR DESCRIPTION
On this branch, I updated a GHA workflow so it would once again redeploy Spin workloads after pushing new container images to GHCR. We had temporarily disabled this functionality while NERSC staff was debugging Spin.