### PR TITLE
Fix logic with omics chip selection and study checkboxes

### DIFF
--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -11,8 +11,9 @@ import { fieldDisplayName } from '@/util';
 import { api, Condition, StudySearchResults } from '@/data/api';
 
 import {
-  stateRefs, toggleConditions, dataObjectFilter,
+  stateRefs, dataObjectFilter,
   setConditions,
+  removeConditions,
 } from '@/store';
 import useFacetSummaryData from '@/use/useFacetSummaryData';
 import usePaginatedResults from '@/use/usePaginatedResults';
@@ -53,10 +54,11 @@ export default defineComponent({
 
     /**
      * Set a study (or consortium) as checked in the search results.
+     * @param checked - Whether the item is currently being checked (true) or unchecked (false)
      * @param studyId - ID of the study to select
      * @param children - Optional children studies to also select
      */
-    function setChecked(studyId: string, children: StudySearchResults[] = []) {
+    function setChecked(checked: boolean, studyId: string, children: StudySearchResults[] = []) {
       const conditions: Condition[] = [{
         value: studyId,
         table: 'study',
@@ -65,18 +67,19 @@ export default defineComponent({
       }];
       if (children.length > 0) {
         children.forEach((child) => {
-          if (!studyCheckboxState.value.includes(child.id)) {
-            conditions.push({
-              value: child.id,
-              table: 'study',
-              field: 'study_id',
-              op: '==',
-            });
-          }
+          conditions.push({
+            value: child.id,
+            table: 'study',
+            field: 'study_id',
+            op: '==',
+          });
         });
       }
-
-      toggleConditions(conditions);
+      if (checked) {
+        setConditions([...stateRefs.conditions.value, ...conditions]);
+      } else {
+        removeConditions(conditions);
+      }
     }
 
     /**
@@ -332,10 +335,10 @@ export default defineComponent({
                     <template #action="{ result }">
                       <v-list-item-action>
                         <v-checkbox-btn
-                          :input-value="studyCheckboxState"
+                          :model-value="studyCheckboxState"
                           :value="result.id"
                           @click.stop
-                          @change="setChecked(result.id, result.children)"
+                          @change="setChecked($event.target.checked, result.id, result.children)"
                         />
                       </v-list-item-action>
                     </template>
@@ -414,10 +417,10 @@ export default defineComponent({
                             <v-list-item-action>
                               <v-checkbox-btn
                                 :disabled="studyCheckboxState.includes(props.result.id)"
-                                :input-value="studyCheckboxState"
+                                :model-value="studyCheckboxState"
                                 :value="result.id"
                                 @click.stop
-                                @change="setChecked(result.id)"
+                                @change="setChecked($event.target.checked, result.id)"
                               />
                             </v-list-item-action>
                           </template>
@@ -514,10 +517,10 @@ export default defineComponent({
                     <template #action="{ result }">
                       <v-list-item-action>
                         <v-checkbox-btn
-                          :input-value="studyCheckboxState"
+                          :model-value="studyCheckboxState"
                           :value="result.id"
                           @click.stop
-                          @change="setChecked(result.id, result.children)"
+                          @change="setChecked($event.target.checked, result.id, result.children)"
                         />
                       </v-list-item-action>
                     </template>
@@ -597,10 +600,10 @@ export default defineComponent({
                             <v-list-item-action>
                               <v-checkbox-btn
                                 :disabled="studyCheckboxState.includes(props.result.id)"
-                                :input-value="studyCheckboxState"
+                                :model-value="studyCheckboxState"
                                 :value="result.id"
                                 @click.stop
-                                @change="setChecked(result.id)"
+                                @change="setChecked($event.target.checked, result.id)"
                               />
                             </v-list-item-action>
                           </template>


### PR DESCRIPTION
Resolves #739 

The intent of clicking on the omics processing count chip on a study or consortium result is to filter results by that study ID and omics type. However, if the study ID is already present in the user's filters, clicking on the omics chip will (confusingly) remove the study filter. This PR solves this by breaking this particular interaction into its own function and forcing the action to only add conditions, instead of toggle them.

<img width="386" height="85" alt="Screenshot 2026-02-02 at 2 55 30 PM" src="https://github.com/user-attachments/assets/c3878cab-f23d-4a13-a32b-ad6c356b8f2d" />

While working on this I uncovered several other issues with how the study checkbox logic was being handled. 

1. The same issue existed with checkmarks, where checking a study would actually remove the study filter if it was already present. 
2. There was also bug where checking a study with children would add filters for each study, but unchecking a study with children would only remove the filter for the parent study. Now, when unchecking a study with children, all of its child study filters are removed. 
3. The child checkboxes would also not display as checked when the parent is selected. This has been fixed. 
4. The last checkbox issue was that studies would not display as checked on load. This has also been fixed, i.e. any time a study ID filter is applied, its corresponding checkbox will show as selected.
