### PR TITLE
Fix PI image upload preview on Study Info form

### DIFF
--- a/web/src/views/SubmissionPortal/Components/ImageUpload.vue
+++ b/web/src/views/SubmissionPortal/Components/ImageUpload.vue
@@ -171,10 +171,10 @@ export default defineComponent({
             :size="100"
             class="my-2 elevation-2"
           >
-            <img
+            <v-img
               :src="filePreview"
               :alt="inputLabel + ' preview'"
-            >
+            />
           </v-avatar>
           <img
             v-else


### PR DESCRIPTION
Fixes #2003 

I believe this broke as part of the Vuetify 3 upgrade. It appears that a plain `<img>` cannot be used inside a `<v-avatar>` anymore. Rather a `<v-img>` must be used. I confirmed that the Study details page is already using the correct pattern.