### PR TITLE
Add README.md file to data product downloads

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1070,6 +1070,31 @@ async def get_bulk_download_data_object_to_biosamples_map(
 
 
 @router.get(
+    "/bulk_download/{bulk_download_id}/README.md",
+    tags=["download"],
+)
+async def get_bulk_download_readme(
+    bulk_download_id: UUID,
+    db: Session = Depends(get_db),
+):
+    r"""
+    Return a static README.md file that explains the contents of the bulk download
+    and provides instructions for how to use the data and metadata.
+
+    This endpoint is called by ZipStreamer when it builds the zip archive, so it
+    intentionally does **not** check the `expired` flag on the bulk download.
+    """
+    bulk_download = db.get(models.BulkDownload, bulk_download_id)  # type: ignore[attr-defined]
+    if bulk_download is None:
+        raise HTTPException(status_code=404, detail="Bulk download not found")
+
+    readme_path = resources.files("nmdc_server") / "bulk_download_readme.md"
+    readme_content = readme_path.read_text(encoding="utf-8")
+
+    return Response(content=readme_content, media_type="text/markdown")
+
+
+@router.get(
     "/bulk_download/{bulk_download_id}",
     tags=["download"],
 )

--- a/nmdc_server/bulk_download_readme.md
+++ b/nmdc_server/bulk_download_readme.md
@@ -1,0 +1,37 @@
+# NMDC Data Products
+
+Thank you for downloading data products from the NMDC Data Portal!
+
+The following document explains the structure of the archive you have downloaded.
+
+## Data Product Files
+
+Each file you have downloaded is nested inside of a series of folders that organize the files by their associated counterparts. The hierarchy uses the following structure:
+
+- `Study`
+  - `Biosample`
+    - `DataGeneration`
+      - Data Product File
+
+The name of each folder is a sanitized version of the object's ID (`:` replaced by `_`). For example:
+
+- `nmdc_sty-11-8ws97026`
+  - `nmdc_bsm-11-127y7152`
+    - `nmdc_dgms-11-5fd4qm69`
+      - `nmdc_dobj-11-dhdvdf46_kaiko_QC_metrics.tsv`
+
+## Metadata
+
+At the top level of the download is a folder called `metadata`. This includes two JSON files that are intended to help you understand more about how each data product file was generated and how to relate them back to `Biosample`s.
+
+### `data_objects.json`
+
+This file includes a list of JSON objects where each object represents a `DataObject`. In NMDC terms, a `DataObject` is defined as:
+
+> An object that primarily consists of symbols that represent information. Files, records, and omics data are examples of data objects.
+
+Each data product file included in your download has an associated `DataObject` ID (e.g. `nmdc:dobj-11-zvr19844`). You can tell which file the ID relates to by looking at the `name` field. The `name` value is equal to the name of the data product file (e.g. `nmdc_dobj-11-xmvv4977_nmdc_dobj-11-f6nr5w60_QC_metrics.tsv`).
+
+### `related_biosamples.json`
+
+This file includes a single object whose keys are each of the `DataObject` IDs included in your download. For each `DataObject` ID, there is a list of `Biosample` IDs that are associated with that `DataObject`. This can help you relate your data products back to concrete `Biosample`s.

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -694,6 +694,12 @@ def get_zip_download(db: Session, id: UUID) -> Dict[str, Any]:
     base = settings.portal_api_internal_url
     file_descriptions.append(
         {
+            "url": f"{base}/api/bulk_download/{id}/README.md",
+            "zipPath": "README.md",
+        }
+    )
+    file_descriptions.append(
+        {
             "url": f"{base}/api/bulk_download/{id}/metadata/data_objects.json",
             "zipPath": "metadata/data_objects.json",
         }


### PR DESCRIPTION
Resolves #2030 

Adds a static `README.md` file to the top level of all data product downloads. This file contains helpful documentation about the structure of the download and how to understand the metadata files.

This file is tacked onto the zip file in a similar way to the metadata JSON files. A new endpoint exists that serves the markdown file and that endpoint is added to the zipstreamer list of files. The markdown content itself lives in `nmdc_server/bulk_download_readme.md`.