### PR TITLE
Add name, created, and date_last_modified columns to submission_sample_set

### DIFF
--- a/nmdc_server/migrations/versions/3ead3f3357a2_add_sample_set_name_and_timestamps.py
+++ b/nmdc_server/migrations/versions/3ead3f3357a2_add_sample_set_name_and_timestamps.py
@@ -1,0 +1,92 @@
+"""add name, created, and date_last_modified to submission_sample_set
+
+Revision ID: 3ead3f3357a2
+Revises: 6274a27c66dd
+Create Date: 2026-05-29 16:00:46.605688
+
+"""
+
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import column, table
+
+# revision identifiers, used by Alembic.
+revision: str = "3ead3f3357a2"
+down_revision: Optional[str] = "6274a27c66dd"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    # Add the columns as nullable to allow for backfilling data before enforcing non-null constraints.
+    op.add_column("submission_sample_set", sa.Column("name", sa.String(), nullable=True))
+    op.add_column("submission_sample_set", sa.Column("created", sa.DateTime(), nullable=True))
+    op.add_column(
+        "submission_sample_set", sa.Column("date_last_modified", sa.DateTime(), nullable=True)
+    )
+
+    # Define the relevant parts of the tables to use in the data migration.
+    submission_metadata = table(
+        "submission_metadata",
+        column("id", postgresql.UUID),
+        column("created", sa.DateTime),
+        column("date_last_modified", sa.DateTime),
+    )
+    submission_sample_set = table(
+        "submission_sample_set",
+        column("id", postgresql.UUID),
+        column("submission_metadata_id", postgresql.UUID),
+        column("name", sa.String),
+        column("created", sa.DateTime),
+        column("date_last_modified", sa.DateTime),
+    )
+
+    # Select existing sample sets along with their associated submission.
+    connection = op.get_bind()
+    sample_sets = connection.execute(
+        sa.select(
+            submission_sample_set.c.id,  # type: ignore[arg-type]
+            submission_metadata.c.created,
+            submission_metadata.c.date_last_modified,  # type: ignore[arg-type]
+        ).select_from(
+            submission_sample_set.join(
+                submission_metadata,
+                submission_sample_set.c.submission_metadata_id == submission_metadata.c.id,
+            )
+        )
+    )
+
+    # Backfill the new columns for existing sample sets. The name is generated based on the
+    # creation date of the associated submission. The created and date_last_modified values are
+    # copied from the associated submission.
+    for sample_set in sample_sets:
+        created = sample_set.created
+        connection.execute(
+            submission_sample_set.update()
+            .where(submission_sample_set.c.id == sample_set.id)
+            .values(
+                name=f"Sample Set {created.date().isoformat()}",
+                created=created,
+                date_last_modified=sample_set.date_last_modified,
+            )
+        )
+
+    # After backfilling data, alter the columns to set nullable=False to enforce that all sample
+    # sets have these values.
+    op.alter_column("submission_sample_set", "name", existing_type=sa.String(), nullable=False)
+    op.alter_column("submission_sample_set", "created", existing_type=sa.DateTime(), nullable=False)
+    op.alter_column(
+        "submission_sample_set",
+        "date_last_modified",
+        existing_type=sa.DateTime(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.drop_column("submission_sample_set", "date_last_modified")
+    op.drop_column("submission_sample_set", "created")
+    op.drop_column("submission_sample_set", "name")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -24,6 +24,7 @@ from sqlalchemy import (
     column,
     event,
     func,
+    update,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.ext.associationproxy import association_proxy
@@ -1618,4 +1619,8 @@ def update_submission_sample_set_timestamps(session: Session, _flush_context, _i
             continue
 
         obj.date_last_modified = now
-        obj.submission_metadata.date_last_modified = now
+        session.execute(
+            update(SubmissionMetadata.__table__)
+            .where(SubmissionMetadata.id == obj.submission_metadata_id)
+            .values(date_last_modified=now)
+        )

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1461,7 +1461,9 @@ class SubmissionMetadata(Base):
         if not sample_set_fields.intersection(value):
             return
 
-        first_sample_set = self._first_sample_set or SubmissionSampleSet()
+        first_sample_set = self._first_sample_set or SubmissionSampleSet(
+            name="COMPATIBILITY_DEFAULT"
+        )
         if not self.sample_sets:
             self.sample_sets.append(first_sample_set)
 
@@ -1488,7 +1490,7 @@ class SubmissionMetadata(Base):
     def status(self, value) -> None:
         first_sample_set = self._first_sample_set
         if first_sample_set is None:
-            first_sample_set = SubmissionSampleSet()
+            first_sample_set = SubmissionSampleSet(name="COMPATIBILITY_DEFAULT")
             self.sample_sets.append(first_sample_set)
         first_sample_set.status = value
 
@@ -1515,6 +1517,13 @@ class SubmissionSampleSet(Base):
     id = Column(type_=UUID(as_uuid=True), primary_key=True, default=uuid4)
     submission_metadata_id = Column(
         UUID(as_uuid=True), ForeignKey(SubmissionMetadata.id), nullable=False
+    )
+    name = Column(String, nullable=False)
+    created = Column(DateTime, nullable=False, default=lambda: datetime.now(UTC))
+    date_last_modified = Column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(UTC),
     )
     status = Column(String, nullable=False, default=SubmissionStatusEnum.InProgress.text)
     templates = Column(JSONB, nullable=True)
@@ -1579,3 +1588,34 @@ def update_submission_metadata_date(mapper, _connection, target):
             if history.has_changes():
                 target.date_last_modified = datetime.now(UTC)
                 return
+
+
+SUBMISSION_SAMPLE_SET_MUTABLE_COLUMNS = {
+    "name",
+    "status",
+    "templates",
+    "sample_environment_form",
+    "sender_shipping_info_form",
+    "multi_omics_form",
+    "sample_data",
+}
+
+
+@event.listens_for(Session, "before_flush")
+def update_submission_sample_set_timestamps(session: Session, _flush_context, _instances) -> None:
+    """Keep sample set and parent submission timestamps in sync before flush."""
+    now = datetime.now(UTC)
+
+    for obj in session.new.union(session.dirty):
+        if not isinstance(obj, SubmissionSampleSet):
+            continue
+
+        is_new = obj in session.new
+        if not is_new and not any(
+            get_history(obj, column_name).has_changes()
+            for column_name in SUBMISSION_SAMPLE_SET_MUTABLE_COLUMNS
+        ):
+            continue
+
+        obj.date_last_modified = now
+        obj.submission_metadata.date_last_modified = now


### PR DESCRIPTION
Fixes #2157 

These changes add `name`, `created`, and `date_last_modified` columns to the `submission_sample_set` table. The migration also backfills the values of these columns based on the `created` and `date_last_modified` values from the associated submission.

Because `name` is now required but has no ORM-level default, the two places in the compatibility layer use a placeholder value when constructing a new `SubmissionSampleSet` instance. This is a temporary solution which will go away when the compatibility layer itself goes away in subsequent work. 

These changes use a `before_flush` event to keep the parent submission's `date_last_modified` updated if one of its sample sets is update _or_ if a new sample set is added. I have tested this interactively, but it will be easier to add more effective automated tests once the new endpoints are in place and the compatibility layer is removed.