### PR TITLE
Prevent first row from always being removed in submission tab data merge

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -973,15 +973,14 @@ export default defineComponent({
               v-bind="props"
             >
               <v-tab>
+                {{ HARMONIZER_TEMPLATES[templateKey]?.displayName }}
                 <v-badge
                   :content="validationTotalCounts[templateKey] || '!'"
-                  floating
-                  location="top right"
+                  max="99"
+                  inline
                   :model-value="(validationTotalCounts[templateKey] && validationTotalCounts[templateKey] > 0) || !tabsValidated[templateKey]"
                   :color="(validationTotalCounts[templateKey] && validationTotalCounts[templateKey] > 0) ? 'error' : 'warning'"
-                >
-                  {{ HARMONIZER_TEMPLATES[templateKey]?.displayName }}
-                </v-badge>
+                />
               </v-tab>
             </div>
           </template>


### PR DESCRIPTION
Fixes #1885 

In the Vue 3 upgrade an overly permissive truth-y check was added in order to satisfy stricter type-checking. In this code `environmentRow` can be `undefined` or a number. The function _should_ return `true` if `environmentRow` is zero. So the fix is to explicitly check for `undefined` before doing the numeric check.

Secondarily, I noticed in the screenshots in the linked issue that the badge showing the number of validation errors was being clipped by the tab container with Vuetify 3. I'm fixing that here by changing the badge to be `inline` so that it's not absolutely positioned and actually takes up computable space in the tab.