### PR TITLE
Log programmatic slack messages to the terminal

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -119,7 +119,7 @@ def send_slack_message(text: str) -> bool:
     Reference: https://api.slack.com/messaging/webhooks#posting_with_webhooks
     """
     is_sent = False
-
+    click.echo(text)
     # Check whether a Slack Incoming Webhook URL is defined.
     if isinstance(settings.slack_webhook_url_for_ingester, str):
         click.echo(f"Sending Slack message having text: {text}")


### PR DESCRIPTION
The ingest script utilizes the `send_slack_message` function as its primary indicator of start, completion, and failure. If you are running ingest locally, without the slack webhook configured, it is difficult to monitor the success/failure of an ingest by looking at the standard output in the terminal.

This PR makes it so that anytime the `send_slack_message` is invoked, it will also echo the message to the terminal.