### PR TITLE
Remove `Status` and `Templates` from submission portal home page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,3 +153,46 @@ jobs:
           method: POST
           username: ${{ secrets.SPIN_USER }}
           password: ${{ secrets.SPIN_PASSWORD }}
+
+  restart-dev-deployments:
+    name: Restart (dev) deployments on GKE
+    needs: [ build ]
+    permissions: { contents: read }
+    # Note: The `jobs.<job_id>.if` key doesn't have access to the `env` context (and, so, cannot
+    #       check `env.IS_ORIGINAL_REPO`), but it does have access to the `github` context, so we
+    #       effectively re-derive the value of `env.IS_ORIGINAL_REPO` from that context here.
+    #
+    # Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability
+    #
+    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━━┓ 
+    if: github.repository == 'microbiomedata/nmdc-runtime'
+    runs-on: ubuntu-latest
+    steps:
+      # Create a short-lived token that gives its holder the ability to run GHA workflows in the
+      # private `microbiomedata/nmdc-cloud-deployment` repository.
+      #
+      # Note: This step is written under the assumption that the repository variable named
+      #       `GHA_WF_DISPATCHER_GH_APP_CLIENT_ID` contains the GitHub app's client ID, and the
+      #       repository secret named `GHA_WF_DISPATCHER_GH_APP_PRIVATE_KEY` contains the GitHub
+      #       app's private key.
+      #
+      # Docs: https://github.com/marketplace/actions/create-github-app-token
+      #
+      - name: Create GitHub App token
+        id: create-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.GHA_WF_DISPATCHER_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHA_WF_DISPATCHER_GH_APP_PRIVATE_KEY }}
+          owner: microbiomedata
+          repositories: nmdc-cloud-deployment
+
+      # Use the GitHub CLI to trigger the GHA workflows (in the `nmdc-cloud-deployment` repo)
+      # that use Argo CD to restart the Portal (dev) deployments.
+      # Docs: https://cli.github.com/manual/gh_workflow_run
+      - name: Restart Portal deployments (dev)
+        env:
+          GH_TOKEN: ${{ steps.create-app-token.outputs.token }}
+        run: |
+          gh workflow run argocd-restart-portal.yaml \
+            --repo microbiomedata/nmdc-cloud-deployment --ref main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,8 +164,8 @@ jobs:
     #
     # Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability
     #
-    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━━┓ 
-    if: github.repository == 'microbiomedata/nmdc-runtime'
+    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━┓ 
+    if: github.repository == 'microbiomedata/nmdc-server'
     runs-on: ubuntu-latest
     steps:
       # Create a short-lived token that gives its holder the ability to run GHA workflows in the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,13 +159,13 @@ jobs:
     needs: [ build ]
     permissions: { contents: read }
     # Note: The `jobs.<job_id>.if` key doesn't have access to the `env` context (and, so, cannot
-    #       check `env.IS_ORIGINAL_REPO`), but it does have access to the `github` context, so we
-    #       effectively re-derive the value of `env.IS_ORIGINAL_REPO` from that context here.
+    #       check `env.IS_ORIGINAL_REPO` or `env.IS_PROD_RELEASE`). However, it does have access to
+    #       the `github` context, so we effectively re-derive those same boolean values here.
     #
     # Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability
     #
