### PR TITLE
Fix letter casing in order to resolve Docker build warning (`as` -> `AS`)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts as build-stage
+FROM node:lts AS build-stage
 
 # Define a "build argument" (i.e. a build-time parameter), which can be set via
 # the `--build-arg KEY=VALUE` argument to the `$ docker build` command.
@@ -18,7 +18,7 @@ COPY . .
 RUN yarn run build
 
 
-FROM nginx:1.28-alpine as production-stage
+FROM nginx:1.28-alpine AS production-stage
 LABEL org.opencontainers.image.source=https://github.com/microbiomedata/nmdc-server
 
 RUN rm -v /etc/nginx/nginx.conf


### PR DESCRIPTION
On this branch, I updated two lines in a Dockerfile, so that they use uppercase `AS` instead of lowercase `as`. This is all to resolve the following warnings, which are shown when building the associated container images:

```py
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 21)
```

Fixes: #1857