### PR TITLE
Add custom validation logic to enforce JGI's rules around plate well filling

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -22,6 +22,7 @@ jobs:
     - run: yarn install --frozen-lockfile --network-timeout 300000
     - run: yarn lint
     - run: yarn build
+    - run: yarn test
 
   server:
     runs-on: ubuntu-latest

--- a/web/package.json
+++ b/web/package.json
@@ -69,13 +69,13 @@
     "unplugin-fonts": "^1.4.0",
     "unplugin-vue-components": "^29.0.0",
     "unplugin-vue-router": "^0.15.0",
-    "vite": "^7.3.2",
+    "vite": "7.3.2",
     "vitest": "^4.1.7",
     "vite-plugin-vuetify": "^2.1.2",
     "vue-tsc": "^3.0.7"
   },
   "resolutions": {
-    "vite": "^7.0.0"
+    "vite": "7.3.2"
   },
   "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
 }

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build --force",
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fontsource/roboto": "5.2.7",
@@ -69,8 +70,12 @@
     "unplugin-vue-components": "^29.0.0",
     "unplugin-vue-router": "^0.15.0",
     "vite": "^7.3.2",
+    "vitest": "^4.1.7",
     "vite-plugin-vuetify": "^2.1.2",
     "vue-tsc": "^3.0.7"
+  },
+  "resolutions": {
+    "vite": "^7.0.0"
   },
   "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca"
 }

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -9,6 +9,10 @@ import {
   MetadataSuggestionRequest,
   ColumnHelpInfo,
 } from '@/views/SubmissionPortal/types';
+import {
+  type DataHarmonizerData,
+  validatePlateWellsForJgi,
+} from '@/views/SubmissionPortal/validation';
 
 // a simple data structure to define the relationships between the GOLD ecosystem fields
 const GOLD_FIELDS = {
@@ -338,8 +342,31 @@ export default class HarmonizerApi {
     this.dh.setupTemplate(folder);
   }
 
+  setInvalidCell(row: number, slot: string, message: string) {
+    if (!this.dh.invalid_cells[row]) {
+      this.dh.invalid_cells[row] = {};
+    }
+    const slotInfo = this.slotInfo.get(slot);
+    if (!slotInfo) {
+      console.warn(`Attempted to add invalid cell for unknown slot ${slot}`);
+      return;
+    }
+    const col = slotInfo.columnIndex;
+    this.dh.invalid_cells[row][col] = message;
+  }
+
+  doCustomValidation() {
+    // Our own custom validation that is beyond the schema-level validation that DataHarmonizer performs.
+    const data: DataHarmonizerData = this.dh.getDataObjects();
+    validatePlateWellsForJgi(data).forEach((issue) => {
+      this.setInvalidCell(issue.row, issue.slot, issue.message);
+    });
+  }
+
+
   async validate() {
     await this.dh.validate();
+    this.doCustomValidation();
     this.refreshState();
     return this.dh.invalid_cells;
   }

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -38,6 +38,8 @@ const GOLD_FIELDS = {
   },
 };
 
