### PR TITLE
Fix spacing between fields in contributor card

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -330,7 +330,7 @@ export default defineComponent({
                 variant="outlined"
                 persistent-hint
                 :error-messages="contributor.name ? undefined : ['Contributor Name cannot be empty.']"
-                class="mr-3"
+                class="mr-3 mb-3"
               />
               <v-text-field
                 v-model="contributor.orcid"
@@ -339,6 +339,7 @@ export default defineComponent({
                 :disabled="currentUserOrcid === contributor.orcid || undefined"
                 label="ORCID"
                 variant="outlined"
+                class="mb-3"
                 persistent-hint
                 :style="{ maxWidth: '400px'}"
               >


### PR DESCRIPTION
Previous appearance of contributor card
<img width="1462" height="1384" alt="image" src="https://github.com/user-attachments/assets/e139fc2f-40b8-41aa-ab33-826d2244cba1" />

Updated spacing
<img width="1173" height="212" alt="Screenshot 2026-02-26 at 1 22 07 PM" src="https://github.com/user-attachments/assets/00694936-80f8-42b4-8a3d-97af9ef99b0f" />

This PR resolves #1999 