### PR TITLE
update shipping form validation state when no is selected

### DIFF
--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -35,7 +35,6 @@ import {
 import { setPendingSuggestions } from '@/store/localStorage';
 import * as api from './api';
 import useRequest from '@/use/useRequest.ts';
-import MultiOmicsDataForm from '../Components/MultiOmicsDataForm.vue';
 
 const permissionTitleToDbValueMap: Record<PermissionTitle, SubmissionEditorRole> = {
   Viewer: 'viewer',


### PR DESCRIPTION
Bug fix that resolves #1962 

This change sets `senderShippingInfoForm` to null when `no` is selected for sample shipping.

