### PR TITLE
Fix regression with gene function searching facet

### DIFF
--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -328,7 +328,7 @@ def kegg_text_search(db: Session, query: str, limit: int) -> List[models.KoTermT
     term = query.replace(pathway_prefix, "map") if pathway_prefix else query
     q = (
         db.query(models.KoTermText)
-        .filter(models.KoTermText.text.ilike(f"%{term}%") | models.KoTermText.term.ilike(term))
+        .filter(models.KoTermText.text.ilike(f"%{term}%") | models.KoTermText.term.ilike(f"%{term}%"))
         .order_by(models.KoTermText.term)
         .limit(limit)
     )

--- a/nmdc_server/crud.py
+++ b/nmdc_server/crud.py
@@ -328,7 +328,9 @@ def kegg_text_search(db: Session, query: str, limit: int) -> List[models.KoTermT
     term = query.replace(pathway_prefix, "map") if pathway_prefix else query
     q = (
         db.query(models.KoTermText)
-        .filter(models.KoTermText.text.ilike(f"%{term}%") | models.KoTermText.term.ilike(f"%{term}%"))
+        .filter(
+            models.KoTermText.text.ilike(f"%{term}%") | models.KoTermText.term.ilike(f"%{term}%")
+        )
         .order_by(models.KoTermText.term)
         .limit(limit)
     )

--- a/web/src/components/FilterGene.vue
+++ b/web/src/components/FilterGene.vue
@@ -21,6 +21,11 @@ import { computedAsync } from '@vueuse/core';
 
 export type GeneType = 'kegg' | 'cog' | 'pfam' | 'go';
 
+interface GeneResult {
+  text: string;
+  value: string;
+}
+
 export default defineComponent({
 
   props: {
@@ -63,9 +68,10 @@ export default defineComponent({
 
     async function getGeneResults() {
       const resp = await geneSearch();
-      const results = [];
-      if (resp) resp
-        .map((v: KeggTermSearchResponse) => ({ text: getTermDisplayText(v.term, v.text), value: v.term }));
+      let results: GeneResult[] = [];
+      if (resp) {
+        results = resp.map((v: KeggTermSearchResponse) => ({ text: getTermDisplayText(v.term, v.text), value: v.term }));
+      }
       if (results.length === 0 && search.value && props.geneTypeParams.searchWithInputText(search.value)) {
         results.push({ value: search.value, text: search.value });
       }


### PR DESCRIPTION
Resolves #2146 

Restores Function facets search capability. Terms can be searched by text or term and both support partial matches.

<img width="677" height="638" alt="Screenshot 2026-05-26 at 3 49 16 PM" src="https://github.com/user-attachments/assets/89e7fad6-99e6-4b2d-902c-5081e7ad6c79" />

<img width="660" height="598" alt="Screenshot 2026-05-26 at 4 10 33 PM" src="https://github.com/user-attachments/assets/bbf60c62-5c83-4ce8-8ba2-d7bfe447a38a" />