### PR TITLE
Add check for duplicate sample names across tabs

### DIFF
--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -409,8 +409,8 @@ function validateDuplicateSampleNamesAcrossTabs(): Record<string, Record<number,
   // Track sample names and which tabs/rows they appear in
   const sampleNameMap = new Map<string, Array<{ templateKey: string; rowIndex: number }>>();
 
-  // Collect all sample names from all tabs
-  templateList.value.forEach((templateKey) => {
+  // Collect all sample names from environmental tabs
+  packageName.value.forEach((templateKey) => {
     const template = HARMONIZER_TEMPLATES[templateKey];
     if (!template?.sampleDataSlot || !template?.schemaClass) {
       return;


### PR DESCRIPTION
Resolves https://github.com/microbiomedata/issues/issues/985

This PR adds to check that sample names are unique across ALL tabs in `sampleMetadata` which enforces the one unique sample name per submission approach from the issue.
When a tab is validated a new error can appear that says "Duplicate sample name '{sample name}' found in multiple tabs"
Because tabs are validated independently this error only appears in the validated tab and is not propagated. 
This is also why this check was added in the server and not the DataHarmonizer, since the DH is not aware of other tabs when validating and can't check sample names.

Not currently resolved is the updated guidance. This lives in the NMDC schema (I believe) and has not yet been updated.
