### PR TITLE
Implement indexes for improving FTS speed

### DIFF
--- a/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
+++ b/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
@@ -17,8 +17,7 @@ branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 
 
-# Note: The following are comments from original author of these SQL function definitions:
-#
+# Note: The following is a comment from the original author of these SQL function definitions:
 #       > Full-text search helper functions
 #       >
 #       > These SQL wrapper functions are IMMUTABLE (output depends solely on inputs),

--- a/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
+++ b/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
@@ -92,6 +92,7 @@ BIOSAMPLE_FTS_FUNCTION_DDL = """--sql
     $$
 --end-sql"""
 
+
 def upgrade():
     op.execute(BIOSAMPLE_FTS_FUNCTION_DDL)
     op.execute(STUDY_FTS_FUNCTION_DDL)

--- a/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
+++ b/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
@@ -10,15 +10,88 @@ from typing import Optional
 
 from alembic import op
 
-# The function DDL lives in models.py next to the classes that use it.
-from nmdc_server.models import BIOSAMPLE_FTS_FUNCTION_DDL, STUDY_FTS_FUNCTION_DDL
-
 # revision identifiers, used by Alembic.
 revision: str = "b7d4b19db410"
 down_revision: Optional[str] = "87821b18f9e3"
 branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 
+
+# Note: The following are comments from original author of these SQL function definitions:
+#
+#       > Full-text search helper functions
+#       >
+#       > These SQL wrapper functions are IMMUTABLE (output depends solely on inputs),
+#       > which enables functional GIN indexes on the study and biosample tables.
+#
+# Note: The `--sql`/`--end-sql` SQL comments are tokens that some code editor plugins look for in
+#       order to know where to apply SQL syntax highlighting within literal strings. An example of
+#       such a code editor plugin is:
+#       https://marketplace.visualstudio.com/items?itemName=ptweir.python-string-sql
+#
+STUDY_FTS_FUNCTION_DDL = """--sql
+    CREATE OR REPLACE FUNCTION nmdc_study_fts(
+        p_id text,
+        p_name text,
+        p_description text,
+        p_gold_name text,
+        p_gold_description text,
+        p_scientific_objective text,
+        p_annotations jsonb
+    ) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$
+        SELECT to_tsvector(
+            'simple',
+            concat_ws(
+                ' ',
+                p_id,
+                p_name,
+                p_description,
+                p_gold_name,
+                p_gold_description,
+                p_scientific_objective
+            )
+        ) || to_tsvector('simple', p_annotations)
+    $$
+--end-sql"""
+
+BIOSAMPLE_FTS_FUNCTION_DDL = """--sql
+    CREATE OR REPLACE FUNCTION nmdc_biosample_fts(
+        p_id text,
+        p_name text,
+        p_description text,
+        p_study_id text,
+        p_env_broad_scale_id text,
+        p_env_local_scale_id text,
+        p_env_medium_id text,
+        p_ecosystem text,
+        p_ecosystem_category text,
+        p_ecosystem_type text,
+        p_ecosystem_subtype text,
+        p_specific_ecosystem text,
+        p_annotations jsonb
+    ) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$
+        SELECT to_tsvector(
+            'simple',
+            concat_ws(
+                ' ',
+                p_id,
+                p_name,
+                p_description,
+                p_study_id,
+                p_env_broad_scale_id,
+                p_env_local_scale_id,
+                p_env_medium_id,
+                p_ecosystem,
+                p_ecosystem_category,
+                p_ecosystem_type,
+                p_ecosystem_subtype,
+                p_specific_ecosystem
+            )
+        ) || to_tsvector('simple', p_annotations)
+    $$
+--end-sql"""
 
 def upgrade():
     op.execute(BIOSAMPLE_FTS_FUNCTION_DDL)
@@ -41,7 +114,7 @@ def upgrade():
                 annotations
             )
         )
