### PR TITLE
Fix submission status `v-select` for Vuetify 3

### DIFF
--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -389,6 +389,7 @@ export default defineComponent({
                 :items="availableStatuses"
                 :loading="statusUpdatingSubmissionId === item.id"
                 density="compact"
+                variant="underlined"
                 hide-details
                 :disabled="item.status === SubmissionStatusEnum.InProgress.text"
                 @update:model-value="(newStatus: string) => handleStatusChange(item, newStatus)"


### PR DESCRIPTION
Fixes #1870 

The linked issue only discusses the display of the selected item, but as I was testing I noticed that the API request was not being triggered when changing the selected item.

These changes:

* In the `availableStatuses` list of objects, replace `text` with `title` and move `disabled` into `props`. This makes the shape of `availableStatuses` match `v-select`'s expected [`items`](https://vuetifyjs.com/en/api/v-select/#props-items) object structure. With that, using the `item-title`, `item-value`, `item-disabled` props and the `selection` slot are no longer needed.
* Replace `:value` and `@change` with `:model-value` and `@update:model-value`, respectively. This results in the `handleStatusChange` callback being correctly invoked.
* Remove some odd duplication with two `v-select`s and replace with one `v-select` and a conditional `:disabled` prop.
* A small quality-of-life enhancement: when a submission's status is being updated, keep track of its ID in a `ref` so that the `:loading` prop of the `v-select` can be set.