### PR TITLE
Move `nmdc_study_id` migration to after `biosample_related_document` one

### DIFF
--- a/nmdc_server/migrations/versions/87821b18f9e3_add_nmdc_study_id.py
+++ b/nmdc_server/migrations/versions/87821b18f9e3_add_nmdc_study_id.py
@@ -3,7 +3,7 @@
 This field will store the NMDC study identifier for submissions.
 
 Revision ID: 87821b18f9e3
-Revises: 43ce041c88cb
+Revises: 6867009bb496
 Create Date: 2026-03-06 19:49:29.023313
 
 """
@@ -15,7 +15,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "87821b18f9e3"
-down_revision: Optional[str] = "43ce041c88cb"
+down_revision: Optional[str] = "6867009bb496"
 branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 


### PR DESCRIPTION
On this branch, I changed the migration sequence from this:

```mermaid
flowchart LR
  ellipses["..."]
  ellipses --> 43ce041c88cb --> 6867009bb496
  43ce041c88cb --> 87821b18f9e3
```

into this:

```mermaid
flowchart LR
  ellipses["..."]
  ellipses --> 43ce041c88cb --> 6867009bb496 --> 87821b18f9e3
```

Fixes #2033

FYI @JamesTessmer and @codytodonnell 