+export type InvalidCells = Record<number, Record<number, string>>;
+
 export default class HarmonizerApi {
   schemaSectionNames: Ref<Record<string, string>>;
 
@@ -200,6 +202,9 @@ export default class HarmonizerApi {
     }, 200, { leading: true }));
     this.dh.hot.updateSettings({
       search: true,
+      comments: {
+        readOnly: true,
+      },
       customBorders: true,
       height: '100%',
       width: '100%',
@@ -342,7 +347,15 @@ export default class HarmonizerApi {
     this.dh.setupTemplate(folder);
   }
 
-  setInvalidCell(row: number, slot: string, message: string) {
+  /**
+   * Mark a cell as invalid by adding an entry to the `invalid_cells` object in the DataHarmonizer instance.
+   *
+   * @param row
+   * @param slot
+   * @param message
+   * @private
+   */
+  private setInvalidCell(row: number, slot: string, message: string) {
     if (!this.dh.invalid_cells[row]) {
       this.dh.invalid_cells[row] = {};
     }
@@ -355,8 +368,52 @@ export default class HarmonizerApi {
     this.dh.invalid_cells[row][col] = message;
   }
 
-  doCustomValidation() {
-    // Our own custom validation that is beyond the schema-level validation that DataHarmonizer performs.
+  /**
+   * Private method to clear comments from all cells that are currently marked as invalid in the DataHarmonizer
+   * instance. This method should be called before any operation that may change the validity of cells.
+   *
+   * @private
+   */
+  private clearCommentsForInvalidCells() {
+    const commentsPlugin = this.dh.hot.getPlugin('comments');
+    Object.entries(this.dh.invalid_cells as InvalidCells).forEach(([rowStr, cols]) => {
+      const row = parseInt(rowStr, 10);
+      Object.entries(cols).forEach(([colStr, _]) => {
+        const col = parseInt(colStr, 10);
+        // `false` here means "don't re-render after removing the comment." We'll do a single render at the end.
+        commentsPlugin.removeCommentAtCell(row, col, false);
+      });
+    });
+    this.dh.hot.render();
+  }
+
+  /**
+   * Private method to set comments on all cells that are currently marked as invalid in the DataHarmonizer instance,
+   * with the comment text set to the corresponding error message. This method should be called after any operation
+   * that may have changed the validity of cells, and after `_clearCommentsForInvalidCells` has been called to clear
+   * out old comments.
+   *
+   * @private
+   */
+  private setCommentsForInvalidCells() {
+    const commentsPlugin = this.dh.hot.getPlugin('comments');
+    Object.entries(this.dh.invalid_cells as InvalidCells).forEach(([rowStr, cols]) => {
+      const row = parseInt(rowStr, 10);
+      Object.entries(cols).forEach(([colStr, message]) => {
+        const col = parseInt(colStr, 10);
+        commentsPlugin.updateCommentMeta(row, col, { value: message, readOnly: true });
+      });
+    });
+    this.dh.hot.render();
+  }
+
+  /**
+   * Private method to perform custom validation logic on the data in the DataHarmonizer instance. This method should be
+   * called as part of the overall validation process after the DataHarmonizer's built-in validation has been performed.
+   *
+   * @private
+   */
+  private doCustomValidation() {
     const data: DataHarmonizerData = this.dh.getDataObjects();
     validatePlateWellsForJgi(data).forEach((issue) => {
       this.setInvalidCell(issue.row, issue.slot, issue.message);
@@ -364,9 +421,15 @@ export default class HarmonizerApi {
   }
 
 
+  /**
+   * Validate the data in the DataHarmonizer instance by applying both the DataHarmonizer's built-in validation logic
+   * and any custom validation logic.
+   */
   async validate() {
+    this.clearCommentsForInvalidCells();
     await this.dh.validate();
     this.doCustomValidation();
+    this.setCommentsForInvalidCells();
     this.refreshState();
     return this.dh.invalid_cells;
   }
@@ -436,7 +499,9 @@ export default class HarmonizerApi {
   }
 
   setInvalidCells(invalidCells: Record<number, Record<number, string>>) {
+    this.clearCommentsForInvalidCells();
     this.dh.invalid_cells = invalidCells;
+    this.setCommentsForInvalidCells();
     this.dh.hot.render();
   }
 

--- a/web/src/views/SubmissionPortal/validation.test.ts
+++ b/web/src/views/SubmissionPortal/validation.test.ts
@@ -13,6 +13,18 @@ describe('validatePlateWellsForJgi', () => {
     expect(issues).toEqual([]);
   });
 
+  it('flags rows with no well ID', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: '' },
+      { cont_type: 'plate', container_name: 'plate-1' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Plate position is required if container type is "plate"' },
+      { row: 1, slot: 'cont_well', message: 'Plate position is required if container type is "plate"' },
+    ]);
+  });
+
   it('flags invalid well IDs', () => {
     const issues = validatePlateWellsForJgi([
       { cont_type: 'plate', container_name: 'plate-1', cont_well: 'Z99' },
@@ -72,11 +84,11 @@ describe('validatePlateWellsForJgi', () => {
     ]);
   });
 
-  it('ignores non-plate rows and blank wells', () => {
+  it('ignores non-plate rows', () => {
     const issues = validatePlateWellsForJgi([
       { cont_type: 'tube', container_name: 'tube-1', cont_well: 'Z99' },
-      { cont_type: 'plate', container_name: 'plate-1', cont_well: '' },
-      { cont_type: 'plate', container_name: 'plate-1' },
+      { cont_type: 'tube', container_name: 'tube-2', cont_well: '' },
+      { cont_type: 'tube', container_name: 'tube-3' },
     ]);
 
     expect(issues).toEqual([]);

--- a/web/src/views/SubmissionPortal/validation.test.ts
+++ b/web/src/views/SubmissionPortal/validation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { validatePlateWellsForJgi } from './validation';
+
+describe('validatePlateWellsForJgi', () => {
+  it('returns no issues for sequential non-corner wells starting at B1', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'B1' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'C1' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'D1' },
+    ]);
+
+    expect(issues).toEqual([]);
+  });
+
+  it('flags invalid well IDs', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'Z99' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Invalid well ID' },
+    ]);
+  });
+
+  it('flags corner wells', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'A1' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Corner wells are not allowed' },
+    ]);
+  });
+
+  it('flags duplicate wells on the same plate for both rows', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'B1' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'B1' },
+      { cont_type: 'plate', container_name: 'plate-2', cont_well: 'B1' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Well IDs must be unique on a given plate' },
+      { row: 1, slot: 'cont_well', message: 'Well IDs must be unique on a given plate' },
+    ]);
+  });
+
+  it('flags a plate whose first populated well is not B1', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'C1' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'D1' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Plates must be filled starting with well B1' },
+    ]);
+  });
+
+  it('flags the last good row when there is a gap in fill order', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'B1' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'D1' },
+    ]);
+
+    expect(issues).toEqual([
+      {
+        row: 0,
+        slot: 'cont_well',
+        message: 'Plates must be filled in column order. Subsequent well is not filled',
+      },
+    ]);
+  });
+
+  it('ignores non-plate rows and blank wells', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'tube', container_name: 'tube-1', cont_well: 'Z99' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: '' },
+      { cont_type: 'plate', container_name: 'plate-1' },
+    ]);
+
+    expect(issues).toEqual([]);
+  });
+
+  it('can return multiple issues for the same row', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'A1' },
+      { cont_type: 'plate', container_name: 'plate-1', cont_well: 'A1' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Corner wells are not allowed' },
+      { row: 1, slot: 'cont_well', message: 'Corner wells are not allowed' },
+      { row: 0, slot: 'cont_well', message: 'Well IDs must be unique on a given plate' },
+      { row: 1, slot: 'cont_well', message: 'Well IDs must be unique on a given plate' },
+    ]);
+  });
+});

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -4,7 +4,7 @@
  *
  * In general, DataHarmonizer's built-in LinkML-based validation should be
  * relied on as much as possible. This means adding constraints (e.g. `pattern`,
- * `required`, `minimum_value`, etc) to `nmdc-submission-schema`. However, in
+ * `required`, `minimum_value`, etc.) to `nmdc-submission-schema`. However, in
  * cases where validation logic is too complex to be expressed in LinkML,
  * custom validation functions can be added here and called in
  * `HarmonizerApi.doCustomValidation`.