-    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━┓ 
-    if: github.repository == 'microbiomedata/nmdc-server'
+    #   ┏━━━━━━━━━━━━━━━ IS_ORIGINAL_REPO ━━━━━━━━━━━━━━┓    ┏━━━━━━━ (not) IS_PROD_RELEASE ━━━━━━┓
+    if: github.repository == 'microbiomedata/nmdc-server' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       # Create a short-lived token that gives its holder the ability to run GHA workflows in the

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -39,17 +39,6 @@ const headers: DataTableHeader[] = [
     sortable: true,
   },
   {
-    title: 'Template',
-    value: 'templates',
-    sortable: true,
-  },
-  {
-    title: 'Status',
-    value: 'status',
-    width: '200px',
-    sortable: true,
-  },
-  {
     title: 'Last Modified',
     value: 'date_last_modified',
     sortable: true,
@@ -372,38 +361,8 @@ export default defineComponent({
                 :authenticated="true"
               />
             </template>
-            <template #[`item.templates`]="{ item }">
-              {{ item.templates.map((template) => HARMONIZER_TEMPLATES[template]?.displayName).join(' + ') }}
-            </template>
             <template #[`item.date_last_modified`]="{ item }">
               {{ new Date(item.date_last_modified + 'Z').toLocaleString() }}
-            </template>
-            <template #[`header.status`]="{ column, getSortIcon, toggleSort }">
-              <div class="d-flex align-center ga-1">
-                <v-tooltip
-                  v-if="currentUser?.is_admin || (currentUser?.orcid && submission.data.results.results.some(item => item.reviewers.includes(currentUser!.orcid)))"
-                  location="bottom"
-                >
-                  <template #activator="{ props }">
-                    <v-icon
-                      class="ml-1"
-                      color="grey"
-                      v-bind="props"
-                    >
-                      mdi-information-outline
-                    </v-icon>
-                  </template>
-                  <span>Reviewer can change status of assigned submissions. Some values are user-triggered statuses and cannot be changed or selected.</span>
-                </v-tooltip>
-                <span>
-                  {{ column.title }}
-                </span>
-                <v-icon
-                  class="v-data-table-header__sort-icon"
-                  :icon="getSortIcon(column)"
-                  @click="toggleSort(column)"
-                />
-              </div>
             </template>
             <template #[`item.status`]="{ item }">
               <div class="d-flex align-center">

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -106,6 +106,12 @@ export default defineComponent({
     applySortOptions();
     const assignReviewerRequest = useRequest();
 
+    const submissionEditableState = ref<Record<string, boolean>>({});
+
+    async function checkSubmissionEditable(submissionId: string): Promise<void> {
+      submissionEditableState.value[submissionId] = await editableByStatus(submissionId);
+    }
+
     const statusUpdatingSubmissionId = ref<string | null>(null);
     async function handleStatusChange(item: MetadataSubmissionRecordSlim, newStatus: string) {
       statusUpdatingSubmissionId.value = item.id;
@@ -134,6 +140,14 @@ export default defineComponent({
       submission.setPage(options.value.page);
       applySortOptions();
     });
+
+    watch(() => submission.data.results.results, (newResults) => {
+      if (newResults) {
+        newResults.forEach((item) => {
+          checkSubmissionEditable(item.id);
+        });
+      }
+    }, { deep: false });
 
     function handleOpenDeleteDialog(item: MetadataSubmissionRecordSlim | null) {
       deleteDialogSubmission.value = item;
@@ -217,7 +231,7 @@ export default defineComponent({
       IconBar,
       IntroBlurb,
       TitleBanner,
-      editableByStatus,
+      submissionEditableState,
       getStatus,
       resume,
       addReviewer,
@@ -393,7 +407,7 @@ export default defineComponent({
                   color="primary"
                   @click="() => resume(item as MetadataSubmissionRecord)"
                 >
-                  <span v-if="editableByStatus(item.status) && isAnyContributorForSubmission(item)">
+                  <span v-if="submissionEditableState[item.id] && isAnyContributorForSubmission(item)">
                     Resume
                     <v-icon class="pl-1">mdi-arrow-right-circle</v-icon>
                   </span>

--- a/web/src/views/SubmissionPortal/store/api.ts
+++ b/web/src/views/SubmissionPortal/store/api.ts
@@ -35,7 +35,7 @@ async function createRecord(record: MetadataSubmission, isTestSubmission: boolea
     MetadataSubmissionRecord,
     Partial<MetadataSubmissionRecord>
   >('metadata_submission', {
-    metadata_submission: record,
+    study_form: record.studyForm,
     source_client: 'submission_portal',
     is_test_submission: isTestSubmission,
   });
@@ -175,6 +175,16 @@ async function deleteSubmissionImage(submissionId: string, imageType: Submission
   await client.delete<MetadataSubmissionRecord>(endpoint);
 }
 
+async function getSampleSetsForSubmission(submissionId: string) {
+  const resp = await client.get<any[]>(`metadata_submission/${submissionId}/sample_set`);
+  return resp.data;
+}
+
+async function getSampleSet(sampleSetId: string) {
+  const resp = await client.get<any>(`metadata_submission/sample_set/${sampleSetId}`);
+  return resp.data;
+}
+
 export {
   addressToString,
   createRecord,
@@ -193,4 +203,6 @@ export {
   updateSubmissionStatus,
   addSubmissionRole,
   getSubmissionStatus,
+  getSampleSetsForSubmission,
+  getSampleSet,
 };

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -124,13 +124,19 @@ function isOwner(): boolean {
   return permissionLevelHierarchy[_permissionLevel] === permissionLevelHierarchy.owner;
 }
 
-function editableByStatus(status: SubmissionStatusKey): boolean {
+function isStatusEditable(status: SubmissionStatusKey): boolean {
   const editableStatuses: SubmissionStatusKey[] = ['InProgress', 'UpdatesRequired'];
   return editableStatuses.includes(status);
 }
 
+async function editableByStatus(submissionId: string): Promise<boolean> {
+  const editableStatuses: SubmissionStatusKey[] = ['InProgress', 'UpdatesRequired'];
+  const sampleSets = await api.getSampleSetsForSubmission(submissionId);
+  return sampleSets.some((sampleSet: any) => editableStatuses.includes(sampleSet.status));
+}
+
 function canEditSubmissionByStatus(): boolean {
-  return editableByStatus(status.value);
+  return isStatusEditable(status.value);
 }
 
 /**
@@ -842,25 +848,33 @@ async function generateRecord(isTestSubBool: boolean, studyNameStr: string = '',
   return record;
 }
 
-function updateStateFromRecord(record: MetadataSubmissionRecord) {
-  if (!isEqual(sampleEnvironmentForm, record.metadata_submission.sampleEnvironmentForm)) {
-    Object.assign(sampleEnvironmentForm, record.metadata_submission.sampleEnvironmentForm);
+async function updateStateFromRecord(record: MetadataSubmissionRecord) {
+  const sampleSets = await api.getSampleSetsForSubmission(record.id);
+  if (sampleSets && sampleSets.length > 0) {
+    //default to first sample set for now
+    const firstSampleSetId = sampleSets[0].id;
+    const fullSampleSet = await api.getSampleSet(firstSampleSetId);
+    if (fullSampleSet) {
+      if (!isEqual(sampleEnvironmentForm, fullSampleSet.sample_environment_form)) {
+        Object.assign(sampleEnvironmentForm, fullSampleSet.sample_environment_form);
+      }
+      if (!isEqual(multiOmicsForm, fullSampleSet.multi_omics_form)) {
+        Object.assign(multiOmicsForm, fullSampleSet.multi_omics_form);
+      }
+      if (!isEqual(senderShippingInfoForm, fullSampleSet.sender_shipping_info_form)) {
+        Object.assign(senderShippingInfoForm, fullSampleSet.sender_shipping_info_form);
+      }
+      if (!isEqual(sampleData, fullSampleSet.sample_data)) {
+        Object.assign(sampleData, fullSampleSet.sample_data);
+      }
+      status.value = fullSampleSet.status;
+    }
   }
-  if (!isEqual(studyForm, record.metadata_submission.studyForm)) {
-    Object.assign(studyForm, record.metadata_submission.studyForm);
-  }
-  if (!isEqual(multiOmicsForm, record.metadata_submission.multiOmicsForm)) {
-    Object.assign(multiOmicsForm, record.metadata_submission.multiOmicsForm);
-  }
-  if (!isEqual(senderShippingInfoForm, record.metadata_submission.senderShippingInfoForm)) {
-    Object.assign(senderShippingInfoForm, record.metadata_submission.senderShippingInfoForm);
-  }
-   if (!isEqual(sampleData, record.metadata_submission.sampleData)) {
-    Object.assign(sampleData, record.metadata_submission.sampleData);
+  if (!isEqual(studyForm, record.study_form)) {
+    Object.assign(studyForm, record.study_form);
   }
   createdDate.value = new Date(record.created + 'Z');
   modifiedDate.value = new Date(record.date_last_modified + 'Z');
-  status.value = record.status;
   if (record.permission_level !== null) {
     _permissionLevel = (record.permission_level as SubmissionEditorRole);
   }

--- a/web/src/views/SubmissionPortal/types.ts
+++ b/web/src/views/SubmissionPortal/types.ts
@@ -284,6 +284,7 @@ export interface MetadataSubmissionRecord extends MetadataSubmissionRecordSlim {
   source_client: 'submission_portal' | 'field_notes' | 'nmdc_edge' | null;
   primary_study_image_url: string | null;
   pi_image_url: string | null;
+  study_form: any;
 }
 
 export interface PaginatedResponse<T> {


### PR DESCRIPTION
Resolves https://github.com/microbiomedata/nmdc-server/issues/2159

This update removes all references to `template` and `status` in the submission home page table as well as references to these columns.

Changes also allow the `resume`/`view` buttons to work properly again, creating submissions will now work, and the text displayed for the `resume`/`view` button is correct most of the time.
The text for that button seems to be correct for existing submissions, but all new submissions always show `view`. I think this will be resolved with some of the other issues relating to `sample_set`.

