### PR TITLE
Clarify LC vs GC for mass spec data types

### DIFF
--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -79,8 +79,10 @@ class MultiOmicsForm(BaseModel):
     unknownDoi: Optional[bool] = None
     mpProtocols: Optional[Protocols] = None
     mbProtocols: Optional[Protocols] = None
+    mbGcProtocols: Optional[Protocols] = None
     lipProtocols: Optional[Protocols] = None
     nomProtocols: Optional[Protocols] = None
+    nomLcProtocols: Optional[Protocols] = None
 
     # This allows Field Notes to continue to send alternativeNames, GOLDStudyId, and
     # NCBIBioProjectId in this form until it catches up with the new data model in its next release

--- a/web/src/views/SubmissionPortal/Components/DataTypes.vue
+++ b/web/src/views/SubmissionPortal/Components/DataTypes.vue
@@ -124,6 +124,7 @@ emits: ['revalidate'],
           />
         </v-radio-group>
       </div>
+
       <v-checkbox
         v-model="multiOmicsForm.omicsProcessingTypes"
         label="Metatranscriptome"
@@ -212,7 +213,7 @@ emits: ['revalidate'],
 
       <v-checkbox
         v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metaproteome"
+        label="Metaproteome (LC-MS)"
         value="mp"
         hide-details
       />
@@ -220,9 +221,10 @@ emits: ['revalidate'],
         v-if="multiOmicsForm.omicsProcessingTypes.includes('mp')"
         data-type="mpProtocols"
       />
+
       <v-checkbox
         v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Metabolome"
+        label="Metabolome (LC-MS)"
         value="mb"
         hide-details
       />
@@ -230,6 +232,18 @@ emits: ['revalidate'],
         v-if="multiOmicsForm.omicsProcessingTypes.includes('mb')"
         data-type="mbProtocols"
       />
+
+      <v-checkbox
+        v-model="multiOmicsForm.omicsProcessingTypes"
+        label="Metabolome (GC-MS)"
+        value="mb-gc"
+        hide-details
+      />
+      <ExternalProtocolForm
+        v-if="multiOmicsForm.omicsProcessingTypes.includes('mb-gc')"
+        data-type="mbGcProtocols"
+      />
+
       <v-checkbox
         v-model="multiOmicsForm.omicsProcessingTypes"
         label="Natural Organic Matter (FT-ICR MS)"
@@ -240,14 +254,26 @@ emits: ['revalidate'],
         v-if="multiOmicsForm.omicsProcessingTypes.includes('nom')"
         data-type="nomProtocols"
       />
+
       <v-checkbox
         v-model="multiOmicsForm.omicsProcessingTypes"
-        label="Lipidome"
-        value="lipidome-emsl"
+        label="Natural Organic Matter (LC-FT-ICR MS)"
+        value="nom-lc"
         hide-details
       />
       <ExternalProtocolForm
-        v-if="multiOmicsForm.omicsProcessingTypes.includes('lipidome-emsl')"
+        v-if="multiOmicsForm.omicsProcessingTypes.includes('nom-lc')"
+        data-type="nomLcProtocols"
+      />
+
+      <v-checkbox
+        v-model="multiOmicsForm.omicsProcessingTypes"
+        label="Lipidome (LC-MS)"
+        value="lipidome"
+        hide-details
+      />
+      <ExternalProtocolForm
+        v-if="multiOmicsForm.omicsProcessingTypes.includes('lipidome')"
         data-type="lipProtocols"
       />
     </div>

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -2,7 +2,13 @@
 import { defineProps, computed, ref } from 'vue';
 import { multiOmicsForm, checkDoiFormat } from '../store';
 
