### PR TITLE
Update Alembic migrations to be compatible with SQLAlchemy 2

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,11 @@
 [mypy]
+# TODO: Remove the deprecated `sqlmypy` plugin, now that we're using SQLAlchemy 2.0.
+#
+#       From the SQLAlchemy 1.4 documentation (updated in 2024):
+#       > - "Deprecated since version 2.0: The SQLAlchemy Mypy Plugin is DEPRECATED [...]"
+#       > - "SQLAlchemy 2.0 [...] removes the need for the Mypy plugin [...]"
+#       Docs: https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
+#
 plugins = pydantic.mypy, sqlmypy
 allow_redefinition = false
 check_untyped_defs = true

--- a/nmdc_server/migrations/versions/0ff690fb929d_add_study_name_and_template_columns_to_.py
+++ b/nmdc_server/migrations/versions/0ff690fb929d_add_study_name_and_template_columns_to_.py
@@ -37,7 +37,7 @@ def upgrade():
 
     connection = op.get_bind()
     submissions = connection.execute(
-        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)
+        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)  # type: ignore[arg-type]
     )
 
     for submission in submissions:

--- a/nmdc_server/migrations/versions/5403c7fe0b33_migrate_study_names.py
+++ b/nmdc_server/migrations/versions/5403c7fe0b33_migrate_study_names.py
@@ -31,7 +31,7 @@ def upgrade():
 
     connection = op.get_bind()
     submissions = connection.execute(
-        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)
+        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)  # type: ignore[arg-type]
     )
 
     for submission in submissions:

--- a/nmdc_server/migrations/versions/afa1ff687968_convert_packagename_to_an_array.py
+++ b/nmdc_server/migrations/versions/afa1ff687968_convert_packagename_to_an_array.py
@@ -32,7 +32,7 @@ def upgrade():
 
     connection = op.get_bind()
     submissions = connection.execute(
-        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)
+        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)  # type: ignore[arg-type]
     )
 
     for submission in submissions:
@@ -62,7 +62,7 @@ def downgrade():
     )
     connection = op.get_bind()
     submissions = connection.execute(
-        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)
+        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)  # type: ignore[arg-type]
     )
     for submission in submissions:
         metadata_submission = submission.metadata_submission

--- a/nmdc_server/migrations/versions/ff4e651c3007_migrate_templates.py
+++ b/nmdc_server/migrations/versions/ff4e651c3007_migrate_templates.py
@@ -30,7 +30,7 @@ def upgrade():
 
     connection = op.get_bind()
     submissions = connection.execute(
-        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)
+        sa.select(submission_metadata.c.id, submission_metadata.c.metadata_submission)  # type: ignore[arg-type]
     )
 
     for submission in submissions:


### PR DESCRIPTION
### Background

We migrated from SQLAlchemy 1 to 2 a few months ago. Four Alembic migrations were not migrated accordingly, and so they would not run anymore. They would fail with this kind of error:

```py
sqlalchemy.exc.ArgumentError: Column expression, FROM clause, or other columns clause element expected, got [<sqlalchemy.sql.elements.ColumnClause at 0xffff97a24890; id>, <sqlalchemy.sql.elements.ColumnClause at 0xffff97a03200; metadata_submission>]. Did you mean to say select(<sqlalchemy.sql.elements.ColumnClause at 0xffff97a24890; id>, <sqlalchemy.sql.elements.ColumnClause at 0xffff97a03200; metadata_submission>)?
```

This didn't affect our Spin or Cloud-hosted environments, since the Postgres databases there had already been migrated. However, it did affect local development. Developers would work around this by restoring already-migrated dumps from production.

### Changes

On this branch, I updated those Alembic migrations to be compatible with SQLAlchemy 2.

Updating them involved converting function arguments to positional ones instead of list items. 

However, once I did that conversion, `$ tox -e typecheck` (which is a build-time thing, not a run-time thing) would fail with this kind of error:

```py
nmdc_server/migrations/versions/ff4e651c3007_migrate_templates.py:33: error: Argument 1 to "Select" has incompatible type "Column[Any]"; expected "Iterable[ColumnElement[Any] | FromClause | int] | None"  [arg-type]
```

I interpreted that to mean that our type checker was still checking things based on the rules of SQLAlchemy 1, not 2. 

Indeed, when I looked into the configuration of our type checker, I found that it is using some deprecated things. I added a `TODO` comment to `mypy.ini` about this. I initially tried _removing_ the deprecated thing already; but, when I did that, `$ tox -e typecheck` reported lots more errors (involving lots of lines of code), so I think we are (i.e. the codebase is) still relying on the deprecated thing for some things.

Meanwhile, to suppress the above errors (specific to the changed lines of code) so the GHA checks would pass, I added a `# type: ignore[arg-type]` comment to each of the converted function calls.

Fixes #1808