### PR TITLE
Match button text for sample metadata page and add truncation

### DIFF
--- a/web/src/views/SubmissionPortal/Components/ColumnHelp.vue
+++ b/web/src/views/SubmissionPortal/Components/ColumnHelp.vue
@@ -62,10 +62,13 @@ export default defineComponent({
         color="grey"
         variant="outlined"
         size="small"
+        class="text-truncate justify-start"
         block
         @click="$emit('full-reference-click')"
       >
-        Full {{ harmonizerTemplate.displayName }} Reference
+        <span class="text-truncate" style="max-width: 250px;">
+          Full {{ harmonizerTemplate.displayName }} Reference
+        </span>
         <v-icon class="pl-1">
           mdi-open-in-new
         </v-icon>

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -1073,7 +1073,7 @@ export default defineComponent({
             <v-icon class="pr-1">
               mdi-arrow-left-circle
             </v-icon>
-            Go to Template Selection
+            Go to Sample Environment
           </v-btn-grey>
           <v-spacer />
           <div class="d-flex align-center">


### PR DESCRIPTION
Resolves https://github.com/microbiomedata/nmdc-server/issues/1988

Adds text truncation to buttons on the `ColumnHelp` info tab so text does not overflow.
Changes the text on the Sample Metadata page button to navigate to Sample Environment to say `Go to Sample Environment`

Example of text truncation
<img width="305" height="50" alt="Screenshot 2026-02-19 at 1 31 18 PM" src="https://github.com/user-attachments/assets/8848bb98-a21f-4924-94e9-6e4d1a2e328e" />

