### PR TITLE
Fix metaproteomic analysis facet error

### DIFF
--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -79,6 +79,7 @@ class BaseFilter:
         target_table: Table,
     ) -> Query:
         """Get a query representing unique id's of the target table matching the conditions."""
+        # Note that select_from is necessary to avoid ambiguity when the target_table.model is an AliasedClass
         query = db.query(func.distinct(target_table.model.id).label("id")).select_from(
             target_table.model
         )
@@ -273,8 +274,8 @@ class WorkflowExecutionFilter(OmicsProcessingFilter):
         ).join(model, model.id == association_table.c[f"{self.table.value}_id"])
         return q
 
-    # Override join_self to avoid joining with the workflow execution table twice, since
-    # the workflow execution tables are joined with OmicsProcessing using a separate association table.
+    # Override join_self because the workflow execution tables do not have a
+    # direct relationship with OmicsProcessing, so we need to use the association table.
     def join_self(self, query: Query, parent: Table) -> Query:
         if self.table == parent:
             return query
@@ -440,6 +441,8 @@ class MetaproteomicAnalysisFilter(OmicsProcessingFilter):
             models.MetaproteomicAnalysis.id == association_table.c.metaproteomic_analysis_id,
         )
 
+    # Override join_self because the metaproteomic_analysis table does not have a
+    # direct relationship with OmicsProcessing, so we need to use the association table.
     def join_self(self, query: Query, parent: Table) -> Query:
         if self.table == parent:
             return query

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -271,6 +271,13 @@ class WorkflowExecutionFilter(OmicsProcessingFilter):
         ).join(model, model.id == association_table.c[f"{self.table.value}_id"])
         return q
 
+    # Override join_self to avoid joining with the workflow execution table twice, since
+    # the workflow execution tables are joined with OmicsProcessing using a separate association table.
+    def join_self(self, query: Query, parent: Table) -> Query:
+        if self.table == parent:
+            return query
+        return self.join_omics_processing(query)
+
 
 workflow_filter_classes: List[Type[WorkflowExecutionFilter]] = []
 for table in workflow_execution_tables:

--- a/nmdc_server/filters.py
+++ b/nmdc_server/filters.py
@@ -79,7 +79,9 @@ class BaseFilter:
         target_table: Table,
     ) -> Query:
         """Get a query representing unique id's of the target table matching the conditions."""
-        query = db.query(func.distinct(target_table.model.id).label("id"))
+        query = db.query(func.distinct(target_table.model.id).label("id")).select_from(
+            target_table.model
+        )
         return self._apply_conditions(query, target_table)
 
     def _apply_conditions(
@@ -437,6 +439,11 @@ class MetaproteomicAnalysisFilter(OmicsProcessingFilter):
             models.MetaproteomicAnalysis,
             models.MetaproteomicAnalysis.id == association_table.c.metaproteomic_analysis_id,
         )
+
+    def join_self(self, query: Query, parent: Table) -> Query:
+        if self.table == parent:
+            return query
+        return self.join_omics_processing(query)
 
     def join_biosample(self, query: Query) -> Query:
         association_table = models.metaproteomic_analysis_data_generation_association

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -749,7 +749,6 @@ class StudyQuerySchema(BaseQuerySchema):
         self, db: Session, conditions: Sequence[ConditionSchema]
     ) -> Query:
         """Aggregate omics types into a custom jsonb response."""
-        print("counting omics processing summary with conditions!!!!")
         op_summary_alias = aliased(models.OmicsProcessing)
         biosample_alias = aliased(models.Biosample)
 
@@ -808,7 +807,6 @@ class StudyQuerySchema(BaseQuerySchema):
                     "type", table_name, "count", getattr(omics_subquery.c, f"{table_name}_count")
                 )
             )
-        print("injecting omics processing summary conditions!!!!!!!!")
         # Here we only insert filter conditions that are actually relevant for
         # this aggregation.  This reduces the complexity of subquery greatly.
         op_filter_conditions = [
@@ -818,7 +816,6 @@ class StudyQuerySchema(BaseQuerySchema):
             and c.table.value
             in {"omics_processing", "biosample", "gene_function", "metaproteomic_analysis"}
         ]
-        print(f"omics processing summary conditions: {op_filter_conditions}")
         op_summary_subquery = self._count_omics_processing_summary(
             db, op_filter_conditions
         ).subquery()
@@ -846,7 +843,6 @@ class StudyQuerySchema(BaseQuerySchema):
                 fts_condition_value = c.value
                 fts_condition_exists = True
                 break
-        print("running study query with conditions!!!!!!!")
         biosample_condition_exists = any(
             [condition.table == Table.biosample for condition in self.conditions]
         )
@@ -854,7 +850,6 @@ class StudyQuerySchema(BaseQuerySchema):
             [condition.table == Table.omics_processing for condition in self.conditions]
         )
         if fts_condition_exists or biosample_condition_exists:
-            print("fts or biosample condition exists!!!!!!!!")
             biosample_ids_subquery = (
                 BiosampleQuerySchema(conditions=self.conditions).query(db).subquery()
             )