-    """)
+    --end-sql""")
     op.execute("""--sql
         CREATE INDEX ix_study_fts ON study USING gin (
             nmdc_study_fts(
@@ -54,7 +127,7 @@ def upgrade():
                 annotations
             )
         )
-    """)
+    --end-sql""")
 
 
 def downgrade():

--- a/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
+++ b/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
@@ -5,17 +5,17 @@ Revises: 87821b18f9e3
 Create Date: 2026-04-08 15:51:00.970401
 
 """
+
 from typing import Optional
 
 from alembic import op
 
-# The function DDL lives in models.py next to the classes that use it — see
-# STUDY_FTS_FUNCTION_DDL and BIOSAMPLE_FTS_FUNCTION_DDL defined there.
+# The function DDL lives in models.py next to the classes that use it.
 from nmdc_server.models import BIOSAMPLE_FTS_FUNCTION_DDL, STUDY_FTS_FUNCTION_DDL
 
 # revision identifiers, used by Alembic.
-revision: str = 'b7d4b19db410'
-down_revision: Optional[str] = '87821b18f9e3'
+revision: str = "b7d4b19db410"
+down_revision: Optional[str] = "87821b18f9e3"
 branch_labels: Optional[str] = None
 depends_on: Optional[str] = None
 

--- a/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
+++ b/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
@@ -1,0 +1,51 @@
+"""add_fts_gin_indexes
+
+Revision ID: b7d4b19db410
+Revises: 87821b18f9e3
+Create Date: 2026-04-08 15:51:00.970401
+
+"""
+from typing import Optional
+
+from alembic import op
+
+# The function DDL lives in models.py next to the classes that use it — see
+# STUDY_FTS_FUNCTION_DDL and BIOSAMPLE_FTS_FUNCTION_DDL defined there.
+from nmdc_server.models import BIOSAMPLE_FTS_FUNCTION_DDL, STUDY_FTS_FUNCTION_DDL
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7d4b19db410'
+down_revision: Optional[str] = '87821b18f9e3'
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.execute(BIOSAMPLE_FTS_FUNCTION_DDL)
+    op.execute(STUDY_FTS_FUNCTION_DDL)
+    op.execute("""
+        CREATE INDEX ix_biosample_fts ON biosample USING gin (
+            nmdc_biosample_fts(
+                id, name, description, study_id,
+                env_broad_scale_id, env_local_scale_id, env_medium_id,
+                ecosystem, ecosystem_category, ecosystem_type,
+                ecosystem_subtype, specific_ecosystem,
+                annotations
+            )
+        )
+    """)
+    op.execute("""
+        CREATE INDEX ix_study_fts ON study USING gin (
+            nmdc_study_fts(
+                id, name, description, gold_name, gold_description, scientific_objective,
+                annotations
+            )
+        )
+    """)
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_biosample_fts")
+    op.execute("DROP INDEX IF EXISTS ix_study_fts")
+    op.execute("DROP FUNCTION IF EXISTS nmdc_biosample_fts")
+    op.execute("DROP FUNCTION IF EXISTS nmdc_study_fts")

--- a/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
+++ b/nmdc_server/migrations/versions/b7d4b19db410_add_fts_gin_indexes.py
@@ -23,21 +23,34 @@ depends_on: Optional[str] = None
 def upgrade():
     op.execute(BIOSAMPLE_FTS_FUNCTION_DDL)
     op.execute(STUDY_FTS_FUNCTION_DDL)
