### PR TITLE
Update GHA workflow to deploy container images to GKE-hosted dev environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,3 +153,46 @@ jobs:
           method: POST
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
+
+  restart-dev-deployments:
+    name: Restart (dev) deployments on GKE
+    needs: [ build ]
+    permissions: { contents: read }
+    # Note: The `jobs.<job_id>.if` key doesn't have access to the `env` context (and, so, cannot
+    #       check `env.IS_ORIGINAL_REPO`), but it does have access to the `github` context, so we
+    #       effectively re-derive the value of `env.IS_ORIGINAL_REPO` from that context here.
+    #
+    # Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability
+    #
+    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━━┓ 
+    if: github.repository == 'microbiomedata/nmdc-runtime'
+    runs-on: ubuntu-latest
+    steps:
+      # Create a short-lived token that gives its holder the ability to run GHA workflows in the
+      # private `microbiomedata/nmdc-cloud-deployment` repository.
+      #
+      # Note: This step is written under the assumption that the repository variable named
+      #       `GHA_WF_DISPATCHER_GH_APP_CLIENT_ID` contains the GitHub app's client ID, and the
+      #       repository secret named `GHA_WF_DISPATCHER_GH_APP_PRIVATE_KEY` contains the GitHub
+      #       app's private key.
+      #
+      # Docs: https://github.com/marketplace/actions/create-github-app-token
+      #
+      - name: Create GitHub App token
+        id: create-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GHA_WF_DISPATCHER_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHA_WF_DISPATCHER_GH_APP_PRIVATE_KEY }}
+          owner: microbiomedata
+          repositories: nmdc-cloud-deployment
+
+      # Use the GitHub CLI to trigger the GHA workflows (in the `nmdc-cloud-deployment` repo)
+      # that use Argo CD to restart the Portal (dev) deployments.
+      # Docs: https://cli.github.com/manual/gh_workflow_run
+      - name: Restart Portal deployments (dev)
+        env:
+          GH_TOKEN: ${{ steps.create-app-token.outputs.token }}
+        run: |
+          gh workflow run argocd-restart-portal.yaml \
+            --repo microbiomedata/nmdc-cloud-deployment --ref main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,8 +164,8 @@ jobs:
     #
     # Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability
     #
-    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━━┓ 
-    if: github.repository == 'microbiomedata/nmdc-runtime'
+    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━┓ 
+    if: github.repository == 'microbiomedata/nmdc-server'
     runs-on: ubuntu-latest
     steps:
       # Create a short-lived token that gives its holder the ability to run GHA workflows in the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,13 +159,13 @@ jobs:
     needs: [ build ]
     permissions: { contents: read }
     # Note: The `jobs.<job_id>.if` key doesn't have access to the `env` context (and, so, cannot
-    #       check `env.IS_ORIGINAL_REPO`), but it does have access to the `github` context, so we
-    #       effectively re-derive the value of `env.IS_ORIGINAL_REPO` from that context here.
+    #       check `env.IS_ORIGINAL_REPO` or `env.IS_PROD_RELEASE`). However, it does have access to
+    #       the `github` context, so we effectively re-derive those same boolean values here.
     #
     # Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability
     #
-    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━┓ 
-    if: github.repository == 'microbiomedata/nmdc-server'
+    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━┓    ┏━━━━━━━ (not) IS_PROD_RELEASE ━━━━━━┓
+    if: github.repository == 'microbiomedata/nmdc-server' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       # Create a short-lived token that gives its holder the ability to run GHA workflows in the


### PR DESCRIPTION
On this branch, I updated the GHA workflow that builds the container images and pushes them to GHCR, so that it (effectively) then deploys them to the dev environment on GKE.

Outside of this PR, I have created the requisite repository variable and repository secret, referenced within the added workflow steps:

- `GHA_WF_DISPATCHER_GH_APP_CLIENT_ID` contains the GitHub app's client ID (copy/pasted from https://github.com/organizations/microbiomedata/settings/apps/gh-actions-workflow-dispatcher)
- `GHA_WF_DISPATCHER_GH_APP_PRIVATE_KEY` contains the GitHub app's private key (copy/pasted from the `.pem` file downloaded from the "Private key" section of that same web page)

This PR is the `nmdc-server` analogue to the `nmdc-runtime` PR https://github.com/microbiomedata/nmdc-runtime/pull/1500, which was merged and tested (it worked).