@@ -873,7 +868,6 @@ class StudyQuerySchema(BaseQuerySchema):
                 )
             study_query = study_query.filter(study_id_filter)
         elif omics_condition_exists:
-            print("omics condition exists!!!!!!!!!!!!!!!!")
             omics_query = OmicsProcessingQuerySchema(conditions=self.conditions).query(db)
             studies_from_omics_query = omics_query.with_entities(
                 models.OmicsProcessing.study_id
@@ -884,7 +878,6 @@ class StudyQuerySchema(BaseQuerySchema):
         return study_query
 
     def execute(self, db: Session) -> Query:
-        print("executing study query with conditions!!!!!!!")
         sample_subquery = BiosampleQuerySchema(conditions=self.conditions).query(db).subquery()
         sample_count = (
             db.query(

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -749,6 +749,7 @@ class StudyQuerySchema(BaseQuerySchema):
         self, db: Session, conditions: Sequence[ConditionSchema]
     ) -> Query:
         """Aggregate omics types into a custom jsonb response."""
+        print("counting omics processing summary with conditions!!!!")
         op_summary_alias = aliased(models.OmicsProcessing)
         biosample_alias = aliased(models.Biosample)
 
@@ -807,7 +808,7 @@ class StudyQuerySchema(BaseQuerySchema):
                     "type", table_name, "count", getattr(omics_subquery.c, f"{table_name}_count")
                 )
             )
-
+        print("injecting omics processing summary conditions!!!!!!!!")
         # Here we only insert filter conditions that are actually relevant for
         # this aggregation.  This reduces the complexity of subquery greatly.
         op_filter_conditions = [
@@ -817,6 +818,7 @@ class StudyQuerySchema(BaseQuerySchema):
             and c.table.value
             in {"omics_processing", "biosample", "gene_function", "metaproteomic_analysis"}
         ]
+        print(f"omics processing summary conditions: {op_filter_conditions}")
         op_summary_subquery = self._count_omics_processing_summary(
             db, op_filter_conditions
         ).subquery()
@@ -844,6 +846,7 @@ class StudyQuerySchema(BaseQuerySchema):
                 fts_condition_value = c.value
                 fts_condition_exists = True
                 break
+        print("running study query with conditions!!!!!!!")
         biosample_condition_exists = any(
             [condition.table == Table.biosample for condition in self.conditions]
         )
@@ -851,6 +854,7 @@ class StudyQuerySchema(BaseQuerySchema):
             [condition.table == Table.omics_processing for condition in self.conditions]
         )
         if fts_condition_exists or biosample_condition_exists:
+            print("fts or biosample condition exists!!!!!!!!")
             biosample_ids_subquery = (
                 BiosampleQuerySchema(conditions=self.conditions).query(db).subquery()
             )
@@ -869,6 +873,7 @@ class StudyQuerySchema(BaseQuerySchema):
                 )
             study_query = study_query.filter(study_id_filter)
         elif omics_condition_exists:
+            print("omics condition exists!!!!!!!!!!!!!!!!")
             omics_query = OmicsProcessingQuerySchema(conditions=self.conditions).query(db)
             studies_from_omics_query = omics_query.with_entities(
                 models.OmicsProcessing.study_id
@@ -879,6 +884,7 @@ class StudyQuerySchema(BaseQuerySchema):
         return study_query
 
     def execute(self, db: Session) -> Query:
+        print("executing study query with conditions!!!!!!!")
         sample_subquery = BiosampleQuerySchema(conditions=self.conditions).query(db).subquery()
         sample_count = (
             db.query(


### PR DESCRIPTION
Resolves #2147 

Use of the Metaproteomics Analysis Category filter in the Data Portal was triggering this backend error:

> Don't know how to join to <Mapper at 0x7b998f925340; MetaproteomicAnalysis>. Please use the .select_from() method to establish an explicit left side, as well as providing an explicit ON clause if not present already to help resolve the ambiguity.

This caused the study and consortia results to be incorrect (unfiltered) when using this facet.

The fix targets the overarching filter classes: `BaseFilter`, `WorkflowExecutionFilter`, and `MetaproteomicAnalysisFilter`. There were two main changes made here:
1. The `matches` query in `BaseFilter` was resulting in ambiguous SQL because of the cases where the target table was an `AliasedClass`.
2. For  `WorkflowExecutionFilter` and `MetaproteomicAnalysisFilter`, the `join_self` function needed to be overridden so that the proper association tables were found/used for those subqueries.

I'll note, because it wasn't obvious to me at first, that these filters are invoked in query.py on various instantiated filters created with `create_filter_class()` (e.g. [line 477 in query.py](https://github.com/microbiomedata/nmdc-server/blob/main/nmdc_server/query.py#L477)). The joins are triggered from the `matches` function which gets called on those instantiated filter classes.

AI disclosure: Claude Sonnet 4.6 was used to assist the diagnosis and solution for this bug.

