### PR TITLE
Add `--skip-etl` CLI option to ingest script

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -218,7 +218,12 @@ def truncate():
     help="Skip the ETL step (i.e. the core of the ingest process)",
 )
 def ingest(
-    verbose, function_limit, skip_annotation, swap_rancher_secrets, swap_google_secrets: bool, skip_etl: bool
+    verbose,
+    function_limit,
+    skip_annotation,
+    swap_rancher_secrets,
+    swap_google_secrets: bool,
+    skip_etl: bool,
 ):
     """Ingest the latest data from mongo into the ingest database."""
     level = logging.WARN


### PR DESCRIPTION
On this branch, I added a CLI option to the ingest script.

The CLI option is `--skip-etl` and, when it is passed in, the ingest script will refrain from performing the ETL step (i.e. it will refrain from calling `do_ingest()`). 

This involved wrapping that call (and its surrounding `try`/`except` block) within an `if` block.