### PR TITLE
Implement frontend-only health check endpoint at `/health`

### DIFF
--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -15,6 +15,14 @@ http {
 
         client_max_body_size ${NGINX_CLIENT_MAX_BODY_SIZE};
 
+        # Configure a health check endpoint, which HTTP clients can use to
+        # check whether this web server is responding to HTTP requests.
+        location = /health {
+            access_log off;
+            default_type application/json;
+            return 200 '{"web_server": true}';
+        }
+
         location / {
             try_files ${DOLLAR}uri ${DOLLAR}uri/ /index.html;
         }

--- a/web/nginx.conf.template
+++ b/web/nginx.conf.template
@@ -20,6 +20,7 @@ http {
         location = /health {
             access_log off;
             default_type application/json;
+            add_header Cache-Control no-store;
             return 200 '{"web_server": true}';
         }
 


### PR DESCRIPTION
On this branch, I implemented an endpoint at `/health`. As long as Nginx is responding to HTTP requests, in general, that endpoint will return an HTTP 200 response with the following payload:

```json
{"web_server": true}
```

The field name in the payload (i.e. `"web_server"`) was chosen to mimic the backend's health check endpoint, which uses the same field name in its response (see: `https://data.microbiomedata.org/api/health`).

The way that Nginx evaluates `location` blocks is (this is a quote from the [Nginx docs](https://nginx.org/en/docs/http/ngx_http_core_module.html#location):

> Also, using the “=” modifier it is possible to define an exact match of URI and location. **If an exact match is found, the search terminates.** For example, if a “/” request happens frequently, defining “location = /” will speed up the processing of these requests, as search terminates right after the first comparison. Such a location cannot obviously contain nested locations. 

Side note: Based on what the second sentence says, we might be able to eke out some additional performance by updating our `/` and `/index.html` blocks to use an `=` sign, so Nginx doesn't have to evaluate the regular expressions below them. I don't want to do that in this PR, though, because I don't want to test it right now or complicate this PR.

Finally, here's what the new endpoint responds with:

- From the CLI (verbose):
  ```console
  $ curl http://localhost:8080/health -v
  * Host localhost:8080 was resolved.
  * IPv6: ::1
  * IPv4: 127.0.0.1
  *   Trying [::1]:8080...
  * Connected to localhost (::1) port 8080
  > GET /health HTTP/1.1
  > Host: localhost:8080
  > User-Agent: curl/8.7.1
  > Accept: */*
  > 
  * Request completely sent off
  < HTTP/1.1 200 OK
  < Server: nginx/1.28.3
  < Date: Fri, 10 Apr 2026 06:33:59 GMT
  < Content-Type: application/json
  < Content-Length: 20
  < Connection: keep-alive
  < 
  * Connection #0 to host localhost left intact
  {"web_server": true}
  ```
- From the browser:
  <img width="372" height="181" alt="image" src="https://github.com/user-attachments/assets/91345ba7-6ee2-4077-8bf0-b24a0c504a48" />

I plan to configure our Kubernetes `*Probe`s (e.g. `livenessProbe`, `readinessProbe`) to use this new endpoint to gauge the health of the frontend container, independently of the backend container (this is why `/api/health` is insufficient for my use case), without requesting the comparatively heavy `index.html` file, and without adding noise to the server logs.