### PR TITLE
Implement study consortia redesign

### DIFF
--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -399,6 +399,19 @@ class BaseQuerySchema(BaseModel):
             "Table.pfam_function:id",
             "Table.go_function:id",
         ]
+        # When filtering on study_id, always automatically include its child studies in the search.
+        if condition.key in ["Table.study:id", "Table.study.study_id"] and condition.op in [Operation.equal, Operation.like]:
+            child_studies = db.query(models.Study.id).filter(models.Study.part_of.contains([condition.value]))
+            child_conditions =  [
+                SimpleConditionSchema(
+                    op="==",
+                    field=condition.field,
+                    value=study.id,
+                    table=condition.table,
+                )
+                for study in child_studies
+            ]
+            return [condition] + child_conditions
         if condition.key in gene_search_keys and type(condition.value) is str:
             if any([condition.value.startswith(val) for val in KeggTerms.PATHWAY[0]]):
                 prefix = [val for val in KeggTerms.PATHWAY[0] if condition.value.startswith(val)][0]

--- a/nmdc_server/query.py
+++ b/nmdc_server/query.py
@@ -197,6 +197,7 @@ ConditionValue = Union[schemas.AnnotationValue, RangeValue, List[GoldTreeValue]]
 
 
 class BaseConditionSchema(BaseModel):
+    op: Any
     field: str
     value: ConditionValue
     table: Table
@@ -400,9 +401,14 @@ class BaseQuerySchema(BaseModel):
             "Table.go_function:id",
         ]
         # When filtering on study_id, always automatically include its child studies in the search.