@@ -20,6 +20,10 @@ export type ValidationIssue = {
   message: string,
 }
 
+// Constants related to 96-well plates used by validatePlateWellsForJgi
+// See:
+// - https://en.wikipedia.org/wiki/Microplate
+// - https://commons.wikimedia.org/wiki/File:96-Well_plate.svg
 const PLATE_ROWS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 const PLATE_COLS = Array.from({ length: 12 }, (_, i) => (i + 1).toString());
 const VALID_WELL_ORDER = PLATE_COLS.map((col) => PLATE_ROWS.map((row) => `${row}${col}`)).flat();

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -44,6 +44,9 @@ function getTrimmedString(value: string | number | string[] | undefined) {
  *   filled in column order without gaps (e.g. if C1 is filled, B1 must also be
  *   filled).
  *
+ * See:
+ * - https://jgi.doe.gov/sites/default/files/2025-01/OC_Sequencing_SampleOverview_PlateGuidelines_0.pdf
+ *
  * @param data - The data of the current DataHarmonizer tab to validate
  * @returns An array of validation issues
  */

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -1,3 +1,15 @@
+/**
+ * This file contains custom validation logic to be used in conjunction with
+ * DataHarmonizer.
+ *
+ * In general, DataHarmonizer's built-in LinkML-based validation should be
+ * relied on as much as possible. This means adding constraints (e.g. `pattern`,
+ * `required`, `minimum_value`, etc) to `nmdc-submission-schema`. However, in
+ * cases where validation logic is too complex to be expressed in LinkML,
+ * custom validation functions can be added here and called in
+ * `HarmonizerApi.doCustomValidation`.
+ */
+
 export type DataHarmonizerRow = Record<string, string | number | string[]>
 
 export type DataHarmonizerData = DataHarmonizerRow[]
@@ -18,6 +30,19 @@ function getTrimmedString(value: string | number | string[] | undefined) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+/**
+ * Validates that for rows with `cont_type` of "plate", the `cont_well` values
+ * are valid and follow JGI's plate filling rules:
+ * - Valid well IDs are A1-H12, but corner wells (A1, A12, H1, H12) are not
+ *   allowed.
+ * - Well IDs must be unique on a given plate (i.e. same `container_name`).
+ * - For each plate, the first populated well must be B1, and wells must be
+ *   filled in column order without gaps (e.g. if C1 is filled, B1 must also be
+ *   filled).
+ *
+ * @param data - The data of the current DataHarmonizer tab to validate
+ * @returns An array of validation issues
+ */
 export function validatePlateWellsForJgi(data: DataHarmonizerData): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const validWellSet = new Set(VALID_WELL_ORDER);

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -1,0 +1,118 @@
+export type DataHarmonizerRow = Record<string, string | number | string[]>
+
+export type DataHarmonizerData = DataHarmonizerRow[]
+
+export type ValidationIssue = {
+  row: number,
+  slot: string,
+  message: string,
+}
+
+const PLATE_ROWS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+const PLATE_COLS = Array.from({ length: 12 }, (_, i) => (i + 1).toString());
+const VALID_WELL_ORDER = PLATE_COLS.map((col) => PLATE_ROWS.map((row) => `${row}${col}`)).flat();
+const CORNER_WELLS = ['A1', 'A12', 'H1', 'H12'];
+const CONT_WELL_SLOT = 'cont_well';
+
+function getTrimmedString(value: string | number | string[] | undefined) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function validatePlateWellsForJgi(data: DataHarmonizerData): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const validWellSet = new Set(VALID_WELL_ORDER);
+  const fillableWellOrder = VALID_WELL_ORDER.filter((well) => !CORNER_WELLS.includes(well));
+  const fillableWellIndex = new Map(fillableWellOrder.map((well, index) => [well, index]));
+  const duplicateWellRows = new Map<string, number[]>();
+  const rowsByContainer = new Map<string, { rowIndex: number, contWell: string }[]>();
+
+  data.forEach((row, rowIndex) => {
+    const contType = getTrimmedString(row.cont_type);
+    if (contType !== 'plate') {
+      return;
+    }
+
+    const contWell = getTrimmedString(row.cont_well);
+    if (!contWell) {
+      return;
+    }
+
+    const containerName = getTrimmedString(row.container_name);
+
+    if (!validWellSet.has(contWell)) {
+      issues.push({ row: rowIndex, slot: CONT_WELL_SLOT, message: 'Invalid well ID' });
+    }
+
+    if (CORNER_WELLS.includes(contWell)) {
+      issues.push({ row: rowIndex, slot: CONT_WELL_SLOT, message: 'Corner wells are not allowed' });
+    }
+
+    const duplicateKey = `${containerName}::${contWell}`;
+    const duplicateRows = duplicateWellRows.get(duplicateKey) || [];
+    duplicateRows.push(rowIndex);
+    duplicateWellRows.set(duplicateKey, duplicateRows);
+
+    if (!fillableWellIndex.has(contWell)) {
+      return;
+    }
+
+    const containerRows = rowsByContainer.get(containerName) || [];
+    containerRows.push({ rowIndex, contWell });
+    rowsByContainer.set(containerName, containerRows);
+  });
+
+  duplicateWellRows.forEach((rowIndexes) => {
+    if (rowIndexes.length < 2) {
+      return;
+    }
+    rowIndexes.forEach((rowIndex) => {
+      issues.push({ row: rowIndex, slot: CONT_WELL_SLOT, message: 'Well IDs must be unique on a given plate' });
+    });
+  });
+
+  rowsByContainer.forEach((containerRows) => {
+    if (containerRows.length === 0) {
+      return;
+    }
+
+    const sortedRows = [...containerRows].sort(
+      (a, b) => fillableWellIndex.get(a.contWell)! - fillableWellIndex.get(b.contWell)!,
+    );
+    const uniqueSortedRows = sortedRows.filter(
+      (row, index) => index === 0 || row.contWell !== sortedRows[index - 1]?.contWell,
+    );
+
+    const firstRow = uniqueSortedRows[0];
+    if (!firstRow) {
+      return;
+    }
+
+    if (firstRow.contWell !== 'B1') {
+      issues.push({
+        row: firstRow.rowIndex,
+        slot: CONT_WELL_SLOT,
+        message: 'Plates must be filled starting with well B1',
+      });
+    }
+
+    for (let i = 1; i < uniqueSortedRows.length; i += 1) {
+      const previousRow = uniqueSortedRows[i - 1];
+      const currentRow = uniqueSortedRows[i];
+      if (!previousRow || !currentRow) {
+        continue;
+      }
+      const previousIndex = fillableWellIndex.get(previousRow.contWell)!;
+      const currentIndex = fillableWellIndex.get(currentRow.contWell)!;
+
+      if (currentIndex !== previousIndex + 1) {
+        issues.push({
+          row: previousRow.rowIndex,
+          slot: CONT_WELL_SLOT,
+          message: 'Plates must be filled in column order. Subsequent well is not filled',
+        });
+      }
+    }
+  });
+
+  return issues;
+}

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -62,7 +62,8 @@ export function validatePlateWellsForJgi(data: DataHarmonizerData): ValidationIs
     }
 
     const contWell = getTrimmedString(row.cont_well);
