### PR TITLE
Update date value when month or year changes

### DIFF
--- a/web/src/components/Presentation/DateInput.vue
+++ b/web/src/components/Presentation/DateInput.vue
@@ -1,5 +1,5 @@
 <script>
-import { defineComponent, ref, computed } from 'vue';
+import { defineComponent, ref, computed, watch } from 'vue';
 import moment from 'moment';
 import * as chrono from 'chrono-node';
 
@@ -15,6 +15,9 @@ export default defineComponent({
     const menu = ref(false);
     const menuRef = ref(null);
     const textFieldDate = ref(moment(props.modelValue).format('MMM D, YYYY'));
+    const m = moment(props.modelValue).isValid() ? moment(props.modelValue) : moment();
+    const viewMonth = ref(m.month());
+    const viewYear = ref(m.year());
 
     const textFieldRules = [
       (v) => chrono.parse(v).length === 1 || 'Invalid date',
@@ -41,6 +44,18 @@ export default defineComponent({
       emit('update:modelValue', date.format('YYYY-MM-DDT00:00:00.000'));
     }
 
+    /**
+     * When the month or year is changed in the date picker,
+     * we need to update the text field and emit the new date value.
+     * It can be confusing if the date value doesn't change when the user changes the month or year,
+     * so we will update the date to the first of the month.
+     */
+    watch([viewMonth, viewYear], ([month, year]) => {
+      const date = moment().year(year).month(month).date(1);
+      textFieldDate.value = date.format('MMM D, YYYY');
+      emit('update:modelValue', date.format('YYYY-MM-DDT00:00:00.000'));
+    });
+
     function closeMenu() {
       // if (menuRef.value) {
       //   menuRef.value.save(props.modelValue);
@@ -53,6 +68,8 @@ export default defineComponent({
       textFieldDate,
       textFieldRules,
       isoDate,
+      viewMonth,
+      viewYear,
       menuRef,
       closeMenu,
       updateFromTextField,
@@ -87,6 +104,8 @@ export default defineComponent({
     <v-card>
       <v-date-picker
         v-model="isoDate"
+        v-model:month="viewMonth"
+        v-model:year="viewYear"
         elevation="0"
         no-title
         scrollable


### PR DESCRIPTION
Resolves #2020 

The date inputs had caused some confusion because when the user changes the month or year, the date value itself would not update until a user would click on a day from the new month/year. Now, whenever a user changes the month or year, the date value automatically updates to the first of the new month-year combo.