### PR TITLE
Restore update of `modifiedDate` state

### DIFF
--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -859,6 +859,7 @@ function updateStateFromRecord(record: MetadataSubmissionRecord) {
     Object.assign(sampleData, record.metadata_submission.sampleData);
   }
   createdDate.value = new Date(record.created + 'Z');
+  modifiedDate.value = new Date(record.date_last_modified + 'Z');
   status.value = record.status;
   if (record.permission_level !== null) {
     _permissionLevel = (record.permission_level as SubmissionEditorRole);


### PR DESCRIPTION
I noticed on dev (**not** on prod) that the Last Modified timestamp of submissions were not being presented on the submission summary page:
<img width="1046" height="377" alt="image" src="https://github.com/user-attachments/assets/8bdaed6b-b1a5-4081-99fb-17156d5acd56" />

This was caused by the `modifiedDate` ref not being updated in `updateStateFromRecord`. I believe this was accidentally dropped in https://github.com/microbiomedata/nmdc-server/commit/f06ca7b238f688822acd7938db61eb7b662b8e8c#diff-04ee0d419cc3e4c8a706fb6a5783bfadb69775408126ee2d65033126815bf772L833.