### PR TITLE
Include progress bar's label in what gets hidden when STDOUT is not a TTY

### DIFF
--- a/nmdc_server/ingest/all.py
+++ b/nmdc_server/ingest/all.py
@@ -1,4 +1,3 @@
-import io
 import os
 import sys
 from typing import Any, Dict, Iterator
@@ -208,7 +207,7 @@ def load(db: Session, function_limit=None, skip_annotation=False) -> Dict[str, c
                         length=len(annotation_activities),
                         # Define a label to be displayed next to the progress bar; and only show
                         # the label and progress bar when the output is a TTY.
-                        # 
+                        #
                         # Note: Once we update Click to 8.2.0 or newer, replace the use of the `file`
                         #       parameter below with a use of the new `hidden` parameter. We use
                         #       this parameter as a workaround for now because, even though Click


### PR DESCRIPTION
On this branch, I made it so that, when the ingester's output stream is not connected to a TTY, not only does the Click hide the progress bar, itself, but it also hides the progress bar's label. When no label is defined, Click would print an empty line in the ingester's output, which disrupted its otherwise consistent output of "Thing: Starting" followed by "Thing: Finished in x seconds". I also defined a label for the progress bar.

Here's a proof of concept showing the fix I implemented in action. The fix was basically to tell Click to send the progress bar (**and its label**) to `/dev/null` when the output stream is not connected to a TTY.

```sh
$ pip freeze | grep click      
click==8.1.7
$ bpython
bpython version 0.26 on top of Python 3.12.11 
```

```py
>>> import sys
>>> import os
>>> import click
>>> sys.stdout.isatty()
True
>>> devnull = open(os.devnull, "w")
>>> with click.progressbar(range(5), label="Bar"):
...     pass
... 
Bar  [------------------------------------]    0%
>>> with click.progressbar(range(5), label="Bar", file=None):
...     pass
... 
Bar  [------------------------------------]    0%
>>> with click.progressbar(range(5), label="Bar", file=devnull):
...     pass
... 
>>>
```

Fixes #2031 