### PR TITLE
Activate uv virtual environment in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ COPY . /app/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
+# Activate the virtual environment
+ENV PATH="/app/.venv/bin:$PATH"
+
 COPY .env.production /app/.env
 RUN chmod +x /app/start.sh
 WORKDIR /app/
-CMD ["uv", "run", "/app/start.sh"]
+CMD ["/app/start.sh"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -281,7 +281,7 @@ It is recommended to use `127.0.0.1` instead of `localhost` for local developmen
     ```
 5. Run the ingest command:
     ```bash
-    docker-compose run backend nmdc-server ingest -vv --function-limit 100
+    docker compose run backend nmdc-server ingest -vv --function-limit 100
     ```
 
     > **Note**: The `--function-limit` flag is optional. It is used to reduce the time that the ingest takes by limiting the number of certain types of objects loaded. This can be useful for testing purposes. For more information on options run `nmdc-server ingest --help`.
@@ -315,21 +315,21 @@ export NMDC_GCS_FAKE_API_ENDPOINT=http://localhost:4443
 
 ```bash
 # Autogenerate a migration diff from the current HEAD
-docker-compose run backend alembic -c nmdc_server/alembic.ini revision --autogenerate
+docker compose run backend alembic -c nmdc_server/alembic.ini revision --autogenerate
 ```
 
 In order to generate a migration, your database state should match HEAD.  If you started the server from a totally empty database, then the default behavior is to ignore migration scripts and set up the database to match `models.py`.  Before you can generate a migration, you need to reset your database to match HEAD.
 
 ```bash
 # Destroy everything.  You'll lose your data!
-docker-compose down -v
-docker-compose up -d db
+docker compose down -v
+docker compose up -d db
 # Create the database
-docker-compose run backend psql -c "create database nmdc_a;" -d postgres
+docker compose run backend psql -c "create database nmdc_a;" -d postgres
 # Run migrations to HEAD
-docker-compose run backend alembic -c nmdc_server/alembic.ini upgrade head
+docker compose run backend alembic -c nmdc_server/alembic.ini upgrade head
 # Autogenerate a migration diff from the current HEAD
-docker-compose run backend alembic -c nmdc_server/alembic.ini revision --autogenerate
+docker compose run backend alembic -c nmdc_server/alembic.ini revision --autogenerate
 ```
 
 ## Testing migrations
@@ -352,7 +352,7 @@ A handy IPython shell is provided with some commonly used symbols automatically
 imported, and `autoreload 2` enabled. To run it:
 
 ```bash
-docker-compose run --rm backend nmdc-server shell
+docker compose run --rm backend nmdc-server shell
 ```
 
 You can also pass `--print-sql` to output all SQL queries. Note that if you have SQL logging enabled via the `NMDC_PRINT_SQL` environment variable, you will not need to pass `--print-sql` to the command.


### PR DESCRIPTION
Fixes #2103 

These changes activate the uv virtual environment before executing the container startup command (whether the default via `CMD` over overridden at runtime). Activation is done by prepending the path as suggested by the [uv docs](https://docs.astral.sh/uv/guides/integration/docker/#using-the-environment). Having the virtual environment activated automatically makes containers running the backend image behave (from an outside view) equivalently to the old `pip`-based approach which modified the system Python environment. I thought that would be more convenient than having to sprinkle `uv run`s everywhere (and potentially missing some).