### PR TITLE
Postpone copying of submission-related data until end of ingest process

### DIFF
--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -88,6 +88,8 @@ def do_ingest(function_limit, skip_annotation) -> Dict[str, ETLReport]:
             #
             # Note: This set of data depends upon the script having already ingested data from
             #       the MongoDB database (this data has some foreign keys pointing to that data).
+            #       Specifically, each `FileDownload` has a foreign key pointing to a `DataObject`,
+            #       and the latter is ingested from the MongoDB database.
             #
             logger.info("Copying dependent data from the portal database to the ingest database.")
             with duration_logger(logger, "Merging download-related data"):
@@ -104,10 +106,10 @@ def do_ingest(function_limit, skip_annotation) -> Dict[str, ETLReport]:
             #
             # Note: This set of data does _not_ depend upon the script having already ingested data
             #       from the MongoDB database (this data has no foreign keys pointing to that data).
-            #       So, we could copy this data earlier in the ingest process. The reason we do it
-            #       this late is to minimize the amount of time between when we copy submission data
-            #       and when we promote the "ingest" database into the new "portal" database, to
-            #       reduce the opportunity for submission changes to end up in the wrong database.
+            #       The reason we copy this data so late in the ingest process is to minimize the
+            #       amount of time between when we copy it and when we promote the "ingest" database
+            #       into the new "portal" database, to reduce the opportunity for submission changes
+            #       users make during the overall ingest process to end up in the wrong database.
             #
             logger.info("Copying independent data from the portal database to the ingest database.")
             with duration_logger(logger, "Merging auth-related data"):


### PR DESCRIPTION
On this branch, I mainly moved the 3 `merge_download_artifact(...)` invocations related to copying submission data, to later in the ingest process, so that the amount of time during which users' submission changes would end up in the wrong database is smaller.

While doing this, I also:
- Moved other "MongoDB-data-independent" data-copying statements to later in the ingest process (to keep them together with the submission-related ones)
- Added comments explaining the concept of "MongoDB-data-dependency"
- Nested each group of data-copying statements within a `with duration_logger(...)` block so per-group durations appear in the console log

Note: When I tested ingest **locally** (which took 20 minutes), I got a lot of the following message at the console:

```console
INFO  [root] Error: data object with download history was removed.
```

That might be due to my local Postgres database not containing "realistic" data.