-    op.execute("""
+    op.execute("""--sql
         CREATE INDEX ix_biosample_fts ON biosample USING gin (
             nmdc_biosample_fts(
-                id, name, description, study_id,
-                env_broad_scale_id, env_local_scale_id, env_medium_id,
-                ecosystem, ecosystem_category, ecosystem_type,
-                ecosystem_subtype, specific_ecosystem,
+                id,
+                name,
+                description,
+                study_id,
+                env_broad_scale_id,
+                env_local_scale_id,
+                env_medium_id,
+                ecosystem,
+                ecosystem_category,
+                ecosystem_type,
+                ecosystem_subtype,
+                specific_ecosystem,
                 annotations
             )
         )
     """)
-    op.execute("""
+    op.execute("""--sql
         CREATE INDEX ix_study_fts ON study USING gin (
             nmdc_study_fts(
-                id, name, description, gold_name, gold_description, scientific_objective,
+                id,
+                name,
+                description,
+                gold_name,
+                gold_description,
+                scientific_objective,
                 annotations
             )
         )

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Session, backref, query_expression, relationship
 from sqlalchemy.orm.attributes import get_history
 from sqlalchemy.orm.relationships import RelationshipProperty
+from sqlalchemy.schema import DDL
 
 from nmdc_server.database import Base, update_multiomics_sql
 
@@ -360,13 +361,14 @@ class AnnotatedModel:
 
 
 # ---- Full-text search helper functions -----------------------------------------------
-# These SQL wrapper functions declare themselves IMMUTABLE.
-# This is correct because their output depends solely on their inputs.
-# This enables functional GIN indexes.
+# These SQL wrapper functions are IMMUTABLE (output depends solely on inputs),
+# which enables functional GIN indexes on the study and biosample tables.
 #
 # The DDL strings are kept here, next to the models that use them, so the index
-# definition and the underlying function are easy to find together.  The migration
-# (b7d4b19db410) imports these constants and executes them.
+# definition and the underlying function are easy to find together.  The Alembic
+# migration (b7d4b19db410) imports and executes these constants for existing databases.
+# The event listeners below ensure metadata.create_all() (used by the test suite)
+# emits them before attempting to create the GIN indexes that depend on them.
 # --------------------------------------------------------------------------------------
 STUDY_FTS_FUNCTION_DDL = """\
 CREATE OR REPLACE FUNCTION nmdc_study_fts(
@@ -395,20 +397,32 @@ CREATE OR REPLACE FUNCTION nmdc_biosample_fts(
     )) || to_tsvector('simple', p_annotations)
 $$"""
 
+# These event listeners ensure that the above SQL functions are created
+# before any attempt to create the GIN indexes that depend on them.
+event.listen(Base.metadata, "before_create", DDL(STUDY_FTS_FUNCTION_DDL))
+event.listen(Base.metadata, "before_create", DDL(BIOSAMPLE_FTS_FUNCTION_DDL))
+
+
 class Study(Base, AnnotatedModel):
     __tablename__ = "study"
 
     # Index Creation (for FTS) Part 1:
     # bare column() refs, used only for __table_args__
     # (DDL context requires unqualified names)
-    _ts_vector_index = func.nmdc_study_fts(
-        column("id"), column("name"), column("description"),
-        column("gold_name"), column("gold_description"), column("scientific_objective"),
-        column("annotations"),
-    )
-
     __table_args__ = (
-        Index("ix_study_fts", _ts_vector_index, postgresql_using="gin"),
+        Index(
+            "ix_study_fts",
+            func.nmdc_study_fts(
+                column("id"),
+                column("name"),
+                column("description"),
+                column("gold_name"),
+                column("gold_description"),
+                column("scientific_objective"),
+                column("annotations"),
+            ),
+            postgresql_using="gin",
+        ),
     )
 
     add_date = Column(DateTime, nullable=True)
@@ -483,8 +497,12 @@ class Study(Base, AnnotatedModel):
 # __ts_vector__ is assigned after class creation using fully-qualified ORM
 # column attrs (e.g. Study.id), so it can be used directly in query filters
 Study.__ts_vector__ = func.nmdc_study_fts(
-    Study.id, Study.name, Study.description,
-    Study.gold_name, Study.gold_description, Study.scientific_objective,
+    Study.id,
+    Study.name,
+    Study.description,
+    Study.gold_name,
+    Study.gold_description,
+    Study.scientific_objective,
     Study.annotations,
 )
 
@@ -502,16 +520,26 @@ class Biosample(Base, AnnotatedModel):
     # Index Creation (for FTS) Part 1:
     # bare column() refs, used only for __table_args__
     # (DDL context requires unqualified names)
-    _ts_vector_index = func.nmdc_biosample_fts(
-        column("id"), column("name"), column("description"), column("study_id"),
-        column("env_broad_scale_id"), column("env_local_scale_id"), column("env_medium_id"),
-        column("ecosystem"), column("ecosystem_category"), column("ecosystem_type"),
-        column("ecosystem_subtype"), column("specific_ecosystem"),
-        column("annotations"),
-    )
-
     __table_args__ = (
-        Index("ix_biosample_fts", _ts_vector_index, postgresql_using="gin"),
+        Index(
+            "ix_biosample_fts",
+            func.nmdc_biosample_fts(
+                column("id"),
+                column("name"),
+                column("description"),
+                column("study_id"),
+                column("env_broad_scale_id"),
+                column("env_local_scale_id"),
+                column("env_medium_id"),
+                column("ecosystem"),
+                column("ecosystem_category"),
+                column("ecosystem_type"),
+                column("ecosystem_subtype"),
+                column("specific_ecosystem"),
+                column("annotations"),
+            ),
+            postgresql_using="gin",
+        ),
     )
 
     add_date = Column(DateTime, nullable=True)
@@ -577,10 +605,18 @@ class Biosample(Base, AnnotatedModel):
 # __ts_vector__ is assigned after class creation using fully-qualified ORM
 # column attrs (e.g. Biosample.id), so it can be used directly in query filters
 Biosample.__ts_vector__ = func.nmdc_biosample_fts(
-    Biosample.id, Biosample.name, Biosample.description, Biosample.study_id,
-    Biosample.env_broad_scale_id, Biosample.env_local_scale_id, Biosample.env_medium_id,
-    Biosample.ecosystem, Biosample.ecosystem_category, Biosample.ecosystem_type,
-    Biosample.ecosystem_subtype, Biosample.specific_ecosystem,
+    Biosample.id,
+    Biosample.name,
+    Biosample.description,
+    Biosample.study_id,
+    Biosample.env_broad_scale_id,
+    Biosample.env_local_scale_id,
+    Biosample.env_medium_id,
+    Biosample.ecosystem,
+    Biosample.ecosystem_category,
+    Biosample.ecosystem_type,
+    Biosample.ecosystem_subtype,
+    Biosample.specific_ecosystem,
     Biosample.annotations,
 )
 

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -369,8 +369,7 @@ class AnnotatedModel:
 #       getting redefined over time, which would "break version history." That is our rationale
 #       for having copied them verbatim.
 #
-# Note: The following are comments from original author of these SQL function definitions:
-#
+# Note: The following is a comment from the original author of these SQL function definitions:
 #       > The event listeners below ensure `metadata.create_all()` (used by the test suite)
 #       > emits these statements before attempting to create the GIN indexes that depend on
 #       > the SQL functions.

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -360,20 +360,23 @@ class AnnotatedModel:
     annotations = Column(JSONB, nullable=False, default=dict)
 
 
-# ---- Full-text search helper functions -----------------------------------------------
-# These SQL wrapper functions are IMMUTABLE (output depends solely on inputs),
-# which enables functional GIN indexes on the study and biosample tables.
+# Note: The following SQL function definitions (i.e. CREATE statements) were copied verbatim
+#       from an Alembic migration (i.e. `b7d4b19db410_add_fts_gin_indexes.py`). We opted to
+#       not `import` the definitions from the migration to this module because that would be
+#       the only occurrence of that pattern in the repo (and importing from an Alembic migration
+#       just... feels... wrong). We also opted to not `import` the definitions from this module
+#       into the migration because that would expose us to the risk of the migration effectively
+#       getting redefined over time, which would "break version history." That is our rationale
+#       for having copied them verbatim.
 #
-# The DDL strings are kept here, next to the models that use them, so the index
-# definition and the underlying function are easy to find together.  The Alembic
-# migration (b7d4b19db410) imports and executes these constants for existing databases.
-# The event listeners below ensure metadata.create_all() (used by the test suite)
-# emits them before attempting to create the GIN indexes that depend on them.
-# --------------------------------------------------------------------------------------
+# Note: The following are comments from original author of these SQL function definitions:
 #
-# Note: The `--sql` SQL comment is a token that some code editor plugins look for in order to enable
-#       SQL syntax highlighting within literal strings. An example of such a code editor plugin is:
-#       https://marketplace.visualstudio.com/items?itemName=ptweir.python-string-sql
+#       > The event listeners below ensure `metadata.create_all()` (used by the test suite)
+#       > emits these statements before attempting to create the GIN indexes that depend on
+#       > the SQL functions.
+#
+# TODO: Update the `nmdc-server` test suite so that it uses the Alembic migrations to set up the
+#       test database. Then, we'll be able to eliminate this "copy" of these function definitions.
 #
 STUDY_FTS_FUNCTION_DDL = """--sql
     CREATE OR REPLACE FUNCTION nmdc_study_fts(
@@ -399,7 +402,7 @@ STUDY_FTS_FUNCTION_DDL = """--sql
             )
         ) || to_tsvector('simple', p_annotations)
     $$
-"""
+--end-sql"""
 
 BIOSAMPLE_FTS_FUNCTION_DDL = """--sql
     CREATE OR REPLACE FUNCTION nmdc_biosample_fts(
@@ -437,7 +440,7 @@ BIOSAMPLE_FTS_FUNCTION_DDL = """--sql
             )
         ) || to_tsvector('simple', p_annotations)
     $$
-"""
+--end-sql"""
 
 # These event listeners ensure that the above SQL functions are created
 # before any attempt to create the GIN indexes that depend on them.

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -21,7 +21,9 @@ from sqlalchemy import (
     Table,
     Text,
     UniqueConstraint,
+    column,
     event,
+    func,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -357,8 +359,57 @@ class AnnotatedModel:
     annotations = Column(JSONB, nullable=False, default=dict)
 
 
+# ---- Full-text search helper functions -----------------------------------------------
+# These SQL wrapper functions declare themselves IMMUTABLE.
+# This is correct because their output depends solely on their inputs.
+# This enables functional GIN indexes.
+#
+# The DDL strings are kept here, next to the models that use them, so the index
+# definition and the underlying function are easy to find together.  The migration
+# (b7d4b19db410) imports these constants and executes them.
+# --------------------------------------------------------------------------------------
+STUDY_FTS_FUNCTION_DDL = """\
+CREATE OR REPLACE FUNCTION nmdc_study_fts(
+    p_id text, p_name text, p_description text,
+    p_gold_name text, p_gold_description text, p_scientific_objective text,
+    p_annotations jsonb
+) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+    SELECT to_tsvector('simple', concat_ws(' ',
+        p_id, p_name, p_description, p_gold_name, p_gold_description, p_scientific_objective
+    )) || to_tsvector('simple', p_annotations)
+$$"""
+
+BIOSAMPLE_FTS_FUNCTION_DDL = """\
+CREATE OR REPLACE FUNCTION nmdc_biosample_fts(
+    p_id text, p_name text, p_description text,
+    p_study_id text, p_env_broad_scale_id text, p_env_local_scale_id text,
+    p_env_medium_id text, p_ecosystem text, p_ecosystem_category text,
+    p_ecosystem_type text, p_ecosystem_subtype text, p_specific_ecosystem text,
+    p_annotations jsonb
+) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
+    SELECT to_tsvector('simple', concat_ws(' ',
+        p_id, p_name, p_description, p_study_id,
+        p_env_broad_scale_id, p_env_local_scale_id, p_env_medium_id,
+        p_ecosystem, p_ecosystem_category, p_ecosystem_type,
+        p_ecosystem_subtype, p_specific_ecosystem
+    )) || to_tsvector('simple', p_annotations)
+$$"""
+
 class Study(Base, AnnotatedModel):
     __tablename__ = "study"
+
+    # Index Creation (for FTS) Part 1:
+    # bare column() refs, used only for __table_args__
+    # (DDL context requires unqualified names)
+    _ts_vector_index = func.nmdc_study_fts(
+        column("id"), column("name"), column("description"),
+        column("gold_name"), column("gold_description"), column("scientific_objective"),
+        column("annotations"),
+    )
+
+    __table_args__ = (
+        Index("ix_study_fts", _ts_vector_index, postgresql_using="gin"),
+    )
 
     add_date = Column(DateTime, nullable=True)
     mod_date = Column(DateTime, nullable=True)
@@ -428,6 +479,15 @@ class Study(Base, AnnotatedModel):
         return doi_info
 
 
+# Index Creation (for FTS) Part 2:
+# __ts_vector__ is assigned after class creation using fully-qualified ORM
+# column attrs (e.g. Study.id), so it can be used directly in query filters
+Study.__ts_vector__ = func.nmdc_study_fts(
+    Study.id, Study.name, Study.description,
+    Study.gold_name, Study.gold_description, Study.scientific_objective,
+    Study.annotations,
+)
+
 biosample_input_association = Table(
     "biosample_input_association",
     Base.metadata,
@@ -438,6 +498,21 @@ biosample_input_association = Table(
 
 class Biosample(Base, AnnotatedModel):
     __tablename__ = "biosample"
+
+    # Index Creation (for FTS) Part 1:
+    # bare column() refs, used only for __table_args__
+    # (DDL context requires unqualified names)
+    _ts_vector_index = func.nmdc_biosample_fts(
+        column("id"), column("name"), column("description"), column("study_id"),
+        column("env_broad_scale_id"), column("env_local_scale_id"), column("env_medium_id"),
+        column("ecosystem"), column("ecosystem_category"), column("ecosystem_type"),
+        column("ecosystem_subtype"), column("specific_ecosystem"),
+        column("annotations"),
+    )
+
+    __table_args__ = (
+        Index("ix_biosample_fts", _ts_vector_index, postgresql_using="gin"),
+    )
 
     add_date = Column(DateTime, nullable=True)
     mod_date = Column(DateTime, nullable=True)
@@ -496,6 +571,18 @@ class Biosample(Base, AnnotatedModel):
     def populate_multiomics(cls, db: Session):
         db.execute(update_multiomics_sql)
         db.commit()
+
+
+# Index Creation (for FTS) Part 2:
+# __ts_vector__ is assigned after class creation using fully-qualified ORM
+# column attrs (e.g. Biosample.id), so it can be used directly in query filters
+Biosample.__ts_vector__ = func.nmdc_biosample_fts(
+    Biosample.id, Biosample.name, Biosample.description, Biosample.study_id,
+    Biosample.env_broad_scale_id, Biosample.env_local_scale_id, Biosample.env_medium_id,
+    Biosample.ecosystem, Biosample.ecosystem_category, Biosample.ecosystem_type,
+    Biosample.ecosystem_subtype, Biosample.specific_ecosystem,
+    Biosample.annotations,
+)
 
 
 class BiosampleRelatedDocument(Base):

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -370,32 +370,74 @@ class AnnotatedModel:
 # The event listeners below ensure metadata.create_all() (used by the test suite)
 # emits them before attempting to create the GIN indexes that depend on them.
 # --------------------------------------------------------------------------------------
-STUDY_FTS_FUNCTION_DDL = """\
-CREATE OR REPLACE FUNCTION nmdc_study_fts(
-    p_id text, p_name text, p_description text,
-    p_gold_name text, p_gold_description text, p_scientific_objective text,
-    p_annotations jsonb
-) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-    SELECT to_tsvector('simple', concat_ws(' ',
-        p_id, p_name, p_description, p_gold_name, p_gold_description, p_scientific_objective
-    )) || to_tsvector('simple', p_annotations)
-$$"""
+#
+# Note: The `--sql` SQL comment is a token that some code editor plugins look for in order to enable
+#       SQL syntax highlighting within literal strings. An example of such a code editor plugin is:
+#       https://marketplace.visualstudio.com/items?itemName=ptweir.python-string-sql
+#
+STUDY_FTS_FUNCTION_DDL = """--sql
+    CREATE OR REPLACE FUNCTION nmdc_study_fts(
+        p_id text,
+        p_name text,
+        p_description text,
+        p_gold_name text,
+        p_gold_description text,
+        p_scientific_objective text,
+        p_annotations jsonb
+    ) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$
+        SELECT to_tsvector(
+            'simple',
+            concat_ws(
+                ' ',
+                p_id,
+                p_name,
+                p_description,
+                p_gold_name,
+                p_gold_description,
+                p_scientific_objective
+            )
+        ) || to_tsvector('simple', p_annotations)
+    $$
+"""
 
-BIOSAMPLE_FTS_FUNCTION_DDL = """\
-CREATE OR REPLACE FUNCTION nmdc_biosample_fts(
-    p_id text, p_name text, p_description text,
-    p_study_id text, p_env_broad_scale_id text, p_env_local_scale_id text,
-    p_env_medium_id text, p_ecosystem text, p_ecosystem_category text,
-    p_ecosystem_type text, p_ecosystem_subtype text, p_specific_ecosystem text,
-    p_annotations jsonb
-) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-    SELECT to_tsvector('simple', concat_ws(' ',
-        p_id, p_name, p_description, p_study_id,
-        p_env_broad_scale_id, p_env_local_scale_id, p_env_medium_id,
-        p_ecosystem, p_ecosystem_category, p_ecosystem_type,
-        p_ecosystem_subtype, p_specific_ecosystem
-    )) || to_tsvector('simple', p_annotations)
-$$"""
+BIOSAMPLE_FTS_FUNCTION_DDL = """--sql
+    CREATE OR REPLACE FUNCTION nmdc_biosample_fts(
+        p_id text,
+        p_name text,
+        p_description text,
+        p_study_id text,
+        p_env_broad_scale_id text,
+        p_env_local_scale_id text,
+        p_env_medium_id text,
+        p_ecosystem text,
+        p_ecosystem_category text,
+        p_ecosystem_type text,
+        p_ecosystem_subtype text,
+        p_specific_ecosystem text,
+        p_annotations jsonb
+    ) RETURNS tsvector LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $$
+        SELECT to_tsvector(
+            'simple',
+            concat_ws(
+                ' ',
+                p_id,
+                p_name,
+                p_description,
+                p_study_id,
+                p_env_broad_scale_id,
+                p_env_local_scale_id,
+                p_env_medium_id,
+                p_ecosystem,
+                p_ecosystem_category,
+                p_ecosystem_type,
+                p_ecosystem_subtype,
+                p_specific_ecosystem
+            )
+        ) || to_tsvector('simple', p_annotations)
+    $$
+"""
 
 # These event listeners ensure that the above SQL functions are created
 # before any attempt to create the GIN indexes that depend on them.

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -1106,63 +1106,20 @@ class BiosampleQuerySchema(BaseQuerySchema):
                     term,
                 )
 
-        # Fallback: tsvector full-text search on biosample fields
-        envo_broad_scale = aliased(models.EnvoTerm)
-        envo_local_scale = aliased(models.EnvoTerm)
-        envo_medium = aliased(models.EnvoTerm)
-
-        biosample_search_fields = func.concat_ws(
-            " ",
-            models.Biosample.id,
-            models.Biosample.name,
-            models.Biosample.description,
-            models.Biosample.alternate_identifiers,
-            models.Biosample.annotations,
-            models.Biosample.collection_date,
-            models.Biosample.study_id,
-            models.Biosample.env_broad_scale_id,
-            envo_broad_scale.label,
-            models.Biosample.env_local_scale_id,
-            envo_local_scale.label,
-            models.Biosample.env_medium_id,
-            envo_medium.label,
-            models.Biosample.ecosystem,
-            models.Biosample.ecosystem_category,
-            models.Biosample.ecosystem_type,
-            models.Biosample.ecosystem_subtype,
-            models.Biosample.specific_ecosystem,
-        )
+        # Fallback: tsvector full-text search on biosample fields.
         biosample_fts_query = (
             db.query(models.Biosample.id.label("id"))
-            .outerjoin(envo_broad_scale, envo_broad_scale.id == models.Biosample.env_broad_scale_id)
-            .outerjoin(envo_local_scale, envo_local_scale.id == models.Biosample.env_local_scale_id)
-            .outerjoin(envo_medium, envo_medium.id == models.Biosample.env_medium_id)
             .filter(
-                func.to_tsvector("simple", biosample_search_fields).op("@@")(
-                    func.plainto_tsquery("simple", term)
-                )
+                models.Biosample.__ts_vector__.op("@@")(func.plainto_tsquery("simple", term))
             )
         )
 
-        # Also search study fields and return all biosamples belonging to matching studies
-        study_search_fields = func.concat_ws(
-            " ",
-            models.Study.id,
-            models.Study.name,
-            models.Study.description,
-            models.Study.gold_name,
-            models.Study.gold_description,
-            models.Study.scientific_objective,
-            models.Study.annotations,
-            models.Study.alternate_identifiers,
-        )
+        # Also search study fields and return all biosamples belonging to matching studies.
         study_fts_query = (
             db.query(models.Biosample.id.label("id"))
             .join(models.Study, models.Biosample.study_id == models.Study.id)
             .filter(
-                func.to_tsvector("simple", study_search_fields).op("@@")(
-                    func.plainto_tsquery("simple", term)
-                )
+                models.Study.__ts_vector__.op("@@")(func.plainto_tsquery("simple", term))
             )
         )
 

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -1107,20 +1107,15 @@ class BiosampleQuerySchema(BaseQuerySchema):
                 )
 
         # Fallback: tsvector full-text search on biosample fields.
-        biosample_fts_query = (
-            db.query(models.Biosample.id.label("id"))
-            .filter(
-                models.Biosample.__ts_vector__.op("@@")(func.plainto_tsquery("simple", term))
-            )
+        biosample_fts_query = db.query(models.Biosample.id.label("id")).filter(
+            models.Biosample.__ts_vector__.op("@@")(func.plainto_tsquery("simple", term))
         )
 
         # Also search study fields and return all biosamples belonging to matching studies.
         study_fts_query = (
             db.query(models.Biosample.id.label("id"))
             .join(models.Study, models.Biosample.study_id == models.Study.id)
-            .filter(
-                models.Study.__ts_vector__.op("@@")(func.plainto_tsquery("simple", term))
-            )
+            .filter(models.Study.__ts_vector__.op("@@")(func.plainto_tsquery("simple", term)))
         )
 
         return biosample_fts_query.union(study_fts_query)


### PR DESCRIPTION
Resolves #2061 

This PR adds two new indexes (one for `Biosample` and one for `Study`) to optimize the speed of full text search queries. Local tests show these FTS queries completing in under 10 seconds (previously ~45 seconds).

There are two new SQL functions defined called `nmdc_study_fts` and `nmdc_biosample_fts`. These then get used inside the `Study` and `Biosample` models respectively to create immutable indexes based on the supplied columns from that model. Using a DDL script here was necessary because of the inclusion of the `JSONB` columns like `annotations` in the index.

After model class creation, we add a `__ts_vector__` field which uses fully-qualified column names (like `Biosample.name`) which enables us to easily query this field without any issues.

NOTE: this update requires a migration