### PR TITLE
Fix app banner styles

### DIFF
--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -13,20 +13,12 @@ export default defineComponent({
 </script>
 
 <template>
-  <v-banner
+  <v-alert
     v-if="showAppBanner"
+    :title="title || undefined"
+    :text="message || undefined"
     color="blue"
-    dark
     icon="mdi-information"
     class="ma-4"
-  >
-    <p
-      class="title"
-    >
-      {{ title || '' }}
-    </p>
-    <p>
-      {{ message || '' }}
-    </p>
-  </v-banner>
+  />
 </template>


### PR DESCRIPTION
Resolves #1860 

Changes the app banner to use the new `v-alert` component which restores its blue styles.