### PR TITLE
Restore missing Templates and Date Modified column formatting

### DIFF
--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -320,6 +320,12 @@ export default defineComponent({
               :authenticated="true"
             />
           </template>
+          <template #[`item.templates`]="{ item }">
+            {{ item.templates.map((template) => HARMONIZER_TEMPLATES[template].displayName).join(' + ') }}
+          </template>
+          <template #[`item.date_last_modified`]="{ item }">
+            {{ new Date(item.date_last_modified + 'Z').toLocaleString() }}
+          </template>
           <template #[`header.status`]="{ header }">
             <v-tooltip
               v-if="currentUser.is_admin"


### PR DESCRIPTION
Fixes #1835 

These changes restores some column formatting that was lost (I believe accidentally) in https://github.com/microbiomedata/nmdc-server/pull/1822.