### PR TITLE
Add DOI and/or URL as acceptable protocol ("same as above" option)

### DIFF
--- a/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
+++ b/web/src/views/SubmissionPortal/Components/ExternalProtocolForm.vue
@@ -263,7 +263,7 @@ const urlValueRules = () => (
           used), and/or cleaned prior to analysis on an instrument.
         </div>
         <v-checkbox
-          v-if="protocolNames.length > 0 && !currentProtocol.sampleProtocol.name"
+          v-if="protocolNames.length > 0 && !currentProtocol.sampleProtocol.name && !currentProtocol.sampleProtocol.doi && !currentProtocol.sampleProtocol.url"
           v-model="currentProtocol.sampleProtocol.sharedData"
         >
           <template #label>


### PR DESCRIPTION
Closes #1779 

Added the DOI and URL protocol types as options for "same as above" checkbox (see photos for example)

<img width="1960" height="1261" alt="image" src="https://github.com/user-attachments/assets/4c6471df-641b-4777-9372-1b965ad0a574" />

<img width="2206" height="1123" alt="image" src="https://github.com/user-attachments/assets/5ad15b84-f30d-417a-ab1b-e108c9fd16c9" />


