### PR TITLE
Make 'jgi_sample_contact' read only in DataHarmonizer

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -100,6 +100,7 @@ const ALWAYS_READ_ONLY_COLUMNS = [
   'jgi_samp_id',
   'jgi_seq_project_name',
   'jgi_project_pi',
+  'jgi_sample_contact',
   'jgi_proposal_id',
 ];
 


### PR DESCRIPTION
This PR undoes https://github.com/microbiomedata/nmdc-server/pull/1929/, making jgi_sample_contact read only in DataHarmonizer.