### PR TITLE
Update data table components and props for Vuetify 3

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1942,7 +1942,7 @@ async def get_users(
     pagination: Pagination = Depends(),
     search_filter: Optional[str] = None,
 ):
-    users = db.query(User)
+    users = db.query(User).order_by(models.User.name)
     if search_filter:
         users = users.filter(
             (

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -357,8 +357,8 @@ export default defineComponent({
           :headers="headers"
           :items="submission.data.results.results"
           :items-length="submission.data.results.count"
+          :items-per-page-options="[10, 20, 50]"
           :loading="submission.loading.value"
-          :footer-props="{ itemsPerPageOptions: [10, 20, 50] }"
           @update:options="updateTableOptions"
         >
           <template #[`item.study_name`]="{ item }">

--- a/web/src/views/User/UserPage.vue
+++ b/web/src/views/User/UserPage.vue
@@ -41,8 +41,15 @@ export default defineComponent({
       users.setPage(options.value.page);
     }, { deep: true });
 
+    const updating = ref(false);
     async function updateAdminStatus(item: User) {
-      await api.updateUser(item.id, item);
+      updating.value = true;
+      try {
+        await api.updateUser(item.id, item);
+        await users.refetch();
+      } finally {
+        updating.value = false;
+      }
     }
 
     return {
@@ -52,6 +59,7 @@ export default defineComponent({
       options,
       currentUser,
       searchFilter,
+      updating,
     };
   },
 });
@@ -73,17 +81,15 @@ export default defineComponent({
           hide-details
         />
         <v-card variant="outlined">
-          <v-data-table
+          <v-data-table-server
             v-model:options="options"
             v-model:items-per-page="users.data.limit"
-            dense
+            density="compact"
             :headers="headers"
             :items="users.data.results.results"
-            :server-items-length="users.data.results.count"
-            :loading="users.loading.value"
-            :footer-props="{itemsPerPageOptions : [10, 20, 50] }"
-            item-key="name"
-            class="elevation-1"
+            :items-length="users.data.results.count"
+            :items-per-page-options="[10, 20, 50]"
+            :loading="users.loading.value || updating"
           >
             <template #[`item.orcid`]="{ item }">
               <orcid-id
@@ -95,12 +101,13 @@ export default defineComponent({
             <template #[`item.is_admin`]="{ item }">
               <v-switch
                 v-model="item.is_admin"
-                class="mt-2"
+                color="primary"
+                hide-details
                 :disabled="item.name==currentUser?.name"
-                @click="updateAdminStatus(item)"
+                @update:model-value="updateAdminStatus(item)"
               />
             </template>
-          </v-data-table>
+          </v-data-table-server>
         </v-card>
       </v-card>
     </v-container>


### PR DESCRIPTION
Fixes #1882 

The primary changes here are updates to the `UserPage` component to use new Vuetify 3 components (e.g. `v-data-table` &rarr; `v-data-table-server`) and props (e.g. `@click` &rarr; `@update:model-value`).

There was also one similar fix needed in `SubmissionList`.

Finally I set a default, hardcoded sort order on the backend `User` query. Otherwise, the order of rows isn't stable on refetch.