### PR TITLE
Delete stray period character from icon button

### DIFF
--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -436,7 +436,7 @@ export default defineComponent({
                 >
                   <span v-if="editableByStatus(item.status) && isAnyContributorForSubmission(item)">
                     Resume
-                    <v-icon class="pl-1">mdi-arrow-right-circle</v-icon>.
+                    <v-icon class="pl-1">mdi-arrow-right-circle</v-icon>
                   </span>
                   <span v-else>
                     <v-icon class="pl-1">mdi-eye</v-icon>


### PR DESCRIPTION
Fixes #2047 

See issue for the "before" screenshot.

I am currently working from a place where I cannot spin up the portal locally in order to obtain an "after" screenshot.