### PR TITLE
Add ORCID ID validation rule

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -248,6 +248,9 @@ export default defineComponent({
           <v-text-field
             v-model="studyForm.piOrcid"
             label="ORCID iD"
+            :rules="[
+              v => !v || /(\d{4}-){3}\d{3}(\d|X)/.test(v) || 'ORCID iD must be in valid format (0000-0000-0000-0000)',
+            ]"
             :disabled="!isOwner() || currentUserOrcid === studyForm.piOrcid || undefined"
             variant="outlined"
             :hint="Definitions.piOrcid"


### PR DESCRIPTION
Closes #1318 

Adds a rule to validate ORCID IDs in the "Principal Investigator" section (correct format - 16-digit value, separated by hyphens, ie 0000-0000-0000-0000, last value can be 0-9 or X)