### PR TITLE
Collect publication DOIs in Study Information page

### DIFF
--- a/nmdc_server/schemas_submission.py
+++ b/nmdc_server/schemas_submission.py
@@ -20,7 +20,7 @@ class Contributor(BaseModel):
 
 class Doi(BaseModel):
     value: str
-    provider: str
+    provider: Optional[str] = None
 
 
 class StudyFormCreate(BaseModel):
@@ -30,6 +30,7 @@ class StudyFormCreate(BaseModel):
     piOrcid: str
     fundingSources: Optional[List[str]] = None
     dataDois: Optional[List[Doi]] = None
+    publicationDois: Optional[List[Doi]] = None
     linkOutWebpage: List[str]
     studyDate: Optional[str] = None
     description: str

--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -191,9 +191,9 @@ const doiValueRules = () => (
 
       // Split by comma and validate each DOI
       const dois = value.split(',').map((doi) => doi.trim());
-      const allValid = dois.every((doi) => checkDoiFormat(doi));
+      const allValid = dois.every((doi) => checkDoiFormat(doi) === true);
 
-      return allValid || 'All DOIs must be valid (comma-separated if multiple)';
+      return allValid || 'All DOIs must be in 10.xxxx/xxxxx format (comma-separated if multiple)';
     },
   ]
 );

--- a/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
+++ b/web/src/views/SubmissionPortal/Components/MultiOmicsDataForm.vue
@@ -83,8 +83,7 @@ export default defineComponent({
           return valid || 'DOI must be provided if a provider is selected.';
         },
         (value: string) => {
-          const valid = !value || checkDoiFormat(value);
-          return valid || 'DOI must be in the correct format.';
+          return !value || checkDoiFormat(value);
         },
       ]
     );

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -82,6 +82,16 @@ export default defineComponent({
       });
     }
 
+    function addPublicationDoi() {
+      if (!Array.isArray(studyForm.publicationDois)) {
+        studyForm.publicationDois = [];
+      }
+      studyForm.publicationDois.push({
+        value: '',
+        provider: null,
+      });
+    }
+
     function revalidate() {
       formRef.value?.validate();
     }
@@ -123,6 +133,7 @@ export default defineComponent({
       addContributor,
       addFundingSource,
       addDataDoi,
+      addPublicationDoi,
       doiProviderValues,
       requiredRules,
       permissionLevelChoices,
@@ -430,6 +441,49 @@ export default defineComponent({
       </PageSection>
 
       <PageSection
+        heading="Publication DOIs"
+        subheading="DOIs for any publications associated with this study."
+      >
+        <div
+          v-for="(doi, i) in studyForm.publicationDois"
+          :key="`publication_doi_${i}`"
+          class="d-flex"
+        >
+          <v-card class="d-flex flex-column flex-fill pa-4 mb-4">
+            <v-text-field
+              v-model="doi.value"
+              label="Publication DOI *"
+              hide-details="auto"
+              variant="outlined"
+              required
+              :rules="requiredRules('DOI value must be provided',[
+                checkDoiFormat,
+              ])"
+            />
+          </v-card>
+          <v-btn
+            icon
+            variant="plain"
+            :disabled="!canEditSubmissionMetadata()"
+            @click="studyForm.publicationDois?.splice(i, 1)"
+          >
+            <v-icon>mdi-minus-circle</v-icon>
+          </v-btn>
+        </div>
+        <v-btn-grey
+          class="mb-4"
+          :disabled="!canEditSubmissionMetadata()"
+          @click="addPublicationDoi"
+        >
+          <v-icon class="pr-1">
+            mdi-plus-circle
+          </v-icon>
+          Add Publication DOI
+        </v-btn-grey>
+      </PageSection>
+
+
+      <PageSection
         heading="Data DOIs"
         subheading="Data DOIs for this study"
       >
@@ -448,9 +502,9 @@ export default defineComponent({
                 persistent-hint
                 variant="outlined"
                 required
-                class="mb-2 mr-3"
+                class="mr-3 flex-1-1-100"
                 :rules="requiredRules('DOI value must be provided',[
-                  v => checkDoiFormat(v) || 'DOI must be valid',
+                  checkDoiFormat,
                 ])"
               >
                 <template #message="{ message }">
@@ -468,7 +522,7 @@ export default defineComponent({
                 persistent-hint
                 variant="outlined"
                 clearable
-                class="mb-2 mr-3"
+                class="flex-1-1-100"
                 :rules="studyForm.dataDois[i]?.provider ? undefined : ['A provider must be selected.']"
               >
                 <template #message="{ message }">
@@ -481,7 +535,7 @@ export default defineComponent({
             v-if="studyForm.dataDois !== null"
             icon
             variant="plain"
-            :disabled="!isOwner()"
+            :disabled="!canEditSubmissionMetadata()"
             @click="studyForm.dataDois.splice(i, 1)"
           >
             <v-icon>mdi-minus-circle</v-icon>

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -327,6 +327,7 @@ const studyFormDefault = {
   linkOutWebpage: [],
   studyDate: null,
   dataDois: [] as Doi[] | null,
+  publicationDois: [] as Doi[] | null,
   fundingSources: [] as string[] | null,
   description: '',
   notes: '',
@@ -407,9 +408,8 @@ function removeAwardDoi(i: number) {
   }
 }
 
-function checkDoiFormat(v: string) {
-  const valid = /^(?:doi:)?10.\d{2,9}\/.*$/.test(v);
-  return valid;
+function checkDoiFormat(v: string): string | boolean {
+  return /^(?:doi:)?10.\d{2,9}\/.*$/.test(v) || 'DOI must be in the format "10.xxxx/xxxxx"';
 }
 
 // When "Have data already been generated for your study?" changes, reset the answers to dependent questions

--- a/web/src/views/SubmissionPortal/types.ts
+++ b/web/src/views/SubmissionPortal/types.ts
@@ -296,7 +296,7 @@ export interface LockOperationResult {
 
 export interface Doi {
   value: string;
-  provider: string;
+  provider: string | null;
 }
 
 export interface DataProtocol {


### PR DESCRIPTION
Fixes #2007 

The primary purpose of these changes is to add a Publication DOIs section to the Submission Portal's Study Information page. This section allows users to enter an arbitrary number of Publication DOIs. Note that this _only_ collects what the schema refers to as the [`doi_value`](https://microbiomedata.github.io/nmdc-schema/doi_value/) and _not_ the [`doi_provider`](https://microbiomedata.github.io/nmdc-schema/doi_provider/) because the enum values for that slot are more geared towards data DOIs.

<img width="1408" height="605" alt="image" src="https://github.com/user-attachments/assets/2e4063fc-2919-4981-9812-f4d97a5acd0a" />


Secondary changes:

* Update Python and TypeScript tying so make `Doi.provider` optional -- in agreement with the schema's [`Doi` class](https://microbiomedata.github.io/nmdc-schema/Doi/).
* Clean up DOI format validation code to provide more useful error messages.