-type DataType = 'mpProtocols' | 'mbProtocols' | 'nomProtocols' | 'lipProtocols';
+type DataType =
+  'mpProtocols' |
+  'mbProtocols' |
+  'mbGcProtocols' |
+  'lipProtocols' |
+  'nomProtocols' |
+  'nomLcProtocols';
 
 type ProtocolHelp = {
   samplePrepHint: string,
@@ -57,7 +63,37 @@ const protocolHelp: Record<DataType, ProtocolHelp> = {
       "using electrospray ionization. MS/MS data were collected in data-dependent mode using normalized collision " +
       "energies (NCE) of 35 or 30. Each sample was analyzed in both positive and negative ESI modes.",
   },
+  mbGcProtocols: {
+    samplePrepHint: "The description should include details such as extractant(s), derivatization, any cleanup steps, " +
+      "and reconstitution solvent(s).",
+    samplePrepExample: "Soil was bead beat in 60% MeOH for 15 min at 4°C. 12 mL of ice-cold chloroform was added to " +
+      "the sample. Samples were probe sonicated at 60% amplitude for 30 seconds on ice, cooled on ice and sonicated " +
+      "again. Samples were incubated for 5 min at -80°C, vortexed for 1 min and centrifuged at 4,500g for 10 min at " +
+      "4°C. The upper aqueous phase was collected into a separate glass vial, dried in a vacuum concentrator, and " +
+      "stored at -20C. Samples were resuspended in 200uL of methanol and centrifuged. The supernatant was transferred " +
+      "to a smaller glass vial and dried in a vacuum concentrator. Dried samples were dissolved in 20uL methoxyamine " +
+      "solution and incubated at 37C for 90min, then centrifuged and vialed for GC-MS analysis.",
+    dataAcquisitionHint: "This description should include chromatographic and spectrometry conditions including resolution.",
+    dataAcquisitionExample: "An Agilent GC 7890A coupled with a single quadrupole MSD 5975C (Agilent Technologies, " +
+      "Inc, Santa Clara, CA) system was used for all analyses, and separations were performed using a HP-5MS column " +
+      "(30 m × 0.25 mm × 0.25 μm; Agilent Technologies, Inc.). The sample injection mode was splitless, and the " +
+      "injection volume was 1 μL. The GC oven was held at 60°C for 1 min after injection, and then increased to 325°C " +
+      "by 10°C/min, followed by a 5 min hold at 325°C. The injection port temperature was held at 250°C throughout " +
+      "the analysis.",
+  },
   nomProtocols: {
+    samplePrepHint: "The description should include details such as extractant(s) and any cleanup steps.",
+    samplePrepExample: "300mg of soil was added to a glass vial for sequential extraction. 1mL of MilliQ water was " +
+      "added to the vial. The vial was shaken at room temperature and 2000 RPM for 2 hours, then centrifuged at " +
+      "4500RPM for 5 minutes. The water supernatant was pulled off and stored at -80C. Extraction was repeated using " +
+      "1mL of methanol followed by 1mL of ethanol-stabilized chloroform.",
+    dataAcquisitionHint: "This description should include spectrometry conditions like polarity and acquisition mode and (if applicable) chromatographic conditions.",
+    dataAcquisitionExample: "Extracts were analyzed using Fourier transform ion cyclotron mass spectrometry (FT-ICR-MS) " +
+      "with a 12 T Bruker SolariX equipped with a standard Bruker electrospray ionization (ESI) source using negative " +
+      "polarity acquired in full scan, located at the Environmental Molecular Sciences Laboratory (EMSL) user facility " +
+      "located in Richland, WA, USA.",
+  },
+  nomLcProtocols: {
     samplePrepHint: "The description should include details such as extractant(s) and any cleanup steps.",
     samplePrepExample: "300mg of soil was added to a glass vial for sequential extraction. 1mL of MilliQ water was " +
       "added to the vial. The vial was shaken at room temperature and 2000 RPM for 2 hours, then centrifuged at " +
@@ -104,8 +140,14 @@ const protocolNames = computed(() => {
   if (multiOmicsForm.mbProtocols?.sampleProtocol.name) {
     names.add(multiOmicsForm.mbProtocols.sampleProtocol.name);
   }
+  if (multiOmicsForm.mbGcProtocols?.sampleProtocol.name) {
+    names.add(multiOmicsForm.mbGcProtocols.sampleProtocol.name);
+  }
   if (multiOmicsForm.nomProtocols?.sampleProtocol.name) {
     names.add(multiOmicsForm.nomProtocols.sampleProtocol.name);
+  }
+  if (multiOmicsForm.nomLcProtocols?.sampleProtocol.name) {
+    names.add(multiOmicsForm.nomLcProtocols.sampleProtocol.name);
   }
   if (multiOmicsForm.lipProtocols?.sampleProtocol.name) {
     names.add(multiOmicsForm.lipProtocols.sampleProtocol.name);

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -351,6 +351,11 @@ interface Protocols {
 /**
  * Multi-Omics Form Step
  */
+export type OmicsProcessingType =
+  // non-doe types
+  'mg' | 'mt' | 'mp' | 'mb' | 'mb-gc' | 'nom' | 'nom-lc' | 'lipidome' |
+  // doe facility associated types
+  'lipidome-emsl' | 'mp-emsl' | 'mb-emsl' | 'nom-emsl' | 'mg-jgi' | 'mg-lr-jgi' | 'mt-jgi' | 'mb-jgi';
 const multiOmicsFormDefault = {
   award: null as null | string,
   awardDois: [] as Doi[] | null,
@@ -363,15 +368,17 @@ const multiOmicsFormDefault = {
   mgInterleaved: null as null | boolean,
   mtCompatible: null as null | boolean,
   mtInterleaved: null as null | boolean,
-  omicsProcessingTypes: [] as string[],
+  omicsProcessingTypes: [] as OmicsProcessingType[],
   otherAward: null as null | string,
   ship: null as null | boolean,
   studyNumber: '',
   unknownDoi: null as null | boolean,
   mpProtocols: null as null | Protocols,
   mbProtocols: null as null | Protocols,
+  mbGcProtocols: null as null | Protocols,
   lipProtocols: null as null | Protocols,
   nomProtocols: null as null | Protocols,
+  nomLcProtocols: null as null | Protocols,
 };
 const multiOmicsForm = reactive(clone(multiOmicsFormDefault));
 const multiOmicsAssociationsDefault = {
@@ -486,12 +493,20 @@ watch(() => multiOmicsForm.omicsProcessingTypes, (newValue, oldValue) => {
   if (!newValue.includes('mb') && oldValue.includes('mb')) {
     multiOmicsForm.mbProtocols = null;
   }
+  // mb-gc was removed
+  if (!newValue.includes('mb-gc') && oldValue.includes('mb-gc')) {
+    multiOmicsForm.mbGcProtocols = null;
+  }
   // nom was removed
   if (!newValue.includes('nom') && oldValue.includes('nom')) {
     multiOmicsForm.nomProtocols = null;
   }
+  // nom-lc was removed
+  if (!newValue.includes('nom-lc') && oldValue.includes('nom-lc')) {
+    multiOmicsForm.nomLcProtocols = null;
+  }
   // lipidome was removed
-  if (!newValue.includes('lipidome-emsl') && oldValue.includes('lipidome-emsl')) {
+  if (!newValue.includes('lipidome') && oldValue.includes('lipidome')) {
     multiOmicsForm.lipProtocols = null;
   }
 });


### PR DESCRIPTION
Fixes https://github.com/microbiomedata/nmdc-server/issues/1939

These changes update the data type checkboxes on the Multi-omics Data form to clarify LC vs GC for mass spec types:

* Relabel 3 existing types. This _only_ affects the displayed label. Any existing submissions where, for example, "Metaproteome" was checked will now see "Metaproteome (LC-MS)" checked.
  * Metaproteome &rarr; Metaproteome (LC-MS)
  * Metabolome &rarr; Metabolome (LC-MS)
  * Lipidome &rarr; Lipidome (LC-MS)
* Add two new types
  * Metabolome (GC-MS)
  * Natural Organic Matter (LC-FT-ICR MS)
* Protocol examples and help info added for the new types according to the Google Doc
* Form resetting logic updated to account for the new checkboxes

Screenshot with changes:

<img width="1152" height="890" alt="image" src="https://github.com/user-attachments/assets/2a57acf2-dc5c-4ff0-a5cf-f4342531700e" />
