### PR TITLE
Add secondary ordering columns for submission query

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -895,7 +895,12 @@ def get_submissions_for_user(
     all_submissions = (
         db.query(models.SubmissionMetadata)
         .join(models.User, models.SubmissionMetadata.author_id == models.User.id)
+        # Primary sort by requested column
         .order_by(column.asc() if order == "asc" else column.desc())
+        # Secondary sorts to ensure consistent order since primary sort may have ties
+        # (e.g. multiple submissions from the same author)
+        .order_by(models.SubmissionMetadata.study_name.asc())
+        .order_by(models.SubmissionMetadata.id.asc())
     )
 
     if is_test_submission_filter != None:


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/issues/issues/1531

When the sort order contains ties (e.g. multiple submissions with the same author), Postgres doesn't guarantee any specific order for the tied rows. That means it may come up with different orders for tied rows with `offset = 150, limit = 50` versus `offset = 200, limit = 50`. And the effect is that some individual rows may appear in the results for both queries, either query, or neither query.

The fix is to tell Postgres how to break the ties by adding secondary sort orders. The changes here make it first sort by the requested column (which may result in ties, especial for sorting by author), any ties should be broken by study name (which will _probably_ be unique), and if there are _still_ ties then break the tie by `id` which is guaranteed to be unique. That gives us stable sorting across paginated queries. 