### PR TITLE
Account for AppBanner size when computing DataHarmonizer container height

### DIFF
--- a/web/src/components/AppBanner.vue
+++ b/web/src/components/AppBanner.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { computed, defineComponent } from 'vue';
+import { computed, defineComponent, onUpdated, ref, useTemplateRef } from 'vue';
 import { stateRefs } from '@/store';
 
 export default defineComponent({
@@ -7,18 +7,33 @@ export default defineComponent({
     const message = stateRefs.bannerMessage;
     const title = stateRefs.bannerTitle;
     const showAppBanner = computed(() => message.value || title.value);
-    return { showAppBanner, message, title };
+
+    // Compute the height of the banner on updates and expose it to the parent component as `height`
+    const containerElement = useTemplateRef<HTMLDivElement>("container");
+    const containerHeight = ref<number>(0);
+    onUpdated(() => {
+      containerHeight.value = containerElement.value?.offsetHeight || 0;
+    })
+
+    return {
+      showAppBanner,
+      message,
+      title,
+      height: containerHeight
+    };
   },
 });
 </script>
 
 <template>
-  <v-alert
-    v-if="showAppBanner"
-    :title="title || undefined"
-    :text="message || undefined"
-    color="blue"
-    icon="mdi-information"
-    class="ma-4"
-  />
+  <div ref="container">
+    <v-alert
+      v-if="showAppBanner"
+      :title="title || undefined"
+      :text="message || undefined"
+      color="blue"
+      icon="mdi-information"
+      class="ma-4"
+    />
+  </div>
 </template>

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import {
-  computed, defineComponent, ref, nextTick, watch, onMounted, shallowRef,
+  computed, defineComponent, ref, nextTick, watch, onMounted, shallowRef, inject,
 } from 'vue';
 import {
   clamp, debounce, flattenDeep, has, sum,
@@ -46,6 +46,7 @@ import {
   canEditSubmissionByStatus,
   SubmissionStatusEnum,
 } from './store';
+import { AppBannerHeightKey } from './SubmissionView.vue';
 import SubmissionStepper from './Components/SubmissionStepper.vue';
 import SubmissionDocsLink from './Components/SubmissionDocsLink.vue';
 import SubmissionPermissionBanner from './Components/SubmissionPermissionBanner.vue';
@@ -644,9 +645,14 @@ export default defineComponent({
       }
     });
 
+    // Get app banner height provided by SubmissionView. This will be used to correctly size
+    // the DataHarmonizer container, which needs a fixed height.
+    const appBannerHeight = inject(AppBannerHeightKey);
+
     return {
       user,
       APP_HEADER_HEIGHT,
+      appBannerHeight,
       HELP_SIDEBAR_WIDTH,
       TABS_HEIGHT,
       ColorKey,
@@ -704,7 +710,7 @@ export default defineComponent({
 
 <template>
   <div
-    :style="{'overflow-y': 'hidden', 'overflow-x': 'hidden', 'height': `calc(100vh - ${APP_HEADER_HEIGHT}px)`}"
+    :style="{'overflow-y': 'hidden', 'overflow-x': 'hidden', 'height': `calc(100vh - ${APP_HEADER_HEIGHT + (appBannerHeight || 0)}px)`}"
     class="d-flex flex-column"
   >
     <SubmissionStepper />
@@ -930,7 +936,10 @@ export default defineComponent({
     </div>
 
     <v-layout class="harmonizer-and-sidebar">
-      <v-tabs v-model="activeTabIndex" color="primary">
+      <v-tabs
+        v-model="activeTabIndex"
+        color="primary"
+      >
         <v-tooltip
           v-for="templateKey in templateList"
           :key="templateKey"
@@ -1182,14 +1191,6 @@ html {
   height: 100%;
   flex-grow: 1;
   overflow: hidden;
-}
-
-.harmonizer-bottom-container {
-  position: fixed;
-  bottom: 0;
-  z-index: 1000;
-  background: #fff;
-  width: 100%;
 }
 
 .v-navigation-drawer__scrim {

--- a/web/src/views/SubmissionPortal/SubmissionView.vue
+++ b/web/src/views/SubmissionPortal/SubmissionView.vue
@@ -2,8 +2,12 @@
 import {
   computed,
   defineComponent,
+  InjectionKey,
   PropType,
+  provide,
+  Ref,
   toRef,
+  useTemplateRef,
   watch,
 } from 'vue';
 import { stateRefs } from '@/store';
@@ -16,10 +20,11 @@ import LoginPrompt from '@/views/SubmissionPortal/Components/LoginPrompt.vue';
 import { loadRecord } from './store';
 import { useRoute } from 'vue-router';
 
+export const AppBannerHeightKey = Symbol() as InjectionKey<Ref<number>>;
+
 export default defineComponent({
   components: {
     AppBanner,
-
     IconBar,
     IntroBlurb,
     LoginPrompt,
@@ -89,6 +94,11 @@ export default defineComponent({
       },
     }
 
+    // Get the height of the app banner to provide to child components
+    const appBanner = useTemplateRef<InstanceType<typeof AppBanner>>("appBanner");
+    const appBannerHeight = computed(() => appBanner.value?.height || 0);
+    provide(AppBannerHeightKey, appBannerHeight);
+
     return {
       stateRefs,
       req,
@@ -101,8 +111,8 @@ export default defineComponent({
 
 <template>
   <v-defaults-provider :defaults="styleDefaults">
-    <v-main>
-      <AppBanner />
+    <v-main class="d-flex flex-column">
+      <AppBanner ref="appBanner" />
       <v-container
         v-if="!stateRefs.user.value && !req.loading.value"
       >


### PR DESCRIPTION
Fixes #1875 

DataHarmonizer needs a container (not necessarily the direct parent, but some ancestor element) with a fixed height in order to work properly. We set the height on the element that contains the stepper header, the validation controls, DataHarmonizer itself and the help sidebar, and the footer. Currently we set the height of that element as the window height (`100vh`) minus the main application bar height (`APP_HEADER_HEIGHT`). The problem is that this doesn't take into account the height of the site banner which is sometimes shown. This element is outside of the fixed-height container, so it needs to be taken into account as well.

These changes are a little more complex than I would have hoped, but other options I looked at would involve touching the layout of _all_ pages. Here's the summary of what's happening here.

1. The site banner (`AppBanner`) now computes its own height and exposes that as a value that the component that renders `AppBanner` can access.
2. `SubmissionView` renders some common elements for all Submission Portal pages, including `AppBanner`. It uses a `ref` to get the height of the `AppBanner` component and uses [`provide`](https://vuejs.org/guide/components/provide-inject.html#provide-inject) to make that value available to its component tree.
3. `HarmonizerView` is where the `AppBanner` height is needed, so it uses `inject` to get the value. It uses the value when setting the height of the fixed-height container.