### PR TITLE
Add check to date histogram for empty data set

### DIFF
--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -105,7 +105,7 @@ watch(() => props.myConditions, () => {
       :height="height"
     />
     <ChartContainer
-      v-if="facetSummaryUnconditional && facetSummary"
+      v-if="facetSummaryUnconditional && facetSummary && facetSummary.bins && facetSummary.bins.length > 0"
       :height="height"
     >
       <template #default="{ width }">
@@ -123,6 +123,13 @@ watch(() => props.myConditions, () => {
         </div>
       </template>
     </ChartContainer>
+    <div
+      v-else-if="!loading && facetSummaryUnconditional"
+      class="d-flex align-center justify-center"
+      :style="{ height: `${height}px` }"
+    >
+      <p class="text-grey">No results for this search</p>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Resolves #2091 

Add a check to the `DateHistogram` to see if `facetSummary.bins` length is greater than 0 before displaying anything.
Tested with the same settings as shown in the issue and it appears to be resolved.