### PR TITLE
Refrain from trying to create databases that already exist

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -13,18 +13,12 @@ done
 echo 'Creating and migrating database'
 
 # If either database "nmdc_a" or "nmdc_b" doesn't exist yet, create it now so they both exist.
-#
-# Explanations of the commands used in this block:
-# - `$ psql --list --tuples-only` dumps a table whose first column contains database names
-#   and whose column borders are drawn using '|' characters (like a Markdown table).
-# - `$ cut -d '|' -f 1` captures the database names, which are in the first column of that table.
-# - `$ grep --quiet --word-regexp "${db_name}"` returns a success status if this name is among them.
-#   A success status will cause the `&&` to execute, resulting in `db_exists` containing "true".
-#
 echo "Ensuring databases exist..."
-db_names=$(PGDATABASE=postgres psql --list --tuples-only | cut -d '|' -f 1)
 for db_name in "nmdc_a" "nmdc_b"; do
-  db_exists=$(echo "${db_names}" | grep --quiet --word-regexp "${db_name}" && echo "true" || echo "false")
+  # Note: This psql command returns "true" if the database exists; otherwise it returns an empty
+  #       string. The `--no-psqlrc --tuples-only --no-align` options simplify the result format.
+  psql_command="SELECT 'true' FROM pg_database WHERE datname = '${db_name}' LIMIT 1;"
+  db_exists=$(PGDATABASE=postgres psql --no-psqlrc --tuples-only --no-align --command "${psql_command}")
   if [ "${db_exists}" = "true" ]; then
     echo "Database exists: ${db_name}"
   else


### PR DESCRIPTION
### Background

Previously, the `backend` container's log would contain a pair of error messages on every boot. That looked like this:

```sql
ERROR:  database "nmdc_a" already exists
ERROR:  database "nmdc_b" already exists
```

Similarly, the `db` container's log would contain corresponding error message, which looked like this:

```sql
2026-02-01 02:18:45.627 UTC [1495] ERROR:  database "nmdc_a" already exists
2026-02-01 02:18:45.627 UTC [1495] STATEMENT:  create database nmdc_a;
2026-02-01 02:18:45.658 UTC [1496] ERROR:  database "nmdc_b" already exists
2026-02-01 02:18:45.658 UTC [1496] STATEMENT:  create database nmdc_b;
```

### Changes

On this branch, I made it so the `backend` only tries to create each database if it does not already exist.

As a result, the `backend` and `db` container logs no longer contain error messages. Here's a before-and-after of the `backend` container log:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d27a354e-772f-4d07-a5c1-c856b257a914" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/533a2195-afeb-4ab3-b1cc-f48e4dbd516d" />