-    if (!contWell) {
+    if (contWell === '') {
+      issues.push({ row: rowIndex, slot: CONT_WELL_SLOT, message: 'Plate position is required if container type is "plate"' });
       return;
     }
 

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -1,7 +1,6 @@
 {
   "extends": "./node_modules/@vue/tsconfig/tsconfig.dom.json",
   "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -4419,21 +4419,7 @@ vite-plugin-vuetify@^2.1.2:
     debug "^4.3.3"
     upath "^2.0.1"
 
-"vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^7.0.0:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.5.tgz#90c2d0b7b94a224e7e7dcf22d2912ff0b5291165"
-  integrity sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==
-  dependencies:
-    esbuild "^0.27.0"
-    fdir "^6.5.0"
-    picomatch "^4.0.3"
-    postcss "^8.5.6"
-    rollup "^4.43.0"
-    tinyglobby "^0.2.15"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@^7.3.2:
+vite@7.3.2, "vite@^6.0.0 || ^7.0.0 || ^8.0.0":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.2.tgz#cb041794d4c1395e28baea98198fd6e8f4b96b5c"
   integrity sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1073,6 +1073,11 @@
     "@sentry/browser" "10.24.0"
     "@sentry/core" "10.24.0"
 
+"@standard-schema/spec@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@stylistic/eslint-plugin@^5.3.1":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz#4cd51beb5602a8978a9a956c3568180efffcabe5"
@@ -1089,6 +1094,19 @@
   version "22.0.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node22/-/node22-22.0.2.tgz#1e04e2c5cc946dac787d69bb502462a851ae51b6"
   integrity sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==
+
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/estree@1.0.8", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.8"
@@ -1247,6 +1265,66 @@
   integrity sha512-+MaE752hU0wfPFJEUAIxqw18+20euHHdxVtMvbFcOEpjEyfqXH/5DCoTHiVJ0J29EhTJdoTkjEv5YBKU9dnoTw==
   dependencies:
     "@rolldown/pluginutils" "1.0.0-beta.29"
+
+"@vitest/expect@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-4.1.8.tgz#45154f1f8559f55c5281eb0dcb1ac37b581a87d8"
+  integrity sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==
+  dependencies:
+    "@standard-schema/spec" "^1.1.0"
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "4.1.8"
+    "@vitest/utils" "4.1.8"
+    chai "^6.2.2"
+    tinyrainbow "^3.1.0"
+
+"@vitest/mocker@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-4.1.8.tgz#d006bfc5894a1af51e74deddef2535d6bd436b16"
+  integrity sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==
+  dependencies:
+    "@vitest/spy" "4.1.8"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.21"
+
+"@vitest/pretty-format@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-4.1.8.tgz#d9d2e248b900d7ad9556c4374fcdf1871c615193"
+  integrity sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==
+  dependencies:
+    tinyrainbow "^3.1.0"
+
+"@vitest/runner@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-4.1.8.tgz#4631808f3996359b74ccc3ca262990e14c295d50"
+  integrity sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==
+  dependencies:
+    "@vitest/utils" "4.1.8"
+    pathe "^2.0.3"
+
+"@vitest/snapshot@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-4.1.8.tgz#37470135d64ea11bb2a839b1c6b7f5de7018f6ee"
+  integrity sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==
+  dependencies:
+    "@vitest/pretty-format" "4.1.8"
+    "@vitest/utils" "4.1.8"
+    magic-string "^0.30.21"
+    pathe "^2.0.3"
+
+"@vitest/spy@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-4.1.8.tgz#3abfe9301d25c39f808dcaa9f10fec0dd370e564"
+  integrity sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==
+
+"@vitest/utils@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-4.1.8.tgz#099ea5255cec08735410cf707edaba2c158c5ad9"
+  integrity sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==
+  dependencies:
+    "@vitest/pretty-format" "4.1.8"
+    convert-source-map "^2.0.0"
+    tinyrainbow "^3.1.0"
 
 "@volar/language-core@2.4.23":
   version "2.4.23"
@@ -1515,6 +1593,11 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 ast-kit@^2.1.1, ast-kit@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ast-kit/-/ast-kit-2.1.2.tgz#167da747afd8bdf3762c702bdc436376100332be"
@@ -1733,6 +1816,11 @@ cfb@^1.1.4, cfb@~1.2.1:
   dependencies:
     adler-32 "~1.3.0"
     crc-32 "~1.2.0"
+
+chai@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-6.2.2.tgz#ae41b52c9aca87734505362717f3255facda360e"
+  integrity sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -2276,6 +2364,11 @@ es-errors@^1.3.0:
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
+es-module-lexer@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-2.1.0.tgz#1dfcbb5ea3bbfb63f28e1fc3676c3676d1c9624c"
+  integrity sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -2617,6 +2710,13 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -2626,6 +2726,11 @@ exit-on-epipe@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
   integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
+
+expect-type@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 exsolve@^1.0.7:
   version "1.0.7"
@@ -3207,7 +3312,7 @@ magic-string@^0.30.17, magic-string@^0.30.19, magic-string@^0.30.3:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-magic-string@~0.30.8:
+magic-string@^0.30.21, magic-string@~0.30.8:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -3435,6 +3540,11 @@ object-code@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/object-code/-/object-code-2.0.0.tgz#251754cb38abca927e0844f50e8184e3ed45c386"
   integrity sha512-qOwMF43O/VAD51nJAB7MKsf1yWksql6O1i0DHRo1yaOQM6xJQH0NAE9UKJzYB7lyKw1jnpeb2BmB8qakjxiYZA==
+
+obug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.1.tgz#2cba74ff241beb77d63055ddf4cd1e9f90b538be"
+  integrity sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==
 
 ohash@^2.0.11:
   version "2.0.11"
@@ -3998,6 +4108,11 @@ sifter@^0.5.4:
     humanize "^0.0.9"
     optimist "^0.6.1"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -4014,6 +4129,16 @@ ssf@~0.11.2:
   integrity sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==
   dependencies:
     frac "~1.1.2"
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^4.0.0-rc.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
+  integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
 
 strip-indent@^4.0.0:
   version "4.1.0"
@@ -4071,10 +4196,20 @@ tiny-emitter@^2.1.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
 tinyexec@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.1.tgz#70c31ab7abbb4aea0a24f55d120e5990bfa1e0b1"
   integrity sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==
+
+tinyexec@^1.0.2:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.2.4.tgz#ae45bb2edebda94c70f4ea897e0f1243e470db71"
+  integrity sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==
 
 tinyglobby@^0.2.14, tinyglobby@^0.2.15:
   version "0.2.15"
@@ -4083,6 +4218,11 @@ tinyglobby@^0.2.14, tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.3"
+
+tinyrainbow@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz#1d8a623893f95cf0a2ddb9e5d11150e191409421"
+  integrity sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -4279,6 +4419,20 @@ vite-plugin-vuetify@^2.1.2:
     debug "^4.3.3"
     upath "^2.0.1"
 
+"vite@^6.0.0 || ^7.0.0 || ^8.0.0", vite@^7.0.0:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.5.tgz#90c2d0b7b94a224e7e7dcf22d2912ff0b5291165"
+  integrity sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==
+  dependencies:
+    esbuild "^0.27.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.2.tgz#cb041794d4c1395e28baea98198fd6e8f4b96b5c"
@@ -4292,6 +4446,32 @@ vite@^7.3.2:
     tinyglobby "^0.2.15"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@^4.1.7:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.8.tgz#9fed17277bf7350497e54338898a7afd46dfd509"
+  integrity sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==
+  dependencies:
+    "@vitest/expect" "4.1.8"
+    "@vitest/mocker" "4.1.8"
+    "@vitest/pretty-format" "4.1.8"
+    "@vitest/runner" "4.1.8"
+    "@vitest/snapshot" "4.1.8"
+    "@vitest/spy" "4.1.8"
+    "@vitest/utils" "4.1.8"
+    es-module-lexer "^2.0.0"
+    expect-type "^1.3.0"
+    magic-string "^0.30.21"
+    obug "^2.1.1"
+    pathe "^2.0.3"
+    picomatch "^4.0.3"
+    std-env "^4.0.0-rc.1"
+    tinybench "^2.9.0"
+    tinyexec "^1.0.2"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.1.0"
+    vite "^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running "^2.3.0"
 
 vscode-uri@^3.0.8:
   version "3.1.0"
@@ -4392,6 +4572,14 @@ which@^5.0.0:
   integrity sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==
   dependencies:
     isexe "^3.1.1"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 wikibase-sdk@^7.14.4:
   version "7.15.0"


### PR DESCRIPTION
Fixes #2154 

These changes implement JGI's rules for 96-well plate filling. The core logic is in the function `validatePlateWellsForJgi` in the new module `web/src/views/SubmissionPortal/validation.ts`. This new module is intended to be a place where any validation logic that is too complex to be expressed in LinkML (i.e. in `nmdc-submission-schema`) can live. The new function is invoked via the existing `HarmonizerApi.validate` method.

Because this logic can (and should!) be tested outside of any UI components, I also added unit tests in `web/src/views/SubmissionPortal/validation.test.ts`. Previously the frontend code had no tests whatsoever 😬, so these changes also add [Vitest](https://vitest.dev/) as a testing framework. This was a fairly low-impact addition since we're already using Vite. However, Yarn 1.x struggles to resolve `vite` as a peer dependency of `vitest`. The workaround is to add a `resolutions` entry in `package.json`. (Incidentally, I'm not sure if Yarn really improves our lives in any meaningful way, and Yarn 1.x hasn't been updated in years. I'd be in favor of moving to either `npm` or `pnpm` at some point.) 

Finally, this validation logic can surface a number of different messages regarding why a given `cont_well` value may be invalid. As a quality-of-life improvement for users I added a small change here that surfaces those validation messages as comments on the DataHarmonizer cells.