### PR TITLE
Synchronize SQLAlchemy model with associated Alembic migration

### DIFF
--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -673,11 +673,29 @@ class BiosampleRelatedDocument(Base):
 
     __tablename__ = "biosample_related_document"
 
-    id = Column(String, primary_key=True)
-    biosample_ids = Column(ARRAY(String), nullable=False, default=list)
-    high_level_type = Column(String, nullable=False)
-    document = Column(JSONB, nullable=False)
-    downstream_neighbor_ids = Column(ARRAY(String), nullable=False, default=list)
+    id = Column(String, primary_key=True, comment="The value in the document's 'id' field")
+    biosample_ids = Column(
+        ARRAY(String),
+        nullable=False,
+        default=list,
+        comment="The IDs of all biosamples downstream of, upstream of, or representing the document",
+    )
+    high_level_type = Column(
+        String,
+        nullable=False,
+        comment="High-level type of the document (e.g., 'nmdc:WorkflowExecution')",
+    )
+    document = Column(
+        JSONB,
+        nullable=False,
+        comment="NMDC Schema-compliant document downstream of, upstream of, or representing the subject biosample",
+    )
+    downstream_neighbor_ids = Column(
+        ARRAY(String),
+        nullable=False,
+        default=list,
+        comment="IDs of documents that are immediately downstream of the document",
+    )
 
 
 omics_processing_output_association = output_association("omics_processing")


### PR DESCRIPTION
On this branch, I added the `comment="..."` kwarg to each `Column()` call in the `BiosampleRelatedDocument` model definition, in order to make those calls be consistent with the associated Alembic migration (i.e. `nmdc_server/migrations/versions/6867009bb496_create_biosample_related_document_table.py`). That pushed most of the calls past the line length limit, so I spread them out among multiple lines.

Fixes #2081 

I confirmed that, with these changes in place, the Alembic `--autogenerate` command no longer generates statements related to these comments.

<details>
<summary>Show/hide Alembic command output</summary>

```py
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
INFO  [alembic.ddl.postgresql] Detected sequence named 'envo_tree_pk_seq' as owned by integer column 'envo_tree(pk)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'ontology_relation_id_seq' as owned by integer column 'ontology_relation(id)', assuming SERIAL and omitting
INFO  [alembic.autogenerate.compare] Detected removed index 'idx_biosample_env_broad_scale_id' on 'biosample'
INFO  [alembic.autogenerate.compare] Detected removed index 'idx_biosample_env_local_scale_id' on 'biosample'
INFO  [alembic.autogenerate.compare] Detected removed index 'idx_biosample_env_medium_id' on 'biosample'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_biosample_related_document_biosample_ids' on 'biosample_related_document'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_biosample_related_document_document_type' on 'biosample_related_document'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_biosample_related_document_downstream_neighbor_ids' on 'biosample_related_document'
INFO  [alembic.autogenerate.compare] Detected removed index 'ix_biosample_related_document_high_level_type' on 'biosample_related_document'
INFO  [alembic.autogenerate.compare] Detected removed index 'idx_envo_ancestor_ancestor_id' on 'envo_ancestor'
```

</details>

<details>
<summary>Show/hide generated Alembic migration</summary>

```py
"""empty message

Revision ID: a6650311e53b
Revises: b7d4b19db410
Create Date: 2026-04-15 22:25:50.590320

"""
from typing import Optional

from alembic import op
import sqlalchemy as sa


# revision identifiers, used by Alembic.
revision: str = 'a6650311e53b'
down_revision: Optional[str] = 'b7d4b19db410'
branch_labels: Optional[str] = None
depends_on: Optional[str] = None


def upgrade():
    # ### commands auto generated by Alembic - please adjust! ###
    op.drop_index('idx_biosample_env_broad_scale_id', table_name='biosample')
    op.drop_index('idx_biosample_env_local_scale_id', table_name='biosample')
    op.drop_index('idx_biosample_env_medium_id', table_name='biosample')
    op.drop_index('ix_biosample_related_document_biosample_ids', table_name='biosample_related_document', postgresql_using='gin')
    op.drop_index('ix_biosample_related_document_document_type', table_name='biosample_related_document')
    op.drop_index('ix_biosample_related_document_downstream_neighbor_ids', table_name='biosample_related_document', postgresql_using='gin')
    op.drop_index('ix_biosample_related_document_high_level_type', table_name='biosample_related_document')
    op.drop_index('idx_envo_ancestor_ancestor_id', table_name='envo_ancestor')
    # ### end Alembic commands ###


def downgrade():
    # ### commands auto generated by Alembic - please adjust! ###
    op.create_index('idx_envo_ancestor_ancestor_id', 'envo_ancestor', ['ancestor_id'], unique=False)
    op.create_index('ix_biosample_related_document_high_level_type', 'biosample_related_document', ['high_level_type'], unique=False)
    op.create_index('ix_biosample_related_document_downstream_neighbor_ids', 'biosample_related_document', ['downstream_neighbor_ids'], unique=False, postgresql_using='gin')
    op.create_index('ix_biosample_related_document_document_type', 'biosample_related_document', [sa.text("(document ->> 'type'::text)")], unique=False)
    op.create_index('ix_biosample_related_document_biosample_ids', 'biosample_related_document', ['biosample_ids'], unique=False, postgresql_using='gin')
    op.create_index('idx_biosample_env_medium_id', 'biosample', ['env_medium_id'], unique=False)
    op.create_index('idx_biosample_env_local_scale_id', 'biosample', ['env_local_scale_id'], unique=False)
    op.create_index('idx_biosample_env_broad_scale_id', 'biosample', ['env_broad_scale_id'], unique=False)
    # ### end Alembic commands ###

```

</details>