-        if condition.key in ["Table.study:id", "Table.study.study_id"] and condition.op in [Operation.equal, Operation.like]:
-            child_studies = db.query(models.Study.id).filter(models.Study.part_of.contains([condition.value]))
-            child_conditions =  [
+        if condition.key in ["Table.study:id", "Table.study.study_id"] and condition.op in [
+            Operation.equal,
+            Operation.like,
+        ]:
+            child_studies = db.query(models.Study.id).filter(
+                models.Study.part_of.contains([condition.value])
+            )
+            child_conditions = [
                 SimpleConditionSchema(
                     op="==",
                     field=condition.field,
@@ -411,7 +417,7 @@ class BaseQuerySchema(BaseModel):
                 )
                 for study in child_studies
             ]
-            return [condition] + child_conditions
+            return [condition, *child_conditions]
         if condition.key in gene_search_keys and type(condition.value) is str:
             if any([condition.value.startswith(val) for val in KeggTerms.PATHWAY[0]]):
                 prefix = [val for val in KeggTerms.PATHWAY[0] if condition.value.startswith(val)][0]

--- a/web/src/colors.js
+++ b/web/src/colors.js
@@ -5,6 +5,8 @@ const red2 = '#ff5252'
 const orange = '#E88320';
 const green = colors.lightGreen.darken2;
 const blue = '#00AAE7';
+const blueDark = '#0087B8';
+const blueDarker = '#004B66';
 const purple = '#4F3B80';
 
 export default {
@@ -12,11 +14,16 @@ export default {
   orange,
   green,
   blue,
+  blueDark,
+  blueDarker,
   purple,
   grey: colors.grey,
   primary: purple,
   secondary: red,
+  info: blue,
   accent: orange,
+  link: blueDark,
+  visited: blueDarker,
   aquatic: blue,
   terrestrial: green,
   hostAssociated: red,

--- a/web/src/colors.js
+++ b/web/src/colors.js
@@ -8,6 +8,7 @@ const blue = '#00AAE7';
 const blueDark = '#0087B8';
 const blueDarker = '#004B66';
 const purple = '#4F3B80';
+const purpleLight = '#7D6FA1';
 
 export default {
   red,
@@ -22,8 +23,8 @@ export default {
   secondary: red,
   info: blue,
   accent: orange,
-  link: blueDark,
-  visited: blueDarker,
+  link: purple,
+  visited: purpleLight,
   aquatic: blue,
   terrestrial: green,
   hostAssociated: red,

--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -48,6 +48,7 @@ declare module 'vue' {
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     SampleListExpansion: typeof import('./components/SampleListExpansion.vue')['default']
+    SearchResultItem: typeof import('./components/Presentation/SearchResultItem.vue')['default']
     SearchResults: typeof import('./components/Presentation/SearchResults.vue')['default']
     TeamInfo: typeof import('./components/TeamInfo.vue')['default']
     TimeHistogram: typeof import('./components/Presentation/TimeHistogram.vue')['default']

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -49,11 +49,11 @@ Icon.Default.mergeOptions({
 const props = withDefaults(defineProps<{
   conditions?: Condition[];
   height?: number;
-  vistab?: number | null;
+  visTab?: number | null;
 }>(), {
   conditions: () => [],
   height: 360,
-  vistab: null,
+  visTab: null,
 });
 
 const emit = defineEmits<{
@@ -83,7 +83,7 @@ const mapCenter = computed(() => {
 });
 
 async function getMapData() {
-  if (props.vistab === 1) {
+  if (props.visTab === 1) {
     return;
   }
   const data = await request(() => api.getEnvironmentGeospatialAggregation(props.conditions));

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -46,7 +46,6 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
     :items-per-page="biosampleSearch.data.limit"
     :results="biosampleSearch.data.results.results"
     :page="biosampleSearch.data.pageSync"
-    :subtitle-key="'study_id'"
     :loading="biosampleSearch.loading.value"
     @set-page="biosampleSearch.setPage($event)"
     @set-items-per-page="biosampleSearch.setItemsPerPage($event)"

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -59,32 +59,58 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
         </span>
       </router-link>
     </template>
-    <template #item-subtitle="props">
-      <span class="pr-2">Study ID:</span>
-      <router-link
-        :to="{name: 'Study', params: { id: (props.result as BiosampleSearchResult).study_id }}"
-        class="pr-2 text-grey-darken-2"
-        v-text="props.result.study_id"
-      />
-      <template
-        v-if="props.result.alternate_identifiers.length || (props.result as BiosampleSearchResult).emsl_biosample_identifiers.length"
-      >
-        <span class="pr-2">Sample Identifiers:</span>
-        <a
-          v-for="id in props.result.alternate_identifiers"
-          :key="id"
-          :href="`https://identifiers.org/${id}`"
-          class="pr-2 text-grey-darken-2"
-          target="_blank"
-          rel="noopener noreferrer"
-        >{{ id }}</a>
-        <span
-          v-for="id in props.result.emsl_biosample_identifiers"
-          :key="id"
-        >
-          {{ id }}
+    <template #item-subtitle="{ result }">
+      <div class="d-flex ga-1">
+        <span class="flex-shrink-0 text-no-wrap">
+          <strong class="mr-1">ID:</strong>
+          <ClickToCopyText>
+            {{ result.id }}
+          </ClickToCopyText>
         </span>
-      </template>
+        <v-icon>mdi-circle-small</v-icon>
+        <span class="flex-shrink-0 text-no-wrap">
+          <strong class="mr-2">Study ID:</strong>
+          <ClickToCopyText>
+            {{ (result as BiosampleSearchResult).study_id }}
+          </ClickToCopyText>
+        </span>
+        <template
+          v-if="result.alternate_identifiers.length || (result as BiosampleSearchResult).emsl_biosample_identifiers.length"
+        >
+          <v-icon>mdi-circle-small</v-icon>
+          <strong class="mr-2">External:</strong>
+          <span class="identifiers-slide-group">
+            <v-slide-group
+              show-arrows
+              next-icon="mdi-chevron-double-right"
+              prev-icon="mdi-chevron-double-left"
+              class="align-center"
+            >
+              <v-slide-group-item
+                v-for="id in result.alternate_identifiers"
+                :key="id"
+              >
+                <a
+                  :href="`https://identifiers.org/${id}`"
+                  class="pr-2 text-grey-darken-2 text-decoration-underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ id }}
+                </a>
+              </v-slide-group-item>
+              <v-slide-group-item
+                v-for="id in result.emsl_biosample_identifiers"
+                :key="id"
+              >
+                <span>
+                  {{ id }}
+                </span>
+              </v-slide-group-item>
+            </v-slide-group>
+          </span>
+        </template>
+      </div>
     </template>
     <template #item-content="props">
       <SampleListExpansion
@@ -113,3 +139,10 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
     </template>
   </SearchResults>
 </template>
+
+<style lang="scss" scoped>
+.identifiers-slide-group {
+  max-width: 500px;
+  overflow: hidden;
+}
+</style>

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -54,12 +54,12 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
     <template #subtitle="props">
       <span class="pr-2">Study ID:</span>
       <router-link
-        :to="{name: 'Study', params: { id: props.result.study_id }}"
+        :to="{name: 'Study', params: { id: (props.result as BiosampleSearchResult).study_id }}"
         class="pr-2 text-grey-darken-2"
         v-text="props.result.study_id"
       />
       <template
-        v-if="props.result.alternate_identifiers.length || props.result.emsl_biosample_identifiers.length"
+        v-if="props.result.alternate_identifiers.length || (props.result as BiosampleSearchResult).emsl_biosample_identifiers.length"
       >
         <span class="pr-2">Sample Identifiers:</span>
         <a
@@ -81,7 +81,7 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
     <template #item-content="props">
       <SampleListExpansion
         v-bind="{
-          result: props.result,
+          result: props.result as BiosampleSearchResult,
           expanded: expandedOmicsDetails,
           loggedInUser,
           showBulk: dataObjectFilter.length > 0,

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -1,8 +1,6 @@
-<script lang="ts">
+<script setup lang="ts">
 import {
   computed,
-  defineComponent,
-  PropType,
   reactive,
 } from 'vue';
 import SearchResults from '@/components/Presentation/SearchResults.vue';
@@ -12,49 +10,33 @@ import { PaginatedResult } from '@/use/usePaginatedResults';
 import { BiosampleSearchResult, DataObjectFilter } from '@/data/api';
 import { stateRefs } from '@/store';
 
-export default defineComponent({
-  components: { SampleListExpansion, SearchResults },
-  props: {
-    biosampleSearch: {
-      type: Object as PropType<PaginatedResult<BiosampleSearchResult>>,
-      required: true,
-    },
-    dataObjectFilter: {
-      type: Array as PropType<DataObjectFilter[]>,
-      required: true,
-    },
-  },
-  setup() {
-    const biosampleType = types.biosample;
+defineProps<{
+  biosampleSearch: PaginatedResult<BiosampleSearchResult>;
+  dataObjectFilter: DataObjectFilter[];
+}>();
 
-    const loggedInUser = computed(() => stateRefs.user.value !== null);
+const biosampleType = types.biosample;
 
-    /**
-     * Expanded Omics details
-     */
-    const expandedOmicsDetails = reactive({
-      resultId: '',
-      omicsProcessingId: '',
-    });
-    function setExpanded(resultId: string, omicsProcessingId: string) {
-      if (expandedOmicsDetails.resultId !== resultId
-        || expandedOmicsDetails.omicsProcessingId !== omicsProcessingId) {
-        expandedOmicsDetails.resultId = resultId;
-        expandedOmicsDetails.omicsProcessingId = omicsProcessingId;
-      } else {
-        expandedOmicsDetails.resultId = '';
-        expandedOmicsDetails.omicsProcessingId = '';
-      }
-    }
+const loggedInUser = computed(() => stateRefs.user.value !== null);
 
-    return {
-      biosampleType,
-      expandedOmicsDetails,
-      setExpanded,
-      loggedInUser,
-    };
-  },
+/**
+ * Expanded Omics details
+ */
+const expandedOmicsDetails = reactive({
+  resultId: '',
+  omicsProcessingId: '',
 });
+
+function setExpanded(resultId: string, omicsProcessingId: string) {
+  if (expandedOmicsDetails.resultId !== resultId
+    || expandedOmicsDetails.omicsProcessingId !== omicsProcessingId) {
+    expandedOmicsDetails.resultId = resultId;
+    expandedOmicsDetails.omicsProcessingId = omicsProcessingId;
+  } else {
+    expandedOmicsDetails.resultId = '';
+    expandedOmicsDetails.omicsProcessingId = '';
+  }
+}
 </script>
 
 <template>

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -103,9 +103,9 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
                 v-for="id in result.emsl_biosample_identifiers"
                 :key="id"
               >
-                <span>
+                <ClickToCopyText icon-overlay>
                   {{ id }}
-                </span>
+                </ClickToCopyText>
               </v-slide-group-item>
             </v-slide-group>
           </span>

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -51,7 +51,17 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
     @set-page="biosampleSearch.setPage($event)"
     @set-items-per-page="biosampleSearch.setItemsPerPage($event)"
   >
-    <template #subtitle="props">
+    <template #item-title="{ result }">
+      <router-link
+        class="text-decoration-none"
+        :to="{ name: 'Sample', params: { id: result.id }}"
+      >
+        <span class="text-subtitle-2">
+          {{ result.name }}
+        </span>
+      </router-link>
+    </template>
+    <template #item-subtitle="props">
       <span class="pr-2">Study ID:</span>
       <router-link
         :to="{name: 'Study', params: { id: (props.result as BiosampleSearchResult).study_id }}"

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -52,7 +52,6 @@ function setExpanded(resultId: string, omicsProcessingId: string) {
   >
     <template #item-title="{ result }">
       <router-link
-        class="text-decoration-none"
         :to="{ name: 'Sample', params: { id: result.id }}"
       >
         <span class="text-subtitle-2">

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -59,7 +59,6 @@ export default defineComponent({
 
 <template>
   <SearchResults
-    disable-navigate-on-click
     :count="biosampleSearch.data.results.count"
     :icon="biosampleType.icon"
     :items-per-page="biosampleSearch.data.limit"

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -67,7 +67,6 @@ export default defineComponent({
     :subtitle-key="'study_id'"
     :loading="biosampleSearch.loading.value"
     @set-page="biosampleSearch.setPage($event)"
-    @selected="$router.push({ name: 'Sample', params: { id: $event }})"
     @set-items-per-page="biosampleSearch.setItemsPerPage($event)"
   >
     <template #subtitle="props">

--- a/web/src/components/Presentation/BiosampleSearchResults.vue
+++ b/web/src/components/Presentation/BiosampleSearchResults.vue
@@ -10,7 +10,7 @@ import { PaginatedResult } from '@/use/usePaginatedResults';
 import { BiosampleSearchResult, DataObjectFilter } from '@/data/api';
 import { stateRefs } from '@/store';
 
-defineProps<{
+const { biosampleSearch, dataObjectFilter } = defineProps<{
   biosampleSearch: PaginatedResult<BiosampleSearchResult>;
   dataObjectFilter: DataObjectFilter[];
 }>();

--- a/web/src/components/Presentation/ClickToCopyText.vue
+++ b/web/src/components/Presentation/ClickToCopyText.vue
@@ -1,30 +1,24 @@
-<script lang="ts">
-import { defineComponent, ref } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 
 /**
  * ClickToCopyText provides a container that copies its text content to the clipboard when clicked.
  */
-export default defineComponent({
-  setup() {
-    const isTooltipVisible = ref(false);
-    const containerRef = ref<HTMLElement | null>(null);
+const { iconOverlay } = defineProps<{
+  /** If true, the copy icon will be overlaid on the right edge of the text instead of appearing to the right of it. */
+  iconOverlay?: boolean;
+}>();
+const isTooltipVisible = ref(false);
+const containerRef = ref<HTMLElement | null>(null);
 
-    const handleClick = () => {
-      const text = containerRef.value?.innerText || '';
-      navigator.clipboard.writeText(text.trim());
-      isTooltipVisible.value = true;
-      setTimeout(() => {
-        isTooltipVisible.value = false;
-      }, 2000);
-    };
-
-    return {
-      containerRef,
-      handleClick,
-      isTooltipVisible,
-    };
-  },
-});
+const handleClick = () => {
+  const text = containerRef.value?.innerText || '';
+  navigator.clipboard.writeText(text.trim());
+  isTooltipVisible.value = true;
+  setTimeout(() => {
+    isTooltipVisible.value = false;
+  }, 2000);
+};
 </script>
 
 <template>
@@ -42,13 +36,20 @@ export default defineComponent({
             <button
               v-bind="hoverProps"
               ref="containerRef"
-              class="slot-container"
+              class="slot-container position-relative"
               @click="handleClick"
             >
               <slot />
               <v-icon
                 v-if="isHovering"
-                class="ml-1"
+                class="ml-1 position-absolute"
+                :style="{
+                  backgroundColor: '#ffffff',
+                  top: '50%',
+                  right: iconOverlay ? 0 : '-20px',
+                  transform: 'translateY(-50%)',
+                  zIndex: 100
+                }"
                 size="inherit"
               >
                 mdi-content-copy

--- a/web/src/components/Presentation/SearchResultItem.vue
+++ b/web/src/components/Presentation/SearchResultItem.vue
@@ -11,7 +11,7 @@ interface Props {
 withDefaults(defineProps<Props>(), {
   titleKey: 'name',
   subtitleKey: 'description',
-  icon: 'mdi-book',
+  icon: 'mdi-book-outline',
 });
 </script>
 
@@ -23,7 +23,7 @@ withDefaults(defineProps<Props>(), {
   >
     <template #prepend>
       <slot
-        name="prepend-action"
+        name="action-left"
         v-bind="{ result }"
       />
       <v-icon>
@@ -40,6 +40,10 @@ withDefaults(defineProps<Props>(), {
         <div class="text-subtitle-2">
           {{ result[titleKey] }}
         </div>
+        <slot
+          name="action-title-right"
+          v-bind="{ result }"
+        />
       </div>
     </v-list-item-title>
     <v-list-item-subtitle>

--- a/web/src/components/Presentation/SearchResultItem.vue
+++ b/web/src/components/Presentation/SearchResultItem.vue
@@ -2,13 +2,11 @@
 import { BiosampleSearchResult, StudySearchResult } from '@/data/api';
 
 interface Props {
-  titleKey?: string;
   result: BiosampleSearchResult | StudySearchResult;
   icon?: string;
 }
 
 withDefaults(defineProps<Props>(), {
-  titleKey: 'name',
   icon: 'mdi-book-outline',
 });
 </script>

--- a/web/src/components/Presentation/SearchResultItem.vue
+++ b/web/src/components/Presentation/SearchResultItem.vue
@@ -6,24 +6,13 @@ interface Props {
   subtitleKey?: string;
   result: BaseSearchResult;
   icon?: string;
-  showCheckbox?: boolean;
-  checkboxValues?: string[];
-  checkboxDisabled?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
   titleKey: 'name',
   subtitleKey: 'description',
   icon: 'mdi-book',
-  showCheckbox: false,
-  checkboxValues: () => [] as string[],
-  checkboxDisabled: false,
 });
-
-const emit = defineEmits<{
-  'checkbox-change': [payload: { checked: boolean; id: string; children: BaseSearchResult[] }];
-  'selected': [id: string];
-}>();
 </script>
 
 <template>
@@ -33,15 +22,10 @@ const emit = defineEmits<{
     :link="false"
   >
     <template #prepend>
-      <v-list-item-action v-if="showCheckbox">
-        <v-checkbox-btn
-          :model-value="checkboxValues"
-          :value="result.id"
-          :disabled="checkboxDisabled"
-          @click.stop
-          @change="emit('checkbox-change', { checked: $event.target.checked, id: result.id, children: result.children ?? [] })"
-        />
-      </v-list-item-action>
+      <slot
+        name="prepend-action"
+        v-bind="{ result }"
+      />
       <v-icon>
         {{
           result.children && Array.isArray(result.children) && result.children.length > 0 && result.study_category === 'research_study'

--- a/web/src/components/Presentation/SearchResultItem.vue
+++ b/web/src/components/Presentation/SearchResultItem.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { BaseSearchResult } from '@/data/api';
+
+interface Props {
+  titleKey?: string;
+  subtitleKey?: string;
+  result: BaseSearchResult;
+  icon?: string;
+  showCheckbox?: boolean;
+  checkboxValues?: string[];
+  checkboxDisabled?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  titleKey: 'name',
+  subtitleKey: 'description',
+  icon: 'mdi-book',
+  showCheckbox: false,
+  checkboxValues: () => [] as string[],
+  checkboxDisabled: false,
+});
+
+const emit = defineEmits<{
+  'checkbox-change': [payload: { checked: boolean; id: string; children: BaseSearchResult[] }];
+  'selected': [id: string];
+}>();
+</script>
+
+<template>
+  <v-list-item
+    :ripple="false"
+    :active="false"
+    :link="false"
+  >
+    <template #prepend>
+      <v-list-item-action v-if="showCheckbox">
+        <v-checkbox-btn
+          :model-value="checkboxValues"
+          :value="result.id"
+          :disabled="checkboxDisabled"
+          @click.stop
+          @change="emit('checkbox-change', { checked: $event.target.checked, id: result.id, children: result.children ?? [] })"
+        />
+      </v-list-item-action>
+      <v-icon>
+        {{
+          result.children && Array.isArray(result.children) && result.children.length > 0 && result.study_category === 'research_study'
+            ? 'mdi-book-multiple-outline'
+            : icon
+        }}
+      </v-icon>
+    </template>
+
+    <v-list-item-title>
+      <div class="d-flex align-center">
+        <div class="text-subtitle-2">
+          {{ result[titleKey] }}
+        </div>
+      </div>
+    </v-list-item-title>
+    <v-list-item-subtitle>
+      <slot
+        name="subtitle"
+        v-bind="{ result }"
+      >
+        {{ result[subtitleKey] || 'No description' }}
+      </slot>
+    </v-list-item-subtitle>
+    <slot
+      name="item-content"
+      v-bind="{ result }"
+    />
+
+    <template #append>
+      <slot
+        name="action-right"
+        v-bind="{ result }"
+      />
+    </template>
+  </v-list-item>
+</template>

--- a/web/src/components/Presentation/SearchResultItem.vue
+++ b/web/src/components/Presentation/SearchResultItem.vue
@@ -3,20 +3,19 @@ import { BiosampleSearchResult, StudySearchResult } from '@/data/api';
 
 interface Props {
   titleKey?: string;
-  subtitleKey?: string;
   result: BiosampleSearchResult | StudySearchResult;
   icon?: string;
 }
 
 withDefaults(defineProps<Props>(), {
   titleKey: 'name',
-  subtitleKey: 'description',
   icon: 'mdi-book-outline',
 });
 </script>
 
 <template>
   <v-list-item
+    class="py-2"
     :ripple="false"
     :active="false"
     :link="false"
@@ -34,31 +33,24 @@ withDefaults(defineProps<Props>(), {
         }}
       </v-icon>
     </template>
-
-    <v-list-item-title>
-      <div class="d-flex align-center">
-        <div class="text-subtitle-2">
-          {{ result[titleKey] }}
-        </div>
+    <div class="d-flex flex-column ga-1">
+      <v-list-item-title>
         <slot
-          name="action-title-right"
+          name="item-title"
           v-bind="{ result }"
         />
-      </div>
-    </v-list-item-title>
-    <v-list-item-subtitle>
+      </v-list-item-title>
+      <v-list-item-subtitle>
+        <slot
+          name="item-subtitle"
+          v-bind="{ result }"
+        />
+      </v-list-item-subtitle>
       <slot
-        name="subtitle"
+        name="item-content"
         v-bind="{ result }"
-      >
-        {{ result[subtitleKey] || 'No description' }}
-      </slot>
-    </v-list-item-subtitle>
-    <slot
-      name="item-content"
-      v-bind="{ result }"
-    />
-
+      />
+    </div>
     <template #append>
       <slot
         name="action-right"

--- a/web/src/components/Presentation/SearchResultItem.vue
+++ b/web/src/components/Presentation/SearchResultItem.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { BaseSearchResult } from '@/data/api';
+import { BiosampleSearchResult, StudySearchResult } from '@/data/api';
 
 interface Props {
   titleKey?: string;
   subtitleKey?: string;
-  result: BaseSearchResult;
+  result: BiosampleSearchResult | StudySearchResult;
   icon?: string;
 }
 

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -11,7 +11,9 @@ interface Props {
   subtitleKey?: string;
   results?: BaseSearchResult[];
   icon?: string;
-  disableNavigateOnClick?: boolean;
+  showCheckbox?: boolean;
+  checkboxValues?: string[];
+  checkboxDisabled?: boolean;
   disablePagination?: boolean;
 }
 
@@ -20,7 +22,9 @@ const props = withDefaults(defineProps<Props>(), {
   subtitleKey: 'description',
   results: () => [] as BaseSearchResult[],
   icon: 'mdi-book',
-  disableNavigateOnClick: false,
+  showCheckbox: false,
+  checkboxValues: () => [] as string[],
+  checkboxDisabled: false,
   disablePagination: false,
 });
 
@@ -28,6 +32,7 @@ const emit = defineEmits<{
   'set-page': [page: number];
   'set-items-per-page': [itemsPerPage: number];
   'selected': [id: string];
+  'checkbox-change': [payload: { checked: boolean; id: string; children: BaseSearchResult[] }];
 }>();
 
 const rows = ref(props.itemsPerPage);
@@ -46,62 +51,51 @@ const rows = ref(props.itemsPerPage);
         <v-divider
           v-if="resultIndex > 0"
         />
-
-        <v-list-item
-          :ripple="!disableNavigateOnClick"
-          :active="false"
-          :link="!disableNavigateOnClick"
-          v-on="{
-            click: disableNavigateOnClick
-              ? () => {}
-              : () => emit('selected', result.id),
+        <SearchResultItem
+          v-bind="{
+            result,
+            titleKey,
+            subtitleKey,
+            icon,
+            showCheckbox,
+            checkboxValues,
+            checkboxDisabled,
           }"
+          @selected="emit('selected', $event)"
+          @checkbox-change="emit('checkbox-change', $event)"
         >
-          <template #prepend>
-            <slot
-              name="action"
-              v-bind="{ result }"
-            />
-            <v-icon>
-              {{
-                result.children && Array.isArray(result.children) && result.children.length > 0 && result.study_category === 'research_study'
-                  ? 'mdi-book-multiple-outline'
-                  : icon
-              }}
-            </v-icon>
-          </template>
-
-          <v-list-item-title>
-            <div class="d-flex align-center">
-              <div class="text-subtitle-2">
-                {{ result[titleKey] }}
-              </div>
-              <slot
-                name="child-list"
-                v-bind="{ result}"
-              />
-            </div>
-          </v-list-item-title>
-          <v-list-item-subtitle>
+          <template
+            v-if="$slots.subtitle"
+            #subtitle="slotProps"
+          >
             <slot
               name="subtitle"
-              v-bind="{ result }"
-            >
-              {{ result[subtitleKey] || 'No description' }}
-            </slot>
-          </v-list-item-subtitle>
-          <slot
-            name="item-content"
-            v-bind="{ result }"
-          />
-
-          <template #append>
-            <slot
-              name="action-right"
-              v-bind="{ result }"
+              v-bind="slotProps"
             />
           </template>
-        </v-list-item>
+          <template
+            v-if="$slots['item-content']"
+            #item-content="slotProps"
+          >
+            <slot
+              name="item-content"
+              v-bind="slotProps"
+            />
+          </template>
+          <template
+            v-if="$slots['action-right']"
+            #action-right="slotProps"
+          >
+            <slot
+              name="action-right"
+              v-bind="slotProps"
+            />
+          </template>
+        </SearchResultItem>
+        <slot
+          name="item-children"
+          v-bind="{ result }"
+        />
       </template>
     </v-list>
     <div

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -7,14 +7,12 @@ interface Props {
   page: number;
   itemsPerPage: number;
   count: number;
-  titleKey?: string;
   results?: StudySearchResult[] | BiosampleSearchResult[];
   icon?: string;
   disablePagination?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  titleKey: 'name',
   results: () => [] as StudySearchResult[] | BiosampleSearchResult[],
   icon: 'mdi-book-outline',
   disablePagination: false,
@@ -41,7 +39,6 @@ const rows = ref(props.itemsPerPage);
         <SearchResultItem
           v-bind="{
             result,
-            titleKey,
             icon,
           }"
         >

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -18,7 +18,7 @@ const props = withDefaults(defineProps<Props>(), {
   titleKey: 'name',
   subtitleKey: 'description',
   results: () => [] as StudySearchResult[] | BiosampleSearchResult[],
-  icon: 'mdi-book',
+  icon: 'mdi-book-outline',
   disablePagination: false,
 });
 
@@ -52,11 +52,20 @@ const rows = ref(props.itemsPerPage);
           }"
         >
           <template
-            v-if="$slots['prepend-action']"
-            #prepend-action="slotProps"
+            v-if="$slots['action-left']"
+            #action-left="slotProps"
           >
             <slot
-              name="prepend-action"
+              name="action-left"
+              v-bind="slotProps"
+            />
+          </template>
+          <template
+            v-if="$slots['action-title-right']"
+            #action-title-right="slotProps"
+          >
+            <slot
+              name="action-title-right"
               v-bind="slotProps"
             />
           </template>

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 
-import { BaseSearchResult } from '@/data/api';
+import { BiosampleSearchResult, StudySearchResult } from '@/data/api';
 
 interface Props {
   page: number;
@@ -9,7 +9,7 @@ interface Props {
   count: number;
   titleKey?: string;
   subtitleKey?: string;
-  results?: BaseSearchResult[];
+  results?: StudySearchResult[] | BiosampleSearchResult[];
   icon?: string;
   disablePagination?: boolean;
 }
@@ -17,7 +17,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   titleKey: 'name',
   subtitleKey: 'description',
-  results: () => [] as BaseSearchResult[],
+  results: () => [] as StudySearchResult[] | BiosampleSearchResult[],
   icon: 'mdi-book',
   disablePagination: false,
 });

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -56,30 +56,6 @@ export default defineComponent({
 
 <template>
   <div>
-    <div
-      v-if="!disablePagination && count > 0"
-      class="d-flex pt-2 pb-0 align-end justify-center"
-    >
-      <v-pagination
-        :model-value="page"
-        :length="Math.ceil(count / rows)"
-        :total-visible="7"
-        active-color="primary"
-        @update:model-value="$emit('set-page', $event)"
-      />
-      <!-- flex-basis is based on the "Items per page" label. Since it is absolutely
-           positioned it doesn't count towards the `auto` width -->
-      <v-select
-        v-model="rows"
-        :items="[5, 10, 15, 20]"
-        label="Items per page"
-        class="ml-4 mb-1 flex-grow-0"
-        :style="{ 'flex-basis': '6rem' }"
-        hide-details
-        variant="plain"
-        @update:model-value="$emit('set-items-per-page', $event)"
-      />
-    </div>
     <v-list
       density="compact"
       class="rounded-b"
@@ -149,5 +125,29 @@ export default defineComponent({
         </v-list-item>
       </template>
     </v-list>
+    <div
+      v-if="!disablePagination && count > 0"
+      class="d-flex pt-2 pb-0 align-end justify-center"
+    >
+      <v-pagination
+        :model-value="page"
+        :length="Math.ceil(count / rows)"
+        :total-visible="7"
+        active-color="primary"
+        @update:model-value="$emit('set-page', $event)"
+      />
+      <!-- flex-basis is based on the "Items per page" label. Since it is absolutely
+           positioned it doesn't count towards the `auto` width -->
+      <v-select
+        v-model="rows"
+        :items="[5, 10, 15, 20]"
+        label="Items per page"
+        class="ml-4 mb-1 flex-grow-0"
+        :style="{ 'flex-basis': '6rem' }"
+        hide-details
+        variant="plain"
+        @update:model-value="$emit('set-items-per-page', $event)"
+      />
+    </div>
   </div>
 </template>

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -11,9 +11,6 @@ interface Props {
   subtitleKey?: string;
   results?: BaseSearchResult[];
   icon?: string;
-  showCheckbox?: boolean;
-  checkboxValues?: string[];
-  checkboxDisabled?: boolean;
   disablePagination?: boolean;
 }
 
@@ -22,17 +19,12 @@ const props = withDefaults(defineProps<Props>(), {
   subtitleKey: 'description',
   results: () => [] as BaseSearchResult[],
   icon: 'mdi-book',
-  showCheckbox: false,
-  checkboxValues: () => [] as string[],
-  checkboxDisabled: false,
   disablePagination: false,
 });
 
 const emit = defineEmits<{
   'set-page': [page: number];
   'set-items-per-page': [itemsPerPage: number];
-  'selected': [id: string];
-  'checkbox-change': [payload: { checked: boolean; id: string; children: BaseSearchResult[] }];
 }>();
 
 const rows = ref(props.itemsPerPage);
@@ -57,13 +49,17 @@ const rows = ref(props.itemsPerPage);
             titleKey,
             subtitleKey,
             icon,
-            showCheckbox,
-            checkboxValues,
-            checkboxDisabled,
           }"
-          @selected="emit('selected', $event)"
-          @checkbox-change="emit('checkbox-change', $event)"
         >
+          <template
+            v-if="$slots['prepend-action']"
+            #prepend-action="slotProps"
+          >
+            <slot
+              name="prepend-action"
+              v-bind="slotProps"
+            />
+          </template>
           <template
             v-if="$slots.subtitle"
             #subtitle="slotProps"

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -1,57 +1,36 @@
-<script lang="ts">
-import { defineComponent, PropType, ref } from 'vue';
+<script setup lang="ts">
+import { ref } from 'vue';
 
 import { BaseSearchResult } from '@/data/api';
 
-export default defineComponent({
-  props: {
-    page: {
-      type: Number,
-      required: true,
-    },
-    itemsPerPage: {
-      type: Number,
-      required: true,
-    },
-    count: {
-      type: Number,
-      required: true,
-    },
-    titleKey: {
-      type: String,
-      default: 'name',
-    },
-    subtitleKey: {
-      type: String,
-      default: 'description',
-    },
-    results: {
-      type: Array as PropType<BaseSearchResult[]>,
-      default: () => [],
-    },
-    icon: {
-      type: String,
-      default: 'mdi-book',
-    },
-    disableNavigateOnClick: {
-      type: Boolean,
-      default: false,
-    },
-    disablePagination: {
-      type: Boolean,
-      default: false,
-    },
-  },
-  emits: ['set-page', 'set-items-per-page', 'selected'],
-  setup(props) {
-    const rows = ref(props.itemsPerPage);
-    return {
-      rows,
-    };
-  },
+interface Props {
+  page: number;
+  itemsPerPage: number;
+  count: number;
+  titleKey?: string;
+  subtitleKey?: string;
+  results?: BaseSearchResult[];
+  icon?: string;
+  disableNavigateOnClick?: boolean;
+  disablePagination?: boolean;
+}
 
+const props = withDefaults(defineProps<Props>(), {
+  titleKey: 'name',
+  subtitleKey: 'description',
+  results: () => [] as BaseSearchResult[],
+  icon: 'mdi-book',
+  disableNavigateOnClick: false,
+  disablePagination: false,
 });
 
+const emit = defineEmits<{
+  'set-page': [page: number];
+  'set-items-per-page': [itemsPerPage: number];
+  'selected': [id: string];
+}>();
+
+const rows = ref(props.itemsPerPage);
 </script>
 
 <template>
@@ -75,7 +54,7 @@ export default defineComponent({
           v-on="{
             click: disableNavigateOnClick
               ? () => {}
-              : () => $emit('selected', result.id),
+              : () => emit('selected', result.id),
           }"
         >
           <template #prepend>
@@ -134,7 +113,7 @@ export default defineComponent({
         :length="Math.ceil(count / rows)"
         :total-visible="7"
         active-color="primary"
-        @update:model-value="$emit('set-page', $event)"
+        @update:model-value="emit('set-page', $event)"
       />
       <!-- flex-basis is based on the "Items per page" label. Since it is absolutely
            positioned it doesn't count towards the `auto` width -->
@@ -146,7 +125,7 @@ export default defineComponent({
         :style="{ 'flex-basis': '6rem' }"
         hide-details
         variant="plain"
-        @update:model-value="$emit('set-items-per-page', $event)"
+        @update:model-value="emit('set-items-per-page', $event)"
       />
     </div>
   </div>

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -8,7 +8,6 @@ interface Props {
   itemsPerPage: number;
   count: number;
   titleKey?: string;
-  subtitleKey?: string;
   results?: StudySearchResult[] | BiosampleSearchResult[];
   icon?: string;
   disablePagination?: boolean;
@@ -16,7 +15,6 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   titleKey: 'name',
-  subtitleKey: 'description',
   results: () => [] as StudySearchResult[] | BiosampleSearchResult[],
   icon: 'mdi-book-outline',
   disablePagination: false,
@@ -32,10 +30,7 @@ const rows = ref(props.itemsPerPage);
 
 <template>
   <div>
-    <v-list
-      density="compact"
-      class="rounded-b"
-    >
+    <v-list>
       <template
         v-for="(result, resultIndex) in results"
         :key="result.id"
@@ -47,7 +42,6 @@ const rows = ref(props.itemsPerPage);
           v-bind="{
             result,
             titleKey,
-            subtitleKey,
             icon,
           }"
         >
@@ -61,20 +55,20 @@ const rows = ref(props.itemsPerPage);
             />
           </template>
           <template
-            v-if="$slots['action-title-right']"
-            #action-title-right="slotProps"
+            v-if="$slots['item-title']"
+            #item-title="slotProps"
           >
             <slot
-              name="action-title-right"
+              name="item-title"
               v-bind="slotProps"
             />
           </template>
           <template
-            v-if="$slots.subtitle"
-            #subtitle="slotProps"
+            v-if="$slots['item-subtitle']"
+            #item-subtitle="slotProps"
           >
             <slot
-              name="subtitle"
+              name="item-subtitle"
               v-bind="slotProps"
             />
           </template>

--- a/web/src/components/SampleListExpansion.vue
+++ b/web/src/components/SampleListExpansion.vue
@@ -69,7 +69,7 @@ export default defineComponent({
 <template>
   <div
     v-if="result.omics_processing.length"
-    class="d-flex flex-column mb-2"
+    class="d-flex flex-column"
   >
     <div class="d-flex flex-row flex-wrap">
       <v-tooltip
@@ -87,7 +87,7 @@ export default defineComponent({
               :variant="!isOpen(projects[0]?.id) ? 'outlined' : 'flat'"
               :color="isOpen(projects[0]?.id) ? 'primary' : 'default'"
               :disabled="isDisabled(omicsType, projects)"
-              class="mr-2 mt-2"
+              class="mr-2"
               @click="() => $emit('open-details', projects[0]?.id)"
             >
               {{ fieldDisplayName(omicsType) }}

--- a/web/src/components/TeamInfo.vue
+++ b/web/src/components/TeamInfo.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue';
-import { StudySearchResults } from '@/data/api';
+import { StudySearchResult } from '@/data/api';
 import OrcidId from '@/components/Presentation/OrcidId.vue';
 
 function getOrcid(person: any) {
@@ -55,7 +55,7 @@ export default defineComponent({
   components: { OrcidId },
   props: {
     item: {
-      type: Object as PropType<StudySearchResults>,
+      type: Object as PropType<StudySearchResult>,
       required: true,
     },
   },

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -63,6 +63,11 @@ export interface BaseSearchResult {
   description: string;
   alternate_identifiers: string[];
   annotations: Record<string, string | string[]>;
+  children?: BaseSearchResult[];
+  omics_processing_counts?: {
+    type: string;
+    count: number;
+  }[] | null;
   [key: string]: unknown; // possibly other things.
 }
 

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -63,7 +63,7 @@ export interface BaseSearchResult {
   description: string;
   alternate_identifiers: string[];
   annotations: Record<string, string | string[]>;
-  children?: BaseSearchResult[];
+  children?: StudySearchResult[]; // only used for StudySearchResult, but included here for convenience in rendering nested studies
   omics_processing_counts?: {
     type: string;
     count: number;
@@ -108,6 +108,7 @@ export interface OmicsProcessingResult extends OmicsProcessingBaseResult {
 }
 
 export interface BiosampleSearchResult extends BaseSearchResult {
+  study_id: string;
   omics_processing_id: string;
   depth: number;
   env_broad_scale_id: string;
@@ -208,7 +209,7 @@ export interface LabelLink {
   url: string,
 }
 
-export interface StudySearchResults extends BaseSearchResult {
+export interface StudySearchResult extends BaseSearchResult {
   principal_investigator_websites: string[];
   principal_investigator_name: string;
   principal_investigator_image_url: string;
@@ -244,7 +245,7 @@ export interface StudySearchResults extends BaseSearchResult {
   study_category: string;
   homepage_website: string[] | null;
   part_of: string[] | null;
-  children: StudySearchResults[];
+  children: StudySearchResult[];
   has_credit_associations: {
     applied_roles: string[];
     applies_to_person: {
@@ -491,7 +492,7 @@ async function searchBiosample(params: SearchParams) {
 }
 
 async function searchStudy(params: SearchParams) {
-  return _search<StudySearchResults>("study", params);
+  return _search<StudySearchResult>("study", params);
 }
 
 async function searchOmicsProcessing(params: SearchParams) {
@@ -521,7 +522,7 @@ async function searchDataObject(params: SearchParams) {
 export type ResultUnion =
   | SearchResponse<BiosampleSearchResult>
   | SearchResponse<OmicsProcessingResult>
-  | SearchResponse<StudySearchResults>
+  | SearchResponse<StudySearchResult>
   | SearchResponse<ReadsQCResult>
   | SearchResponse<MetagenomeAssembyResult>
   | SearchResponse<MetagenomeAnnotationResult>
@@ -570,8 +571,8 @@ async function getBiosample(id: string): Promise<BiosampleSearchResult> {
   return _getById<BiosampleSearchResult>("biosample", id);
 }
 
-async function getStudy(id: string): Promise<StudySearchResults> {
-  return _getById<StudySearchResults>("study", id);
+async function getStudy(id: string): Promise<StudySearchResult> {
+  return _getById<StudySearchResult>("study", id);
 }
 
 async function getBiosampleSource(id: string): Promise<BiosampleResultFromSource> {

--- a/web/src/encoding.ts
+++ b/web/src/encoding.ts
@@ -258,7 +258,7 @@ function makeSetsFromBitmask(mask_str: string) {
 
 const types = {
   study: {
-    icon: 'mdi-book',
+    icon: 'mdi-book-outline',
     heading: 'Studies',
     name: 'study',
     plural: 'studies',

--- a/web/src/plugins/vuetify.ts
+++ b/web/src/plugins/vuetify.ts
@@ -5,6 +5,7 @@
  */
 import { createVuetify } from 'vuetify';
 import '@mdi/font/css/materialdesignicons.css';
+// @ts-ignore
 import 'vuetify/styles';
 // @ts-ignore
 import colors from '@/colors';
@@ -22,6 +23,9 @@ export default createVuetify({
           accent: colors.accent,
           success: colors.success,
           error: colors.error,
+          info: colors.info,
+          link: colors.link,
+          visited: colors.visited,
         },
       },
     },

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -132,6 +132,9 @@ const router = createRouter({
   scrollBehavior: (to, from, savedPosition) => {
     if (savedPosition) {
       return savedPosition;
+    } else if (to.name === from.name) {
+      // If navigating to the same route (e.g. changing query params), don't scroll to top
+      return false;
     } else {
       return { top: 0, left: 0 };
     }

--- a/web/src/styles/settings.scss
+++ b/web/src/styles/settings.scss
@@ -31,7 +31,6 @@ a, .v-theme--light a {
 }
 
 a:hover, .v-theme--light a:hover {
-  color: rgb(var(--v-theme-info));
   text-decoration: underline;
   opacity: 0.85;
 }

--- a/web/src/styles/settings.scss
+++ b/web/src/styles/settings.scss
@@ -24,6 +24,22 @@
   color: inherit;
 }
 
+a, .v-theme--light a {
+  color: rgb(var(--v-theme-link));
+  text-decoration: none;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+a:hover, .v-theme--light a:hover {
+  color: rgb(var(--v-theme-info));
+  text-decoration: underline;
+  opacity: 0.85;
+}
+
+a:visited, .v-theme--light a:visited {
+  color: rgb(var(--v-theme-visited));
+}
+
 // Utilities
 .stack-sm {
   display: flex;

--- a/web/src/use/usePaginatedResults.ts
+++ b/web/src/use/usePaginatedResults.ts
@@ -76,13 +76,11 @@ export default function usePaginatedResult<T>(
 
   const debouncedFetchResults = debounce(fetchResults, 500);
 
+  // If conditions change, reset to page 1 and fetch results
   watch([conditions], (newValues, oldValues) => {
-    const conditionsChanged = !isEqual(newValues, oldValues);
-    const doFetch = data.offset === 0 && conditionsChanged;
+    if (isEqual(newValues, oldValues)) return;
     data.offset = 0;
-    if (doFetch) {
-      debouncedFetchResults();
-    }
+    debouncedFetchResults();
   });
 
   if (dataObjectFilter !== undefined) {

--- a/web/src/use/usePaginatedResults.ts
+++ b/web/src/use/usePaginatedResults.ts
@@ -1,7 +1,7 @@
 import {
   watch, Ref, computed, shallowReactive,
 } from 'vue';
-import { debounce } from 'lodash';
+import { debounce, isEqual } from 'lodash';
 import {
   SearchParams, Condition, DataObjectFilter, SearchResponse,
 } from '@/data/api';
@@ -76,8 +76,9 @@ export default function usePaginatedResult<T>(
 
   const debouncedFetchResults = debounce(fetchResults, 500);
 
-  watch([conditions], () => {
-    const doFetch = data.offset === 0;
+  watch([conditions], (newValues, oldValues) => {
+    const conditionsChanged = !isEqual(newValues, oldValues);
+    const doFetch = data.offset === 0 && conditionsChanged;
     data.offset = 0;
     if (doFetch) {
       debouncedFetchResults();

--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -9,7 +9,7 @@ import {
   Condition,
   DoiInfo,
   LabelLink,
-  StudySearchResults,
+  StudySearchResult,
 } from '@/data/api';
 import { setConditions, setUniqueCondition } from '@/store';
 import AppBanner from '@/components/AppBanner.vue';
@@ -52,14 +52,14 @@ export default defineComponent({
 
   setup(props) {
     const { smAndDown } = useDisplay();
-    const study = ref<StudySearchResults | null>(null);
+    const study = ref<StudySearchResult | null>(null);
     const studyDownloadDialog = ref(false);
     const studyDownloadLoading = ref(false);
     const errorDialog = ref(false);
     const sampleCount = ref(0);
     const omicsProcessingCounts = ref<Record<string, number> | null>(null);
 
-    const parentStudies = ref<StudySearchResults[]>([]);
+    const parentStudies = ref<StudySearchResult[]>([]);
     const conditions = ref<Condition[]>([]);
     const biosampleSearchEnabled = ref(false);
 
@@ -152,7 +152,7 @@ export default defineComponent({
         value: _study.id,
       }];
       if (_study.children.length > 0) {
-        _study.children.forEach((child: StudySearchResults) => {
+        _study.children.forEach((child: StudySearchResult) => {
           conditions.value.push({
             value: child.id,
             table: 'study',

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -44,9 +44,9 @@ const staticUpsetTooltips = {
 
 const props = withDefaults(defineProps<{
   conditions: Condition[];
-  vistab?: number | null;
+  visTab?: number | null;
 }>(), {
-  vistab: null,
+  visTab: null,
 });
 
 const sampleFacetSummary = ref<FacetSummaryResponse[] | null>(null);
@@ -146,7 +146,7 @@ function setBoundsFromMap(val: Condition[]) {
           <ClusterMap
             :conditions="conditions"
             :height="360"
-            :vistab="vistab"
+            :vis-tab="visTab"
             @selected="setBoundsFromMap($event)"
           />
         </TooltipCard>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  computed, ref,
+  computed, Ref, ref,
 
 } from 'vue';
 
@@ -126,10 +126,10 @@ const gatedEnvironmentVisConditions = useClockGate(
   computed(() => (visTab.value === 1)),
   stateRefs.conditions,
 );
-// const showChildren:Ref<any[]> = ref([]);
-// function toggleChildren(value:StudySearchResult) {
-//   showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
-// }
+const showChildren: Ref<any[]> = ref([]);
+function toggleChildren(value:StudySearchResult) {
+  showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
+}
 </script>
 
 <template>
@@ -219,7 +219,7 @@ const gatedEnvironmentVisConditions = useClockGate(
                   @set-page="study.setPage($event)"
                   @set-items-per-page="study.setItemsPerPage($event)"
                 >
-                  <template #prepend-action="{ result }">
+                  <template #action-left="{ result }">
                     <v-list-item-action>
                       <v-checkbox-btn
                         :model-value="studyCheckboxState"
@@ -227,6 +227,26 @@ const gatedEnvironmentVisConditions = useClockGate(
                         @click.stop
                         @change="setChecked($event.target.checked, result.id, result.children as StudySearchResult[])"
                       />
+                    </v-list-item-action>
+                  </template>
+                  <template #action-title-right="{ result }">
+                    <v-list-item-action
+                      v-if="result.children && result.children.length > 0"
+                      class="ml-2"
+                    >
+                      <v-btn
+                        variant="flat"
+                        color="grey"
+                        size="x-small"
+                        @click="toggleChildren(result as StudySearchResult)"
+                      >
+                        {{ result.children.length }} child {{ result.children.length > 1 ? 'studies' : 'study' }}
+                        <template #append>
+                          <v-icon>
+                            {{ showChildren.includes(result.id) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+                          </v-icon>
+                        </template>
+                      </v-btn>
                     </v-list-item-action>
                   </template>
                   <template #action-right="{ result }">
@@ -262,11 +282,10 @@ const gatedEnvironmentVisConditions = useClockGate(
                   </template>
                   <template #item-children="{ result }">
                     <v-card
-                      v-if="result.children?.length"
+                      v-if="showChildren.includes(result.id) && result.children?.length"
                       flat
-                      class="pa-4 mt-2"
+                      class="ml-6 mr-6"
                     >
-                      <v-divider />
                       <SearchResults
                         disable-pagination
                         :count="result.children.length"
@@ -275,8 +294,11 @@ const gatedEnvironmentVisConditions = useClockGate(
                         :results="result.children"
                         :page="1"
                       >
-                        <template #prepend-action="{ result: child }">
+                        <template #action-left="{ result: child }">
                           <v-list-item-action>
+                            <v-icon color="grey-darken-1">
+                              mdi-arrow-right-bottom
+                            </v-icon>
                             <v-checkbox-btn
                               :model-value="studyCheckboxState"
                               :value="child.id"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -1,6 +1,6 @@
-<script lang="ts">
+<script setup lang="ts">
 import {
-  defineComponent, reactive, computed, ref, Ref,
+  reactive, computed, ref, Ref,
 
 } from 'vue';
 
@@ -26,206 +26,159 @@ import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
 
-export default defineComponent({
-  name: 'SearchLayout',
+const showConsortia = ref(true);
+const showStudies = ref(true);
+/**
+ * Study checkbox state logic
+ */
+const studyCheckboxState = computed(() => (
+  stateRefs.conditions.value
+    .filter((c) => c.table === 'study' && c.field === 'study_id')
+    .map((c) => c.value)
+));
 
-  components: {
-    BiosampleSearchResults,
-    AppBanner,
-    BiosampleVisGroup,
-    BulkDownload,
-    EnvironmentVisGroup,
-    SearchResults,
-    SearchSidebar,
-    SearchHelpMenu,
-  },
-
-  setup() {
-    const showConsortia = ref(true);
-    const showStudies = ref(true);
-    /**
-     * Study checkbox state logic
-     */
-    const studyCheckboxState = computed(() => (
-      stateRefs.conditions.value
-        .filter((c) => c.table === 'study' && c.field === 'study_id')
-        .map((c) => c.value)
-    ));
-
-    /**
-     * Set a study (or consortium) as checked in the search results.
-     * @param checked - Whether the item is currently being checked (true) or unchecked (false)
-     * @param studyId - ID of the study to select
-     * @param children - Optional children studies to also select
-     */
-    function setChecked(checked: boolean, studyId: string, children: StudySearchResults[] = []) {
-      const conditions: Condition[] = [{
-        value: studyId,
+/**
+ * Set a study (or consortium) as checked in the search results.
+ * @param checked - Whether the item is currently being checked (true) or unchecked (false)
+ * @param studyId - ID of the study to select
+ * @param children - Optional children studies to also select
+ */
+function setChecked(checked: boolean, studyId: string, children: StudySearchResults[] = []) {
+  const conditions: Condition[] = [{
+    value: studyId,
+    table: 'study',
+    op: '==',
+    field: 'study_id',
+  }];
+  if (children.length > 0) {
+    children.forEach((child) => {
+      conditions.push({
+        value: child.id,
         table: 'study',
-        op: '==',
         field: 'study_id',
-      }];
-      if (children.length > 0) {
-        children.forEach((child) => {
-          conditions.push({
-            value: child.id,
-            table: 'study',
-            field: 'study_id',
-            op: '==',
-          });
-        });
-      }
-      if (checked) {
-        setConditions([...stateRefs.conditions.value, ...conditions]);
-      } else {
-        removeConditions(conditions);
-      }
-    }
-
-    /**
-     * Set study and omics type conditions.
-     * Used when clicking on omics processing count chips.
-     * @param studyId - ID of the study to select
-     * @param omicsType - Type of omics processing to select 
-     */
-    function selectStudyAndOmics(studyId: string, omicsType: string) {
-      const conditions: Condition[] = [{
-        value: studyId,
-        table: 'study',
         op: '==',
-        field: 'study_id',
-      },
-      {
-        value: omicsType,
-        table: 'omics_processing',
-        field: 'omics_type',
-        op: '==',
-      }];
-      setConditions([...stateRefs.conditions.value, ...conditions]);
-    }
-
-    const studyConditions: Ref<Record<string, Condition[]>> = ref<Record<string, Condition[]>>({
-      study: [{
-        field: 'study_category',
-        table: 'study',
-        op: '==',
-        value: 'research_study',
-      }],
-      consortia: [{
-        field: 'study_category',
-        table: 'study',
-        op: '==',
-        value: 'consortium',
-      }],
+      });
     });
+  }
+  if (checked) {
+    setConditions([...stateRefs.conditions.value, ...conditions]);
+  } else {
+    removeConditions(conditions);
+  }
+}
 
-    /**
-     * SearchLayout-level settings
-     */
-    const disableBulkDownload = ref(true);
-    api.getAppSettings().then((appSettings) => {
-      disableBulkDownload.value = appSettings.disable_bulk_download;
-    });
-
-    /**
-     * Expanded Omics details
-     */
-    const expandedOmicsDetails = reactive({
-      resultId: '',
-      omicsProcessingId: '',
-    });
-    function setExpanded(resultId: string, omicsProcessingId: string) {
-      if (expandedOmicsDetails.resultId !== resultId
-        || expandedOmicsDetails.omicsProcessingId !== omicsProcessingId) {
-        expandedOmicsDetails.resultId = resultId;
-        expandedOmicsDetails.omicsProcessingId = omicsProcessingId;
-      } else {
-        expandedOmicsDetails.resultId = '';
-        expandedOmicsDetails.omicsProcessingId = '';
-      }
-    }
-
-    const biosampleType = types.biosample;
-    const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter);
-
-    const studyType = types.study;
-    const studySummaryData = useFacetSummaryData({
-      field: ref('study_id'),
-      table: ref('study'),
-      conditions: stateRefs.conditions,
-    });
-    const studyCondition = computed(() => studyConditions.value.study?.concat(studySummaryData.otherConditions.value) || []);
-    const consortiumCondition = computed(() => studyConditions.value.consortia?.concat(studySummaryData.otherConditions.value) || []);
-
-    const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 5);
-    const consortium = usePaginatedResults(ref(consortiumCondition), api.searchStudy, undefined, 5);
-
-    const studyResults = computed(() => Object.values(study.data.results.results)
-      .map((r) => ({
-        ...r,
-        name: r.annotations.title || r.name,
-        children: r.children?.map((c) => ({
-          ...c,
-          name: c.annotations.title || c.name,
-        })),
-      })));
-    const consortiumStudyResults = computed(() => Object.values(consortium.data.results.results)
-      .map((r) => ({
-        ...r,
-        name: r.annotations.title || r.name,
-        children: r.children?.map((c) => ({
-          ...c,
-          name: c.annotations.title || c.name,
-        })),
-      })));
-
-    const loggedInUser = computed(() => stateRefs.user.value !== null);
-
-    const vistab = ref(0);
-    const gatedOmicsVisConditions = useClockGate(
-      computed(() => (vistab.value === 0)),
-      stateRefs.conditions,
-    );
-    const gatedEnvironmentVisConditions = useClockGate(
-      computed(() => (vistab.value === 1)),
-      stateRefs.conditions,
-    );
-    const showChildren:Ref<any[]> = ref([]);
-    function toggleChildren(value:StudySearchResults) {
-
-      showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
-    }
-
-    return {
-      /* data */
-      biosampleType,
-      biosample,
-      dataObjectFilter,
-      expandedOmicsDetails,
-      gatedEnvironmentVisConditions,
-      gatedOmicsVisConditions,
-      loggedInUser,
-      disableBulkDownload,
-      studyType,
-      study,
-      consortium,
-      studyResults,
-      consortiumStudyResults,
-      showConsortia,
-      showStudies,
-      showChildren,
-      studyCheckboxState,
-      types,
-      vistab,
-      toggleChildren,
-      /* methods */
-      setChecked,
-      selectStudyAndOmics,
-      setExpanded,
-      fieldDisplayName,
-    };
+/**
+ * Set study and omics type conditions.
+ * Used when clicking on omics processing count chips.
+ * @param studyId - ID of the study to select
+ * @param omicsType - Type of omics processing to select 
+ */
+function selectStudyAndOmics(studyId: string, omicsType: string) {
+  const conditions: Condition[] = [{
+    value: studyId,
+    table: 'study',
+    op: '==',
+    field: 'study_id',
   },
+  {
+    value: omicsType,
+    table: 'omics_processing',
+    field: 'omics_type',
+    op: '==',
+  }];
+  setConditions([...stateRefs.conditions.value, ...conditions]);
+}
+
+const studyConditions: Ref<Record<string, Condition[]>> = ref<Record<string, Condition[]>>({
+  study: [{
+    field: 'study_category',
+    table: 'study',
+    op: '==',
+    value: 'research_study',
+  }],
+  consortia: [{
+    field: 'study_category',
+    table: 'study',
+    op: '==',
+    value: 'consortium',
+  }],
 });
+
+/**
+ * SearchLayout-level settings
+ */
+const disableBulkDownload = ref(true);
+api.getAppSettings().then((appSettings) => {
+  disableBulkDownload.value = appSettings.disable_bulk_download;
+});
+
+/**
+ * Expanded Omics details
+ */
+const expandedOmicsDetails = reactive({
+  resultId: '',
+  omicsProcessingId: '',
+});
+function setExpanded(resultId: string, omicsProcessingId: string) {
+  if (expandedOmicsDetails.resultId !== resultId
+    || expandedOmicsDetails.omicsProcessingId !== omicsProcessingId) {
+    expandedOmicsDetails.resultId = resultId;
+    expandedOmicsDetails.omicsProcessingId = omicsProcessingId;
+  } else {
+    expandedOmicsDetails.resultId = '';
+    expandedOmicsDetails.omicsProcessingId = '';
+  }
+}
+
+const biosampleType = types.biosample;
+const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter);
+
+const studyType = types.study;
+const studySummaryData = useFacetSummaryData({
+  field: ref('study_id'),
+  table: ref('study'),
+  conditions: stateRefs.conditions,
+});
+const studyCondition = computed(() => studyConditions.value.study?.concat(studySummaryData.otherConditions.value) || []);
+const consortiumCondition = computed(() => studyConditions.value.consortia?.concat(studySummaryData.otherConditions.value) || []);
+
+const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 5);
+const consortium = usePaginatedResults(ref(consortiumCondition), api.searchStudy, undefined, 5);
+
+const studyResults = computed(() => Object.values(study.data.results.results)
+  .map((r) => ({
+    ...r,
+    name: r.annotations.title || r.name,
+    children: r.children?.map((c) => ({
+      ...c,
+      name: c.annotations.title || c.name,
+    })),
+  })));
+const consortiumStudyResults = computed(() => Object.values(consortium.data.results.results)
+  .map((r) => ({
+    ...r,
+    name: r.annotations.title || r.name,
+    children: r.children?.map((c) => ({
+      ...c,
+      name: c.annotations.title || c.name,
+    })),
+  })));
+
+const loggedInUser = computed(() => stateRefs.user.value !== null);
+
+const vistab = ref(0);
+const gatedOmicsVisConditions = useClockGate(
+  computed(() => (vistab.value === 0)),
+  stateRefs.conditions,
+);
+const gatedEnvironmentVisConditions = useClockGate(
+  computed(() => (vistab.value === 1)),
+  stateRefs.conditions,
+);
+const showChildren:Ref<any[]> = ref([]);
+function toggleChildren(value:StudySearchResults) {
+  showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
+}
 </script>
 
 <template>
@@ -279,6 +232,19 @@ export default defineComponent({
               <EnvironmentVisGroup :conditions="gatedEnvironmentVisConditions" />
             </v-window-item>
           </v-window>
+          <v-card variant="outlined">
+            <v-tabs
+              v-model="vistab"
+              color="primary"
+            >
+              <v-tab key="omics">
+                Studies
+              </v-tab>
+              <v-tab key="environments">
+                Samples
+              </v-tab>
+            </v-tabs>
+          </v-card>
           <v-card variant="outlined">
             <v-card
               flat

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -48,16 +48,16 @@ function setChecked(checked: boolean, studyId: string, children: StudySearchResu
     op: '==',
     field: 'study_id',
   }];
-  if (children.length > 0) {
-    children.forEach((child) => {
-      conditions.push({
-        value: child.id,
-        table: 'study',
-        field: 'study_id',
-        op: '==',
-      });
-    });
-  }
+  // if (children.length > 0) {
+  //   children.forEach((child) => {
+  //     conditions.push({
+  //       value: child.id,
+  //       table: 'study',
+  //       field: 'study_id',
+  //       op: '==',
+  //     });
+  //   });
+  // }
   if (checked) {
     setConditions([...stateRefs.conditions.value, ...conditions]);
   } else {
@@ -299,13 +299,23 @@ function toggleChildren(value:StudySearchResult) {
                             <v-icon color="grey-darken-1">
                               mdi-arrow-right-bottom
                             </v-icon>
-                            <v-checkbox-btn
-                              :model-value="studyCheckboxState"
-                              :value="child.id"
-                              :disabled="studyCheckboxState.includes(result.id)"
-                              @click.stop
-                              @change="setChecked($event.target.checked, child.id)"
-                            />
+                            <span
+                              v-tooltip="{
+                                text: 'This study is already selected because its parent is selected.',
+                                disabled: !studyCheckboxState.includes(result.id),
+                                location: 'bottom',
+                              }"
+                              location="bottom"
+                              class="d-inline-block"
+                            >
+                              <v-checkbox-btn
+                                :model-value="studyCheckboxState"
+                                :value="child.id"
+                                :disabled="studyCheckboxState.includes(result.id)"
+                                @click.stop
+                                @change="setChecked($event.target.checked, child.id)"
+                              />
+                            </span>
                           </v-list-item-action>
                         </template>
                         <template #action-right="{ result: child }">

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -104,7 +104,7 @@ const studySummaryData = useFacetSummaryData({
 });
 const studyCondition = studySummaryData.otherConditions.value || [];
 const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 10);
-const studyResults = computed(() => Object.values(study.data.results.results)
+const studyResults = computed<StudySearchResults[]>(() => Object.values(study.data.results.results)
   .map((r) => ({
     ...r,
     name: r.annotations.title || r.name,
@@ -270,9 +270,9 @@ const gatedEnvironmentVisConditions = useClockGate(
                       <SearchResults
                         disable-navigate-on-click
                         disable-pagination
-                        :count="props.result.children.length"
+                        :count="props.result.children?.length ?? 0"
                         :icon="studyType.icon"
-                        :items-per-page="props.result.children.length"
+                        :items-per-page="props.result.children?.length ?? 0"
                         :results="props.result.children"
                         :page="1"
                         :loading="false"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  computed, ref, Ref,
+  computed, ref,
 
 } from 'vue';
 
@@ -126,10 +126,10 @@ const gatedEnvironmentVisConditions = useClockGate(
   computed(() => (visTab.value === 1)),
   stateRefs.conditions,
 );
-const showChildren:Ref<any[]> = ref([]);
-function toggleChildren(value:StudySearchResults) {
-  showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
-}
+// const showChildren:Ref<any[]> = ref([]);
+// function toggleChildren(value:StudySearchResults) {
+//   showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
+// }
 </script>
 
 <template>
@@ -228,35 +228,10 @@ function toggleChildren(value:StudySearchResults) {
                         :model-value="studyCheckboxState"
                         :value="result.id"
                         @click.stop
-                        @change="setChecked($event.target.checked, result.id, result.children)"
+                        @change="setChecked($event.target.checked, result.id, result.children as StudySearchResults[])"
                       />
                     </v-list-item-action>
                   </template>
-
-                  <template #child-list="{ result }">
-                    <v-list-item-action
-                      v-if="result.children && result.children.length > 0"
-                      class="ma-0"
-                    >
-                      <v-btn
-                        icon
-                        variant="plain"
-                        @click="toggleChildren(result)"
-                      >
-                        <v-icon
-                          v-if="showChildren.includes(result.id)"
-                        >
-                          mdi-chevron-up-box
-                        </v-icon>
-                        <v-icon
-                          v-else
-                        >
-                          mdi-chevron-down-box
-                        </v-icon>
-                      </v-btn>
-                    </v-list-item-action>
-                  </template>
-
                   <template #action-right="{ result }">
                     <v-list-item-action>
                       <v-btn
@@ -277,78 +252,16 @@ function toggleChildren(value:StudySearchResults) {
                         v-for="item in props.result.omics_processing_counts"
                       >
                         <v-chip
-                          v-if="item.count"
-                          :key="item.type"
+                          v-if="(item as any).count"
+                          :key="(item as any).type"
                           size="small"
                           class="mr-2 my-1"
-                          @click.stop="selectStudyAndOmics(props.result.id, item.type)"
+                          @click.stop="selectStudyAndOmics(props.result.id, (item as any).type)"
                         >
-                          {{ fieldDisplayName(item.type) }}: {{ item.count }}
+                          {{ fieldDisplayName((item as any).type) }}: {{ (item as any).count }}
                         </v-chip>
                       </template>
                     </div>
-                    <v-card
-                      v-if="showChildren.includes(props.result.id)"
-                      flat
-                      class="pa-4 mt-2"
-                    >
-                      <v-divider />
-                      <SearchResults
-                        disable-navigate-on-click
-                        disable-pagination
-                        :count="props.result.children.length"
-                        :icon="studyType.icon"
-                        :items-per-page="props.result.children.length"
-                        :results="props.result.children"
-                        :page="1"
-                        :loading="false"
-                        @selected="$router.push({ name: 'Study', params: { id: $event} })"
-                      >
-                        <template #action="{ result }">
-                          <v-list-item-action>
-                            <v-checkbox-btn
-                              :disabled="studyCheckboxState.includes(props.result.id)"
-                              :model-value="studyCheckboxState"
-                              :value="result.id"
-                              @click.stop
-                              @change="setChecked($event.target.checked, result.id)"
-                            />
-                          </v-list-item-action>
-                        </template>
-
-                        <template #action-right="{ result }">
-                          <v-list-item-action>
-                            <v-btn
-                              icon
-                              variant="plain"
-                              size="large"
-                              :to="{ name: 'Study', params: { id: result.id } }"
-                            >
-                              <v-icon>
-                                mdi-chevron-right
-                              </v-icon>
-                            </v-btn>
-                          </v-list-item-action>
-                        </template>
-                        <template #item-content="childProps">
-                          <div v-if="childProps.result.omics_processing_counts">
-                            <template
-                              v-for="item in childProps.result.omics_processing_counts"
-                            >
-                              <v-chip
-                                v-if="item.count"
-                                :key="item.type"
-                                size="small"
-                                class="mr-2 my-1"
-                                @click.stop="selectStudyAndOmics(childProps.result.id, item.type)"
-                              >
-                                {{ fieldDisplayName(item.type) }}: {{ item.count }}
-                              </v-chip>
-                            </template>
-                          </div>
-                        </template>
-                      </SearchResults>
-                    </v-card>
                   </template>
                 </SearchResults>
               </v-tabs-window-item>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -3,6 +3,7 @@ import {
   computed, Ref, ref,
 
 } from 'vue';
+import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc_materialized_patterns.json';
 
 import SearchResults from '@/components/Presentation/SearchResults.vue';
 import { types } from '@/encoding';
@@ -26,6 +27,11 @@ import BiosampleVisGroup from './BiosampleVisGroup.vue';
 import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
+
+const biosampleDescription = NmdcSchema.classes[types.biosample.schemaName].description;
+// TODO: would we rather use the study description from the schema?
+// const studyDescription = NmdcSchema.classes[types.study.schemaName].description;
+const studyDescription = 'Research-driven experimental datasets and standardized data collections.';
 
 /**
  * Study checkbox state logic
@@ -179,10 +185,36 @@ function toggleChildren(value:StudySearchResult) {
               color="primary"
             >
               <v-tab key="studies">
-                Studies ({{ study.data.results.count }})
+                <div class="d-flex align-center ga-2">
+                  <span>Studies ({{ study.data.results.count }})</span>
+                  <v-tooltip location="top">
+                    <template #activator="{ props }">
+                      <v-icon
+                        v-bind="props"
+                        color="grey-darken-1"
+                      >
+                        mdi-help-circle
+                      </v-icon>
+                    </template>
+                    <span>{{ studyDescription }}</span>
+                  </v-tooltip>
+                </div>
               </v-tab>
               <v-tab key="samples">
-                Samples ({{ biosample.data.results.count }})
+                <div class="d-flex align-center ga-2">
+                  <span>Samples ({{ biosample.data.results.count }})</span>
+                  <v-tooltip location="top">
+                    <template #activator="{ props }">
+                      <v-icon
+                        v-bind="props"
+                        color="grey-darken-1"
+                      >
+                        mdi-help-circle
+                      </v-icon>
+                    </template>
+                    <span>{{ biosampleDescription }}</span>
+                  </v-tooltip>
+                </div>
               </v-tab>
               <v-spacer />
               <div 

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -102,8 +102,8 @@ const studySummaryData = useFacetSummaryData({
   table: ref('study'),
   conditions: stateRefs.conditions,
 });
-const studyCondition = studySummaryData.otherConditions.value || [];
-const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 10);
+// const studyCondition = studySummaryData.otherConditions.value || [];
+const study = usePaginatedResults(studySummaryData.otherConditions, api.searchStudy, undefined, 10);
 const studyResults = computed<StudySearchResult[]>(() => Object.values(study.data.results.results)
   .map((r) => ({
     ...r,

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -314,12 +314,12 @@ function toggleChildren(value:StudySearchResult) {
                         v-for="item in result.omics_processing_counts"
                       >
                         <v-chip
-                          v-if="(item as any).count"
-                          :key="(item as any).type"
+                          v-if="item.count"
+                          :key="item.type"
                           size="small"
-                          @click.stop="selectStudyAndOmics(result.id, (item as any).type)"
+                          @click.stop="selectStudyAndOmics(result.id, item.type)"
                         >
-                          {{ fieldDisplayName((item as any).type) }}: {{ (item as any).count }}
+                          {{ fieldDisplayName(item.type) }}: {{ item.count }}
                         </v-chip>
                       </template>
                     </div>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -211,18 +211,24 @@ const gatedEnvironmentVisConditions = useClockGate(
             >
               <v-tabs-window-item key="studies">
                 <SearchResults
-                  show-checkbox
                   :count="study.data.results.count"
                   :icon="studyType.icon"
                   :items-per-page="study.data.limit"
                   :results="studyResults"
                   :page="study.data.pageSync"
-                  :checkbox-values="studyCheckboxState"
                   @set-page="study.setPage($event)"
-                  @selected="$router.push({ name: 'Study', params: { id: $event} })"
                   @set-items-per-page="study.setItemsPerPage($event)"
-                  @checkbox-change="setChecked($event.checked, $event.id, $event.children as StudySearchResults[])"
                 >
+                  <template #prepend-action="{ result }">
+                    <v-list-item-action>
+                      <v-checkbox-btn
+                        :model-value="studyCheckboxState"
+                        :value="result.id"
+                        @click.stop
+                        @change="setChecked($event.target.checked, result.id, result.children as StudySearchResults[])"
+                      />
+                    </v-list-item-action>
+                  </template>
                   <template #action-right="{ result }">
                     <v-list-item-action>
                       <v-btn
@@ -262,18 +268,24 @@ const gatedEnvironmentVisConditions = useClockGate(
                     >
                       <v-divider />
                       <SearchResults
-                        show-checkbox
                         disable-pagination
                         :count="result.children.length"
                         :icon="studyType.icon"
                         :items-per-page="result.children.length"
                         :results="result.children"
                         :page="1"
-                        :checkbox-values="studyCheckboxState"
-                        :checkbox-disabled="studyCheckboxState.includes(result.id)"
-                        @selected="$router.push({ name: 'Study', params: { id: $event} })"
-                        @checkbox-change="setChecked($event.checked, $event.id)"
                       >
+                        <template #prepend-action="{ result: child }">
+                          <v-list-item-action>
+                            <v-checkbox-btn
+                              :model-value="studyCheckboxState"
+                              :value="child.id"
+                              :disabled="studyCheckboxState.includes(result.id)"
+                              @click.stop
+                              @change="setChecked($event.target.checked, child.id)"
+                            />
+                          </v-list-item-action>
+                        </template>
                         <template #action-right="{ result: child }">
                           <v-list-item-action>
                             <v-btn

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -98,7 +98,6 @@ const studySummaryData = useFacetSummaryData({
   table: ref('study'),
   conditions: stateRefs.conditions,
 });
-// const studyCondition = studySummaryData.otherConditions.value || [];
 const study = usePaginatedResults(studySummaryData.otherConditions, api.searchStudy, undefined, 10);
 const studyResults = computed<StudySearchResult[]>(() => Object.values(study.data.results.results)
   .map((r) => ({

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -20,6 +20,7 @@ import usePaginatedResults from '@/use/usePaginatedResults';
 import useClockGate from '@/use/useClockGate';
 import AppBanner from '@/components/AppBanner.vue';
 import BulkDownload from '@/components/BulkDownload.vue';
+import ClickToCopyText from '@/components/Presentation/ClickToCopyText.vue';
 import EnvironmentVisGroup from './EnvironmentVisGroup.vue';
 import BiosampleVisGroup from './BiosampleVisGroup.vue';
 import SearchSidebar from './SearchSidebar.vue';
@@ -218,25 +219,47 @@ function toggleChildren(value:StudySearchResult) {
                       />
                     </v-list-item-action>
                   </template>
-                  <template #action-title-right="{ result }">
-                    <v-list-item-action
-                      v-if="result.children && result.children.length > 0"
-                      class="ml-2"
-                    >
-                      <v-btn
-                        variant="flat"
-                        color="grey-darken-1"
-                        size="x-small"
-                        @click="toggleChildren(result as StudySearchResult)"
+                  <template #item-title="{ result }">
+                    <div class="d-flex align-center">
+                      <router-link
+                        class="text-decoration-none"
+                        :to="{ name: 'Study', params: { id: result.id }}"
                       >
-                        {{ result.children.length }} child {{ result.children.length > 1 ? 'studies' : 'study' }}
-                        <template #append>
-                          <v-icon>
-                            {{ showChildren.includes(result.id) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
-                          </v-icon>
-                        </template>
-                      </v-btn>
-                    </v-list-item-action>
+                        <span class="text-subtitle-2">
+                          {{ result.name }}
+                        </span>
+                      </router-link>
+                      <v-list-item-action
+                        v-if="result.children && result.children.length > 0"
+                        class="ml-2"
+                      >
+                        <v-btn
+                          variant="flat"
+                          color="grey-darken-1"
+                          size="x-small"
+                          @click="toggleChildren(result as StudySearchResult)"
+                        >
+                          {{ result.children.length }} child {{ result.children.length > 1 ? 'studies' : 'study' }}
+                          <template #append>
+                            <v-icon>
+                              {{ showChildren.includes(result.id) ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+                            </v-icon>
+                          </template>
+                        </v-btn>
+                      </v-list-item-action>
+                    </div>
+                  </template>
+                  <template #item-subtitle="{ result }">
+                    <div class="d-flex ga-1">
+                      <span class="flex-shrink-0 text-no-wrap">
+                        <strong class="mr-1">ID:</strong>
+                        <ClickToCopyText>
+                          {{ result.id }}
+                        </ClickToCopyText>
+                      </span>
+                      <v-icon>mdi-circle-small</v-icon>
+                      <span class="text-truncate flex-grow-1">{{ result.description }}</span>
+                    </div>
                   </template>
                   <template #action-right="{ result }">
                     <v-list-item-action>
@@ -253,7 +276,10 @@ function toggleChildren(value:StudySearchResult) {
                     </v-list-item-action>
                   </template>
                   <template #item-content="{ result }">
-                    <div v-if="result.omics_processing_counts">
+                    <div 
+                      v-if="result.omics_processing_counts"
+                      class="d-flex ga-2"
+                    >
                       <template
                         v-for="item in result.omics_processing_counts"
                       >
@@ -261,7 +287,6 @@ function toggleChildren(value:StudySearchResult) {
                           v-if="(item as any).count"
                           :key="(item as any).type"
                           size="small"
-                          class="mr-2 my-1"
                           @click.stop="selectStudyAndOmics(result.id, (item as any).type)"
                         >
                           {{ fieldDisplayName((item as any).type) }}: {{ (item as any).count }}
@@ -306,6 +331,28 @@ function toggleChildren(value:StudySearchResult) {
                               />
                             </span>
                           </v-list-item-action>
+                        </template>
+                        <template #item-title="{ result: child }">
+                          <router-link
+                            class="text-decoration-none"
+                            :to="{ name: 'Study', params: { id: child.id }}"
+                          >
+                            <span class="text-subtitle-2">
+                              {{ child.name }}
+                            </span>
+                          </router-link>
+                        </template>
+                        <template #item-subtitle="{ result: child }">
+                          <div class="d-flex ga-1">
+                            <span class="flex-shrink-0 text-no-wrap">
+                              <strong class="mr-1">ID:</strong>
+                              <ClickToCopyText>
+                                {{ child.id }}
+                              </ClickToCopyText>
+                            </span>
+                            <v-icon>mdi-circle-small</v-icon>
+                            <span class="text-truncate flex-grow-1">{{ child.description }}</span>
+                          </div>
                         </template>
                         <template #action-right="{ result: child }">
                           <v-list-item-action>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -36,28 +36,17 @@ const studyCheckboxState = computed(() => (
 ));
 
 /**
- * Set a study (or consortium) as checked in the search results.
+ * Set a study as checked in the search results.
  * @param checked - Whether the item is currently being checked (true) or unchecked (false)
  * @param studyId - ID of the study to select
- * @param children - Optional children studies to also select
  */
-function setChecked(checked: boolean, studyId: string, children: StudySearchResult[] = []) {
+function setChecked(checked: boolean, studyId: string) {
   const conditions: Condition[] = [{
     value: studyId,
     table: 'study',
     op: '==',
     field: 'study_id',
   }];
-  // if (children.length > 0) {
-  //   children.forEach((child) => {
-  //     conditions.push({
-  //       value: child.id,
-  //       table: 'study',
-  //       field: 'study_id',
-  //       op: '==',
-  //     });
-  //   });
-  // }
   if (checked) {
     setConditions([...stateRefs.conditions.value, ...conditions]);
   } else {
@@ -225,7 +214,7 @@ function toggleChildren(value:StudySearchResult) {
                         :model-value="studyCheckboxState"
                         :value="result.id"
                         @click.stop
-                        @change="setChecked($event.target.checked, result.id, result.children as StudySearchResult[])"
+                        @change="setChecked($event.target.checked, result.id)"
                       />
                     </v-list-item-action>
                   </template>
@@ -236,7 +225,7 @@ function toggleChildren(value:StudySearchResult) {
                     >
                       <v-btn
                         variant="flat"
-                        color="grey"
+                        color="grey-darken-1"
                         size="x-small"
                         @click="toggleChildren(result as StudySearchResult)"
                       >

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -8,7 +8,7 @@ import SearchResults from '@/components/Presentation/SearchResults.vue';
 import { types } from '@/encoding';
 // @ts-ignore
 import { fieldDisplayName } from '@/util';
-import { api, Condition, StudySearchResults } from '@/data/api';
+import { api, Condition, StudySearchResult } from '@/data/api';
 
 import {
   stateRefs, dataObjectFilter,
@@ -41,7 +41,7 @@ const studyCheckboxState = computed(() => (
  * @param studyId - ID of the study to select
  * @param children - Optional children studies to also select
  */
-function setChecked(checked: boolean, studyId: string, children: StudySearchResults[] = []) {
+function setChecked(checked: boolean, studyId: string, children: StudySearchResult[] = []) {
   const conditions: Condition[] = [{
     value: studyId,
     table: 'study',
@@ -104,7 +104,7 @@ const studySummaryData = useFacetSummaryData({
 });
 const studyCondition = studySummaryData.otherConditions.value || [];
 const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 10);
-const studyResults = computed<StudySearchResults[]>(() => Object.values(study.data.results.results)
+const studyResults = computed<StudySearchResult[]>(() => Object.values(study.data.results.results)
   .map((r) => ({
     ...r,
     name: r.annotations.title || r.name,
@@ -127,7 +127,7 @@ const gatedEnvironmentVisConditions = useClockGate(
   stateRefs.conditions,
 );
 // const showChildren:Ref<any[]> = ref([]);
-// function toggleChildren(value:StudySearchResults) {
+// function toggleChildren(value:StudySearchResult) {
 //   showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
 // }
 </script>
@@ -225,7 +225,7 @@ const gatedEnvironmentVisConditions = useClockGate(
                         :model-value="studyCheckboxState"
                         :value="result.id"
                         @click.stop
-                        @change="setChecked($event.target.checked, result.id, result.children as StudySearchResults[])"
+                        @change="setChecked($event.target.checked, result.id, result.children as StudySearchResult[])"
                       />
                     </v-list-item-action>
                   </template>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -262,6 +262,67 @@ const gatedEnvironmentVisConditions = useClockGate(
                         </v-chip>
                       </template>
                     </div>
+                    <v-card
+                      flat
+                      class="pa-4 mt-2"
+                    >
+                      <v-divider />
+                      <SearchResults
+                        disable-navigate-on-click
+                        disable-pagination
+                        :count="props.result.children.length"
+                        :icon="studyType.icon"
+                        :items-per-page="props.result.children.length"
+                        :results="props.result.children"
+                        :page="1"
+                        :loading="false"
+                        @selected="$router.push({ name: 'Study', params: { id: $event} })"
+                      >
+                        <template #action="{ result }">
+                          <v-list-item-action>
+                            <v-checkbox-btn
+                              :disabled="studyCheckboxState.includes(props.result.id)"
+                              :model-value="studyCheckboxState"
+                              :value="result.id"
+                              @click.stop
+                              @change="setChecked($event.target.checked, result.id)"
+                            />
+                          </v-list-item-action>
+                        </template>
+
+                        <template #action-right="{ result }">
+                          <v-list-item-action>
+                            <v-btn
+                              icon
+                              variant="plain"
+                              size="large"
+                              :to="{ name: 'Study', params: { id: result.id } }"
+                            >
+                              <v-icon>
+                                mdi-chevron-right
+                              </v-icon>
+                            </v-btn>
+                          </v-list-item-action>
+                        </template>
+                        <template #item-content="childProps">
+                          <div v-if="childProps.result.omics_processing_counts">
+                            <template
+                              v-for="item in childProps.result.omics_processing_counts"
+                            >
+                              <v-chip
+                                v-if="item.count"
+                                :key="item.type"
+                                size="small"
+                                class="mr-2 my-1"
+                                @click.stop="selectStudyAndOmics(childProps.result.id, item.type)"
+                              >
+                                {{ fieldDisplayName(item.type) }}: {{ item.count }}
+                              </v-chip>
+                            </template>
+                          </div>
+                        </template>
+                      </SearchResults>
+                    </v-card>
                   </template>
                 </SearchResults>
               </v-tabs-window-item>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -222,7 +222,6 @@ function toggleChildren(value:StudySearchResult) {
                   <template #item-title="{ result }">
                     <div class="d-flex align-center">
                       <router-link
-                        class="text-decoration-none"
                         :to="{ name: 'Study', params: { id: result.id }}"
                       >
                         <span class="text-subtitle-2">
@@ -334,7 +333,6 @@ function toggleChildren(value:StudySearchResult) {
                         </template>
                         <template #item-title="{ result: child }">
                           <router-link
-                            class="text-decoration-none"
                             :to="{ name: 'Study', params: { id: child.id }}"
                           >
                             <span class="text-subtitle-2">

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -32,7 +32,7 @@ import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchRes
 const studyCheckboxState = computed(() => (
   stateRefs.conditions.value
     .filter((c) => c.table === 'study' && c.field === 'study_id')
-    .map((c) => c.value)
+    .map((c) => c.value as string)
 ));
 
 /**
@@ -211,27 +211,18 @@ const gatedEnvironmentVisConditions = useClockGate(
             >
               <v-tabs-window-item key="studies">
                 <SearchResults
-                  disable-navigate-on-click
+                  show-checkbox
                   :count="study.data.results.count"
                   :icon="studyType.icon"
                   :items-per-page="study.data.limit"
                   :results="studyResults"
                   :page="study.data.pageSync"
-                  :loading="study.loading.value"
+                  :checkbox-values="studyCheckboxState"
                   @set-page="study.setPage($event)"
                   @selected="$router.push({ name: 'Study', params: { id: $event} })"
                   @set-items-per-page="study.setItemsPerPage($event)"
+                  @checkbox-change="setChecked($event.checked, $event.id, $event.children as StudySearchResults[])"
                 >
-                  <template #action="{ result }">
-                    <v-list-item-action>
-                      <v-checkbox-btn
-                        :model-value="studyCheckboxState"
-                        :value="result.id"
-                        @click.stop
-                        @change="setChecked($event.target.checked, result.id, result.children as StudySearchResults[])"
-                      />
-                    </v-list-item-action>
-                  </template>
                   <template #action-right="{ result }">
                     <v-list-item-action>
                       <v-btn
@@ -246,57 +237,50 @@ const gatedEnvironmentVisConditions = useClockGate(
                       </v-btn>
                     </v-list-item-action>
                   </template>
-                  <template #item-content="props">
-                    <div v-if="props.result.omics_processing_counts">
+                  <template #item-content="{ result }">
+                    <div v-if="result.omics_processing_counts">
                       <template
-                        v-for="item in props.result.omics_processing_counts"
+                        v-for="item in result.omics_processing_counts"
                       >
                         <v-chip
                           v-if="(item as any).count"
                           :key="(item as any).type"
                           size="small"
                           class="mr-2 my-1"
-                          @click.stop="selectStudyAndOmics(props.result.id, (item as any).type)"
+                          @click.stop="selectStudyAndOmics(result.id, (item as any).type)"
                         >
                           {{ fieldDisplayName((item as any).type) }}: {{ (item as any).count }}
                         </v-chip>
                       </template>
                     </div>
+                  </template>
+                  <template #item-children="{ result }">
                     <v-card
+                      v-if="result.children?.length"
                       flat
                       class="pa-4 mt-2"
                     >
                       <v-divider />
                       <SearchResults
-                        disable-navigate-on-click
+                        show-checkbox
                         disable-pagination
-                        :count="props.result.children?.length ?? 0"
+                        :count="result.children.length"
                         :icon="studyType.icon"
-                        :items-per-page="props.result.children?.length ?? 0"
-                        :results="props.result.children"
+                        :items-per-page="result.children.length"
+                        :results="result.children"
                         :page="1"
-                        :loading="false"
+                        :checkbox-values="studyCheckboxState"
+                        :checkbox-disabled="studyCheckboxState.includes(result.id)"
                         @selected="$router.push({ name: 'Study', params: { id: $event} })"
+                        @checkbox-change="setChecked($event.checked, $event.id)"
                       >
-                        <template #action="{ result }">
-                          <v-list-item-action>
-                            <v-checkbox-btn
-                              :disabled="studyCheckboxState.includes(props.result.id)"
-                              :model-value="studyCheckboxState"
-                              :value="result.id"
-                              @click.stop
-                              @change="setChecked($event.target.checked, result.id)"
-                            />
-                          </v-list-item-action>
-                        </template>
-
-                        <template #action-right="{ result }">
+                        <template #action-right="{ result: child }">
                           <v-list-item-action>
                             <v-btn
                               icon
                               variant="plain"
                               size="large"
-                              :to="{ name: 'Study', params: { id: result.id } }"
+                              :to="{ name: 'Study', params: { id: child.id } }"
                             >
                               <v-icon>
                                 mdi-chevron-right
@@ -304,17 +288,17 @@ const gatedEnvironmentVisConditions = useClockGate(
                             </v-btn>
                           </v-list-item-action>
                         </template>
-                        <template #item-content="childProps">
-                          <div v-if="childProps.result.omics_processing_counts">
+                        <template #item-content="{ result: child }">
+                          <div v-if="child.omics_processing_counts">
                             <template
-                              v-for="item in childProps.result.omics_processing_counts"
+                              v-for="item in child.omics_processing_counts"
                             >
                               <v-chip
                                 v-if="item.count"
                                 :key="item.type"
                                 size="small"
                                 class="mr-2 my-1"
-                                @click.stop="selectStudyAndOmics(childProps.result.id, item.type)"
+                                @click.stop="selectStudyAndOmics(child.id, item.type)"
                               >
                                 {{ fieldDisplayName(item.type) }}: {{ item.count }}
                               </v-chip>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {
-  reactive, computed, ref, Ref,
+  computed, ref, Ref,
 
 } from 'vue';
 
@@ -26,8 +26,6 @@ import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
 
-const showConsortia = ref(true);
-const showStudies = ref(true);
 /**
  * Study checkbox state logic
  */
@@ -89,21 +87,6 @@ function selectStudyAndOmics(studyId: string, omicsType: string) {
   setConditions([...stateRefs.conditions.value, ...conditions]);
 }
 
-const studyConditions: Ref<Record<string, Condition[]>> = ref<Record<string, Condition[]>>({
-  study: [{
-    field: 'study_category',
-    table: 'study',
-    op: '==',
-    value: 'research_study',
-  }],
-  consortia: [{
-    field: 'study_category',
-    table: 'study',
-    op: '==',
-    value: 'consortium',
-  }],
-});
-
 /**
  * SearchLayout-level settings
  */
@@ -112,49 +95,16 @@ api.getAppSettings().then((appSettings) => {
   disableBulkDownload.value = appSettings.disable_bulk_download;
 });
 
-/**
- * Expanded Omics details
- */
-const expandedOmicsDetails = reactive({
-  resultId: '',
-  omicsProcessingId: '',
-});
-function setExpanded(resultId: string, omicsProcessingId: string) {
-  if (expandedOmicsDetails.resultId !== resultId
-    || expandedOmicsDetails.omicsProcessingId !== omicsProcessingId) {
-    expandedOmicsDetails.resultId = resultId;
-    expandedOmicsDetails.omicsProcessingId = omicsProcessingId;
-  } else {
-    expandedOmicsDetails.resultId = '';
-    expandedOmicsDetails.omicsProcessingId = '';
-  }
-}
-
-const biosampleType = types.biosample;
-const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter);
-
+const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter, 10);
 const studyType = types.study;
 const studySummaryData = useFacetSummaryData({
   field: ref('study_id'),
   table: ref('study'),
   conditions: stateRefs.conditions,
 });
-const studyCondition = computed(() => studyConditions.value.study?.concat(studySummaryData.otherConditions.value) || []);
-const consortiumCondition = computed(() => studyConditions.value.consortia?.concat(studySummaryData.otherConditions.value) || []);
-
-const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 5);
-const consortium = usePaginatedResults(ref(consortiumCondition), api.searchStudy, undefined, 5);
-
+const studyCondition = studySummaryData.otherConditions.value || [];
+const study = usePaginatedResults(ref(studyCondition), api.searchStudy, undefined, 10);
 const studyResults = computed(() => Object.values(study.data.results.results)
-  .map((r) => ({
-    ...r,
-    name: r.annotations.title || r.name,
-    children: r.children?.map((c) => ({
-      ...c,
-      name: c.annotations.title || c.name,
-    })),
-  })));
-const consortiumStudyResults = computed(() => Object.values(consortium.data.results.results)
   .map((r) => ({
     ...r,
     name: r.annotations.title || r.name,
@@ -166,13 +116,14 @@ const consortiumStudyResults = computed(() => Object.values(consortium.data.resu
 
 const loggedInUser = computed(() => stateRefs.user.value !== null);
 
-const vistab = ref(0);
+const visTab = ref(0);
+const resultsTab = ref(0);
 const gatedOmicsVisConditions = useClockGate(
-  computed(() => (vistab.value === 0)),
+  computed(() => (visTab.value === 0)),
   stateRefs.conditions,
 );
 const gatedEnvironmentVisConditions = useClockGate(
-  computed(() => (vistab.value === 1)),
+  computed(() => (visTab.value === 1)),
   stateRefs.conditions,
 );
 const showChildren:Ref<any[]> = ref([]);
@@ -203,7 +154,7 @@ function toggleChildren(value:StudySearchResults) {
           <v-row class="align-center">
             <v-col>
               <v-tabs
-                v-model="vistab"
+                v-model="visTab"
                 color="primary"
               >
                 <v-tab key="omics">
@@ -219,13 +170,13 @@ function toggleChildren(value:StudySearchResults) {
             </v-col>
           </v-row>
           <v-window
-            v-model="vistab"
+            v-model="visTab"
             class="my-3"
           >
             <v-window-item key="omics">
               <BiosampleVisGroup
                 :conditions="gatedOmicsVisConditions"
-                :vistab="vistab"
+                :vis-tab="visTab"
               />
             </v-window-item>
             <v-window-item key="environments">
@@ -234,416 +185,183 @@ function toggleChildren(value:StudySearchResults) {
           </v-window>
           <v-card variant="outlined">
             <v-tabs
-              v-model="vistab"
+              v-model="resultsTab"
               color="primary"
             >
-              <v-tab key="omics">
-                Studies
+              <v-tab key="studies">
+                Studies ({{ study.data.results.count }})
               </v-tab>
-              <v-tab key="environments">
-                Samples
+              <v-tab key="samples">
+                Samples ({{ biosample.data.results.count }})
               </v-tab>
-            </v-tabs>
-          </v-card>
-          <v-card variant="outlined">
-            <v-card
-              flat
-            >
-              <v-card-title
-                class="pb-0 d-flex align-center"
+              <v-spacer />
+              <div 
+                v-if="!disableBulkDownload"
+                class="d-flex align-center mr-4"
               >
-                {{ consortium.data.results.count === 1 ? 'Consortium' : 'Consortia' }}
-                <v-tooltip
-                  right
-                >
-                  <template #activator="{ props }">
-                    <v-btn
-                      icon
-                      variant="plain"
-                      size="small"
-                      v-bind="props"
-                    >
-                      <v-icon>mdi-help-circle</v-icon>
-                    </v-btn>
-                  </template>
-                  <span>Standardized Data Collections</span>
-                </v-tooltip>
-                <v-spacer />
-                <v-card-actions>
-                  <v-btn
-                    elevation="0"
-                    color="primary"
-                    variant="elevated"
-                    :disabled="consortium.data.results.count === 0"
-                    @click="showConsortia=!showConsortia"
-                  >
-                    {{ showConsortia ? 'Hide' : 'View' }} Consortia
-                    <v-icon>
-                      {{ showConsortia ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
-                    </v-icon>
-                  </v-btn>
-                </v-card-actions>
-              </v-card-title>
-              <v-expand-transition>
-                <div v-show="showConsortia">
-                  <SearchResults
-                    disable-navigate-on-click
-                    :count="consortium.data.results.count"
-                    :icon="'mdi-database'"
-                    :items-per-page="consortium.data.limit"
-                    :results="consortiumStudyResults"
-                    :page="consortium.data.pageSync"
-                    :loading="consortium.loading.value"
-                    @set-page="consortium.setPage($event)"
-                    @selected="$router.push({ name: 'Study', params: { id: $event} })"
-                    @set-items-per-page="consortium.setItemsPerPage($event)"
-                  >
-                    <template #action="{ result }">
-                      <v-list-item-action>
-                        <v-checkbox-btn
-                          :model-value="studyCheckboxState"
-                          :value="result.id"
-                          @click.stop
-                          @change="setChecked($event.target.checked, result.id, result.children)"
-                        />
-                      </v-list-item-action>
-                    </template>
-                    <template #child-list="{ result }">
-                      <v-list-item-action
-                        v-if="result.children && result.children.length > 0"
-                        class="ma-0"
-                      >
-                        <v-btn
-                          icon
-                          variant="plain"
-                          @click="toggleChildren(result)"
-                        >
-                          <v-icon
-                            v-if="showChildren.includes(result.id)"
-                          >
-                            mdi-chevron-up-box
-                          </v-icon>
-                          <v-icon
-                            v-else
-                          >
-                            mdi-chevron-down-box
-                          </v-icon>
-                        </v-btn>
-                      </v-list-item-action>
-                    </template>
-
-                    <template #action-right="{ result }">
-                      <v-list-item-action>
-                        <v-btn
-                          icon
-                          variant="plain"
-                          size="large"
-                          :to="{ name: 'Study', params: { id: result.id } }"
-                        >
-                          <v-icon>
-                            mdi-chevron-right
-                          </v-icon>
-                        </v-btn>
-                      </v-list-item-action>
-                    </template>
-                    <template #item-content="props">
-                      <div v-if="props.result.omics_processing_counts">
-                        <template
-                          v-for="item in props.result.omics_processing_counts"
-                        >
-                          <v-chip
-                            v-if="item.count"
-                            :key="item.type"
-                            size="small"
-                            class="mr-2 my-1"
-                            @click.stop="selectStudyAndOmics(props.result.id, item.type)"
-                          >
-                            {{ fieldDisplayName(item.type) }}: {{ item.count }}
-                          </v-chip>
-                        </template>
-                      </div>
-                      <v-card
-                        v-if="showChildren.includes(props.result.id)"
-                        flat
-                        class="pa-4 mt-2"
-                      >
-                        <v-divider />
-                        <SearchResults
-                          disable-navigate-on-click
-                          disable-pagination
-                          :count="props.result.children.length"
-                          :icon="'mdi-database'"
-                          :items-per-page="props.result.children.length"
-                          :results="props.result.children"
-                          :page="1"
-                          :loading="false"
-                          @selected="$router.push({ name: 'Study', params: { id: $event} })"
-                        >
-                          <template #action="{ result }">
-                            <v-list-item-action>
-                              <v-checkbox-btn
-                                :disabled="studyCheckboxState.includes(props.result.id)"
-                                :model-value="studyCheckboxState"
-                                :value="result.id"
-                                @click.stop
-                                @change="setChecked($event.target.checked, result.id)"
-                              />
-                            </v-list-item-action>
-                          </template>
-
-                          <template #action-right="{ result }">
-                            <v-list-item-action>
-                              <v-btn
-                                icon
-                                variant="plain"
-                                size="large"
-                                :to="{ name: 'Study', params: { id: result.id } }"
-                              >
-                                <v-icon>
-                                  mdi-chevron-right
-                                </v-icon>
-                              </v-btn>
-                            </v-list-item-action>
-                          </template>
-                          <template #item-content="childProps">
-                            <div v-if="childProps.result.omics_processing_counts">
-                              <template
-                                v-for="item in childProps.result.omics_processing_counts"
-                              >
-                                <v-chip
-                                  v-if="item.count"
-                                  :key="item.type"
-                                  size="small"
-                                  class="mr-2 my-1"
-                                  @click.stop="selectStudyAndOmics(props.result.id, item.type)"
-                                >
-                                  {{ fieldDisplayName(item.type) }}: {{ item.count }}
-                                </v-chip>
-                              </template>
-                            </div>
-                          </template>
-                        </SearchResults>
-                      </v-card>
-                    </template>
-                  </SearchResults>
-                </div>
-              </v-expand-transition>
-            </v-card>
-            <v-divider />
-            <v-card
-              flat
-            >
-              <v-card-title class="pb-0 d-flex align-center">
-                {{ study.data.results.count === 1 ? 'Study' : 'Studies' }}
-                <v-tooltip
-                  right
-                >
-                  <template #activator="{ props }">
-                    <v-btn
-                      icon
-                      variant="plain"
-                      size="small"
-                      v-bind="props"
-                    >
-                      <v-icon>mdi-help-circle</v-icon>
-                    </v-btn>
-                  </template>
-                  <span>Research-driven Experimental Data Sets</span>
-                </v-tooltip>
-                <v-spacer />
-                <v-card-actions>
-                  <v-btn
-                    elevation="0"
-                    color="primary"
-                    variant="elevated"
-                    :disabled="study.data.results.count === 0"
-                    @click="showStudies=!showStudies"
-                  >
-                    {{ showStudies ? 'Hide' : 'View' }} Studies
-                    <v-icon>
-                      {{ showStudies ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
-                    </v-icon>
-                  </v-btn>
-                </v-card-actions>
-              </v-card-title>
-              <v-expand-transition>
-                <div v-show="showStudies">
-                  <SearchResults
-                    disable-navigate-on-click
-                    :count="study.data.results.count"
-                    :icon="studyType.icon"
-                    :items-per-page="study.data.limit"
-                    :results="studyResults"
-                    :page="study.data.pageSync"
-                    :loading="study.loading.value"
-                    @set-page="study.setPage($event)"
-                    @selected="$router.push({ name: 'Study', params: { id: $event} })"
-                    @set-items-per-page="study.setItemsPerPage($event)"
-                  >
-                    <template #action="{ result }">
-                      <v-list-item-action>
-                        <v-checkbox-btn
-                          :model-value="studyCheckboxState"
-                          :value="result.id"
-                          @click.stop
-                          @change="setChecked($event.target.checked, result.id, result.children)"
-                        />
-                      </v-list-item-action>
-                    </template>
-
-                    <template #child-list="{ result }">
-                      <v-list-item-action
-                        v-if="result.children && result.children.length > 0"
-                        class="ma-0"
-                      >
-                        <v-btn
-                          icon
-                          variant="plain"
-                          @click="toggleChildren(result)"
-                        >
-                          <v-icon
-                            v-if="showChildren.includes(result.id)"
-                          >
-                            mdi-chevron-up-box
-                          </v-icon>
-                          <v-icon
-                            v-else
-                          >
-                            mdi-chevron-down-box
-                          </v-icon>
-                        </v-btn>
-                      </v-list-item-action>
-                    </template>
-
-                    <template #action-right="{ result }">
-                      <v-list-item-action>
-                        <v-btn
-                          icon
-                          variant="plain"
-                          size="large"
-                          :to="{ name: 'Study', params: { id: result.id } }"
-                        >
-                          <v-icon>
-                            mdi-chevron-right
-                          </v-icon>
-                        </v-btn>
-                      </v-list-item-action>
-                    </template>
-                    <template #item-content="props">
-                      <div v-if="props.result.omics_processing_counts">
-                        <template
-                          v-for="item in props.result.omics_processing_counts"
-                        >
-                          <v-chip
-                            v-if="item.count"
-                            :key="item.type"
-                            size="small"
-                            class="mr-2 my-1"
-                            @click.stop="selectStudyAndOmics(props.result.id, item.type)"
-                          >
-                            {{ fieldDisplayName(item.type) }}: {{ item.count }}
-                          </v-chip>
-                        </template>
-                      </div>
-                      <v-card
-                        v-if="showChildren.includes(props.result.id)"
-                        flat
-                        class="pa-4 mt-2"
-                      >
-                        <v-divider />
-                        <SearchResults
-                          disable-navigate-on-click
-                          disable-pagination
-                          :count="props.result.children.length"
-                          :icon="studyType.icon"
-                          :items-per-page="props.result.children.length"
-                          :results="props.result.children"
-                          :page="1"
-                          :loading="false"
-                          @selected="$router.push({ name: 'Study', params: { id: $event} })"
-                        >
-                          <template #action="{ result }">
-                            <v-list-item-action>
-                              <v-checkbox-btn
-                                :disabled="studyCheckboxState.includes(props.result.id)"
-                                :model-value="studyCheckboxState"
-                                :value="result.id"
-                                @click.stop
-                                @change="setChecked($event.target.checked, result.id)"
-                              />
-                            </v-list-item-action>
-                          </template>
-
-                          <template #action-right="{ result }">
-                            <v-list-item-action>
-                              <v-btn
-                                icon
-                                variant="plain"
-                                size="large"
-                                :to="{ name: 'Study', params: { id: result.id } }"
-                              >
-                                <v-icon>
-                                  mdi-chevron-right
-                                </v-icon>
-                              </v-btn>
-                            </v-list-item-action>
-                          </template>
-                          <template #item-content="childProps">
-                            <div v-if="childProps.result.omics_processing_counts">
-                              <template
-                                v-for="item in childProps.result.omics_processing_counts"
-                              >
-                                <v-chip
-                                  v-if="item.count"
-                                  :key="item.type"
-                                  size="small"
-                                  class="mr-2 my-1"
-                                  @click.stop="selectStudyAndOmics(childProps.result.id, item.type)"
-                                >
-                                  {{ fieldDisplayName(item.type) }}: {{ item.count }}
-                                </v-chip>
-                              </template>
-                            </div>
-                          </template>
-                        </SearchResults>
-                      </v-card>
-                    </template>
-                  </SearchResults>
-                </div>
-              </v-expand-transition>
-            </v-card>
-          </v-card>
-          <v-card
-            variant="outlined"
-            class="my-3"
-          >
-            <div class="ma-3">
-              <div class="d-flex align-center">
-                <v-card-title class="grow py-0">
-                  <span v-if="biosample.loading.value">
-                    Samples
-                  </span>
-                  <span v-else>
-                    {{ biosample.data.results.count }}
-                    {{ biosample.data.results.count === 1 ? 'Sample' : 'Samples' }}
-                  </span>
-                </v-card-title>
-                <v-spacer />
-                <div v-if="!disableBulkDownload">
-                  <BulkDownload
-                    :disabled="!loggedInUser"
-                    :search-result-count="biosample.data.results.count"
-                  />
-                </div>
+                <BulkDownload
+                  :disabled="!loggedInUser"
+                  :search-result-count="biosample.data.results.count"
+                />
               </div>
-            </div>
-            <BiosampleSearchResults
-              :data-object-filter="dataObjectFilter"
-              :biosample-search="biosample"
-            />
-            <h2 v-if="biosample.data.results.count === 0">
-              No results for selected conditions in sample table
-            </h2>
+            </v-tabs>
+            <v-divider />
+            <v-tabs-window
+              v-model="resultsTab"
+            >
+              <v-tabs-window-item key="studies">
+                <SearchResults
+                  disable-navigate-on-click
+                  :count="study.data.results.count"
+                  :icon="studyType.icon"
+                  :items-per-page="study.data.limit"
+                  :results="studyResults"
+                  :page="study.data.pageSync"
+                  :loading="study.loading.value"
+                  @set-page="study.setPage($event)"
+                  @selected="$router.push({ name: 'Study', params: { id: $event} })"
+                  @set-items-per-page="study.setItemsPerPage($event)"
+                >
+                  <template #action="{ result }">
+                    <v-list-item-action>
+                      <v-checkbox-btn
+                        :model-value="studyCheckboxState"
+                        :value="result.id"
+                        @click.stop
+                        @change="setChecked($event.target.checked, result.id, result.children)"
+                      />
+                    </v-list-item-action>
+                  </template>
+
+                  <template #child-list="{ result }">
+                    <v-list-item-action
+                      v-if="result.children && result.children.length > 0"
+                      class="ma-0"
+                    >
+                      <v-btn
+                        icon
+                        variant="plain"
+                        @click="toggleChildren(result)"
+                      >
+                        <v-icon
+                          v-if="showChildren.includes(result.id)"
+                        >
+                          mdi-chevron-up-box
+                        </v-icon>
+                        <v-icon
+                          v-else
+                        >
+                          mdi-chevron-down-box
+                        </v-icon>
+                      </v-btn>
+                    </v-list-item-action>
+                  </template>
+
+                  <template #action-right="{ result }">
+                    <v-list-item-action>
+                      <v-btn
+                        icon
+                        variant="plain"
+                        size="large"
+                        :to="{ name: 'Study', params: { id: result.id } }"
+                      >
+                        <v-icon>
+                          mdi-chevron-right
+                        </v-icon>
+                      </v-btn>
+                    </v-list-item-action>
+                  </template>
+                  <template #item-content="props">
+                    <div v-if="props.result.omics_processing_counts">
+                      <template
+                        v-for="item in props.result.omics_processing_counts"
+                      >
+                        <v-chip
+                          v-if="item.count"
+                          :key="item.type"
+                          size="small"
+                          class="mr-2 my-1"
+                          @click.stop="selectStudyAndOmics(props.result.id, item.type)"
+                        >
+                          {{ fieldDisplayName(item.type) }}: {{ item.count }}
+                        </v-chip>
+                      </template>
+                    </div>
+                    <v-card
+                      v-if="showChildren.includes(props.result.id)"
+                      flat
+                      class="pa-4 mt-2"
+                    >
+                      <v-divider />
+                      <SearchResults
+                        disable-navigate-on-click
+                        disable-pagination
+                        :count="props.result.children.length"
+                        :icon="studyType.icon"
+                        :items-per-page="props.result.children.length"
+                        :results="props.result.children"
+                        :page="1"
+                        :loading="false"
+                        @selected="$router.push({ name: 'Study', params: { id: $event} })"
+                      >
+                        <template #action="{ result }">
+                          <v-list-item-action>
+                            <v-checkbox-btn
+                              :disabled="studyCheckboxState.includes(props.result.id)"
+                              :model-value="studyCheckboxState"
+                              :value="result.id"
+                              @click.stop
+                              @change="setChecked($event.target.checked, result.id)"
+                            />
+                          </v-list-item-action>
+                        </template>
+
+                        <template #action-right="{ result }">
+                          <v-list-item-action>
+                            <v-btn
+                              icon
+                              variant="plain"
+                              size="large"
+                              :to="{ name: 'Study', params: { id: result.id } }"
+                            >
+                              <v-icon>
+                                mdi-chevron-right
+                              </v-icon>
+                            </v-btn>
+                          </v-list-item-action>
+                        </template>
+                        <template #item-content="childProps">
+                          <div v-if="childProps.result.omics_processing_counts">
+                            <template
+                              v-for="item in childProps.result.omics_processing_counts"
+                            >
+                              <v-chip
+                                v-if="item.count"
+                                :key="item.type"
+                                size="small"
+                                class="mr-2 my-1"
+                                @click.stop="selectStudyAndOmics(childProps.result.id, item.type)"
+                              >
+                                {{ fieldDisplayName(item.type) }}: {{ item.count }}
+                              </v-chip>
+                            </template>
+                          </div>
+                        </template>
+                      </SearchResults>
+                    </v-card>
+                  </template>
+                </SearchResults>
+              </v-tabs-window-item>
+              <v-tabs-window-item key="samples">
+                <BiosampleSearchResults
+                  :data-object-filter="dataObjectFilter"
+                  :biosample-search="biosample"
+                />
+                <h2 v-if="biosample.data.results.count === 0">
+                  No results for selected conditions in sample table
+                </h2>
+              </v-tabs-window-item>
+            </v-tabs-window>
           </v-card>
         </v-col>
       </v-row>


### PR DESCRIPTION
Resolves #2153 and resolves #2087

### UI Changes

This PR modifies the UI and UX of the search results. Studies and consortia are now baked into a single section called "Studies." The samples results have been moved into a tab group that is combined with the studies results. Studies is the default visible tab.

The result cards themselves have also been updated. They now include IDs with click-to-copy behavior. The titles are now clickable links to the respective detail pages. Study children have been slightly modified visually (still collapsed/expandable). Alternative identifiers are now rendered in a section labeled "External" and if the width of this section is beyond 500px, then it turns into a [slide group](https://vuetifyjs.com/en/components/slide-groups/#usage).

Links app-wide have been given a default color for both visited and unvisited.

### UX and Functionality Changes

The page no longer scrolls to the top when a filter condition is added/removed. Sample filters will be reflected immediately even if you are beyond page 1 (this was an existing bug). If you are beyond page one and the filters change, your results will reset to page 1.

When filtering by a study ID that has children (using the checkbox feature or the Study ID LIKE filter), the samples associated with its child studies are automatically included in the results.

### Screenshots

<img width="2557" height="1315" alt="Screenshot 2026-06-12 at 4 41 37 PM" src="https://github.com/user-attachments/assets/9c61bbaa-3bbe-4c8c-896d-8d50f46af0ab" />

<img width="1374" height="1133" alt="Screenshot 2026-06-12 at 4 42 39 PM" src="https://github.com/user-attachments/assets/a0222900-356f-42fa-af58-50731c818f13" />

### Still to Come

These issues will be addressed in a future PR:
- #2186
- #2187