### PR TITLE
Return metadata download in a chunked streaming response

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -463,7 +463,8 @@ async def download_metadata(q: query.MultiSearchQuery, db: Session = Depends(get
                     zf.writestr(f"{endpoint_name}.json", json_bytes)
                     del json_bytes
         zip_buffer.seek(0)
-        yield zip_buffer.read()
+        while chunk := zip_buffer.read(settings.zip_streamer_chunk_size_bytes):
+            yield chunk
 
     return StreamingResponse(
         generate_zip(),


### PR DESCRIPTION
Large metadata downloads are still timing out on dev. I believe this is no longer an nginx timeout issue, rather the issue is the backend process dying before sending back any data. Here is a snippet from the dev logs:

```
2026-03-25 16:22:44.857
35.191.70.188 - - [25/Mar/2026:23:22:44 +0000] "POST /api/download_metadata HTTP/1.1" 502 559 "[https://data-dev.microbiomedata.org/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
2026-03-25 16:22:44.857
2026/03/25 23:22:44 [error] 14#14: *1271 upstream prematurely closed connection while reading response header from upstream, client: 35.191.70.188, server: localhost, request: "POST /api/download_metadata HTTP/1.1", upstream: "[http://34.118.233.27:8000/api/download_metadata](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)", host: "data-dev.microbiomedata.org", referrer: "[https://data-dev.microbiomedata.org/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)"2026-03-25 16:22:44.857
35.191.70.188 - - [25/Mar/2026:23:22:44 +0000] "POST /api/download_metadata HTTP/1.1" 502 559 "[https://data-dev.microbiomedata.org/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36"
2026-03-25 16:22:44.857
2026/03/25 23:22:44 [error] 14#14: *1271 upstream prematurely closed connection while reading response header from upstream, client: 35.191.70.188, server: localhost, request: "POST /api/download_metadata HTTP/1.1", upstream: "[http://34.118.233.27:8000/api/download_metadata](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)", host: "data-dev.microbiomedata.org", referrer: "[https://data-dev.microbiomedata.org/](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)"
```

My research suggests that streaming the response back to the client in chunks may keep the connection alive more reliably than trying to capture and send all the data at once. This PR modifies the `/download_metadata` endpoint to do that.