### PR TITLE
Add missing dependency to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "flexparser==0.3.1",
     "fqdn==1.5.1",
     "ghp-import==2.1.0",
+    "google-auth==2.40.3",
     "google-cloud-secret-manager==2.24.0",
     "google-cloud-storage==3.1.1",
     "graphviz==0.20.3",


### PR DESCRIPTION
Resolves #1844 

This fixes the error causing the backend to fail on start up.