### PR TITLE
Add dynamic max-height for study image

### DIFF
--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -203,10 +203,7 @@ export default defineComponent({
       </div>
 
       <div :class="['mainInfoRow', smAndDown ? 'smAndDown' : 'mdAndUp']">
-        <div
-          ref="main-info-col"
-          :class="['mainInfoCol', study.image_url ? 'withImage' : '']"
-        >
+        <div :class="['mainInfoCol', study.image_url ? 'withImage' : '']">
           <IndividualTitle :item="study">
             <template
               v-if="study.description"


### PR DESCRIPTION
Fixes #1895 

These changes make the maximum height of the study image on the study details page dynamic. There are two cases:

1. On small screens, the "main info column" (which contains the study name, description, and data summary) and the "image column" are stacked (both `width: 100%`). The maximum height of the image is capped at 300px by setting the `max-height` prop on the `<v-img>` component.
2. On medium and larger screens, the main info column and image column are displayed side-by-side. In this case we want the height of both to _only_ be dictated by the content of the main info column. This is accomplished by making the image column absolutely positioned and therefore doesn't contribute to the height of the row containing both columns. In this case the `max-height` prop of the `<v-img>` component is _not_ set so that it can fill the maximum allowed space.

The [`useDisplay` composable](https://vuetifyjs.com/en/features/display-and-platform/#usage) from Vuetify is used to make the small vs medium or larger screen size determination. Previously we used Vuetify's `<v-row>` and `<v-col>` components, but with the amount of customization needed here it was easier to directly implement what was needed with CSS classes instead of working around the default behavior of those components.