### PR TITLE
Extend the nginx proxy_read_timeout from 60 (default) to 300 seconds

### DIFF
--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -31,6 +31,7 @@ http {
             proxy_set_header Host ${DOLLAR}host;
             proxy_set_header X-Real-IP ${DOLLAR}remote_addr;
             proxy_set_header X-Forwarded-For ${DOLLAR}proxy_add_x_forwarded_for;
+            proxy_read_timeout 300s;
         }
     }
 }


### PR DESCRIPTION
The PR https://github.com/microbiomedata/nmdc-server/pull/1990 introduced additional options for bulk metadata downloading, however after deploying this to dev we discovered that large download requests would fail after exactly 60 seconds. This PR extends the `proxy_read_timeout` directive in nginx to 300 seconds which seems to be ample time for the largest possible metadata download.