### PR TITLE
Update TSV-formatted submission report to include "Award" column

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1372,9 +1372,9 @@ async def get_metadata_submissions_report(
         #       the user can enter a custom string, which gets stored in the `otherAward` field.
         #
         sentinel_value_for_other = "OTHER"
-        multi_omics_form = metadata["multiOmicsForm"] if "multiOmicsForm" in metadata else {}
-        predefined_award = multi_omics_form["award"] if "award" in multi_omics_form else ""
-        custom_award = multi_omics_form["otherAward"] if "otherAward" in multi_omics_form else ""
+        multi_omics_form = metadata.get("multiOmicsForm", {})
+        predefined_award = multi_omics_form.get("award", "")
+        custom_award = multi_omics_form.get("otherAward", "")
         award = ""
         if isinstance(predefined_award, str) and predefined_award != sentinel_value_for_other:
             award = predefined_award

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1371,12 +1371,12 @@ async def get_metadata_submissions_report(
         #       "Other" radio button (in which case, "OTHER" gets stored in the `award` field),
         #       the user can enter a custom string, which gets stored in the `otherAward` field.
         #
-        SENTINEL_VALUE_FOR_OTHER = "OTHER"
+        sentinel_value_for_other = "OTHER"
         multi_omics_form = metadata["multiOmicsForm"] if "multiOmicsForm" in metadata else {}
         predefined_award = multi_omics_form["award"] if "award" in multi_omics_form else ""
         custom_award = multi_omics_form["otherAward"] if "otherAward" in multi_omics_form else ""
         award = ""
-        if isinstance(predefined_award, str) and predefined_award != SENTINEL_VALUE_FOR_OTHER:
+        if isinstance(predefined_award, str) and predefined_award != sentinel_value_for_other:
             award = predefined_award
         elif isinstance(custom_award, str):
             award = custom_award

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1350,6 +1350,7 @@ async def get_metadata_submissions_report(
         "Date Last Modified",
         "Date Created",
         "Number of Samples",
+        "Award",
     ]
     data_rows = []
     for s in submissions:
@@ -1362,6 +1363,18 @@ async def get_metadata_submissions_report(
         sample_data = metadata["sampleData"]
         for sample_type in sample_data:
             sample_count += len(sample_data[sample_type])
+
+        # Get the award information from the submission, prioritizing the predefined ones.
+        # Note: On the submission portal, this value is solicited from the user by prompting
+        #       them for the "kind of project you have been awarded".
+        multi_omics_form = metadata["multiOmicsForm"] if "multiOmicsForm" in metadata else {}
+        predefined_award = multi_omics_form["award"] if "award" in multi_omics_form else ""
+        custom_award = multi_omics_form["otherAward"] if "otherAward" in multi_omics_form else ""
+        award = ""
+        if isinstance(predefined_award, str) and len(predefined_award) > 0:
+            award = predefined_award
+        elif isinstance(custom_award, str) and len(custom_award) > 0:
+            award = custom_award
 
         author_user = s.author  # note: `s.author` is a `models.User` instance
         study_form = metadata["studyForm"] if "studyForm" in metadata else {}
@@ -1381,6 +1394,7 @@ async def get_metadata_submissions_report(
             s.date_last_modified,
             s.created,
             sample_count,
+            award,
         ]
         data_rows.append(data_row)
 

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1364,16 +1364,21 @@ async def get_metadata_submissions_report(
         for sample_type in sample_data:
             sample_count += len(sample_data[sample_type])
 
-        # Get the award information from the submission, prioritizing the predefined ones.
+        # Get the award information from the submission.
+        #
         # Note: On the submission portal, this value is solicited from the user by prompting
-        #       them for the "kind of project you have been awarded".
+        #       them for the "kind of project you have been awarded". When the user marks the
+        #       "Other" radio button (in which case, "OTHER" gets stored in the `award` field),
+        #       the user can enter a custom string, which gets stored in the `otherAward` field.
+        #
+        SENTINEL_VALUE_FOR_OTHER = "OTHER"
         multi_omics_form = metadata["multiOmicsForm"] if "multiOmicsForm" in metadata else {}
         predefined_award = multi_omics_form["award"] if "award" in multi_omics_form else ""
         custom_award = multi_omics_form["otherAward"] if "otherAward" in multi_omics_form else ""
         award = ""
-        if isinstance(predefined_award, str) and len(predefined_award) > 0:
+        if isinstance(predefined_award, str) and predefined_award != SENTINEL_VALUE_FOR_OTHER:
             award = predefined_award
-        elif isinstance(custom_award, str) and len(custom_award) > 0:
+        elif isinstance(custom_award, str):
             award = custom_award
 
         author_user = s.author  # note: `s.author` is a `models.User` instance

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -268,7 +268,7 @@ def test_get_metadata_submissions_report_as_admin(
                 "doe": None,
                 "dataGenerated": None,
                 "facilityGenerated": None,
-                "award": None,
+                "award": "MONet",
                 "awardDois": [],
                 "mgCompatible": None,
             },
@@ -343,6 +343,7 @@ def test_get_metadata_submissions_report_as_admin(
         "Date Last Modified",
         "Date Created",
         "Number of Samples",
+        "Award",
     ]
     reader = DictReader(response.text.splitlines(), fieldnames=fieldnames, delimiter="\t")
     rows = [row for row in reader]
@@ -362,6 +363,7 @@ def test_get_metadata_submissions_report_as_admin(
     assert data_row["Status"] == SubmissionStatusEnum.InProgress.text
     assert data_row["Is Test Submission"] == "True"
     assert data_row["Number of Samples"] == "4"
+    assert data_row["Award"] == "MONet"
     assert isinstance(data_row["Date Last Modified"], str)
     assert isinstance(data_row["Date Created"], str)
 
@@ -378,6 +380,7 @@ def test_get_metadata_submissions_report_as_admin(
     )  # matches value in upstream faker
     assert data_row["Is Test Submission"] == "False"
     assert data_row["Number of Samples"] == "0"
+    assert data_row["Award"] == ""
     assert isinstance(data_row["Date Last Modified"], str)
     assert isinstance(data_row["Date Created"], str)
 


### PR DESCRIPTION
On this branch, I updated the `GET /metadata_submission/report` endpoint so that the TSV file it returns includes an "Award" column whose value is the value the submitter specified on the submission portal form shown here:

<img width="339" alt="image" src="https://github.com/user-attachments/assets/bd41b072-eb80-4184-af8b-da6ff7612f09" />

"Award" may not be the label stakeholders expect for that column (I derived it from the field names, not the UI). The column's label can be updated via this PR before merging, or via a future PR.

Here's a screenshot of the upper right corner of a TSV file generated by this endpoint in my local environment:

<img width="678" height="144" alt="image" src="https://github.com/user-attachments/assets/f9561bdc-e75d-439a-8a65-9c7f8729991c" />

This addition to the TSV file was requested by a teammate preparing to provide some submission metrics data to someone else.

Fixes #2064 