### PR TITLE
Remove obsolete `version` key from `docker-compose.yml` file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
 
   data:


### PR DESCRIPTION
On this branch, I removed the obsolete `version` key from the `docker-compose.yml` file. With the key present, Docker would report the following warning.

```go
WARN[0000] /path/to/nmdc-server/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

Fixes #1829 