### PR TITLE
Utilize v-html so hyperlinks render properly in filter menus

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -34,6 +34,7 @@ export default [
       'vuejs-accessibility/click-events-have-key-events': 'off',
       'vue/no-dupe-keys': 'off',
       'vue/no-v-html': 'off',
+      'vue/no-v-text-v-html-on-component': 'off',
       // See: https://github.com/vuejs/eslint-plugin-vue/issues/365
       // The issue is supposed to be resolved, but eslint complains without the ignore
       'vue/html-indent': ['warn', 2, { ignores: ['VElement[name=pre].children'] }],

--- a/web/src/components/MenuContent.vue
+++ b/web/src/components/MenuContent.vue
@@ -107,9 +107,8 @@ export default defineComponent({
     <v-card-text
       v-if="description"
       class="py-1 text-caption"
-    >
-      {{ urlify(description) }}
-    </v-card-text>
+      v-html="urlify(description)"
+    />
     <template v-if="isOpen">
       <filter-list
         v-if="summary.type === 'string'"


### PR DESCRIPTION
Resolves #1864

Changes the menu content so that it is rendered by a `v-html` directive. This ensures that html inside the content is parsed as such. I also turned off the eslint rule that advises against using v-html.