### PR TITLE
Disable job that restarts Spin-hosted deployments via Rancher API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,16 @@ jobs:
 
   # Use the Rancher API to redeploy the specified deployments,
   # causing them to use the newly-pushed container images.
+  #
+  # Note: 🚫 This job is intentionally disabled via `if: ${{ false }}`.
+  #          It may be removed entirely in a future commit.
+  #
+  # Note: This `redeploy` job is the Spin counterpart to the subsequently-added `restart-dev-deployments` job below.
+  #       TODO: Standardize the jobs' names, if we keep this `redeploy` job long term.
+  #
   redeploy:
+    if: ${{ false }}
+
     needs: build
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
On this branch, I updated the `.github/workflows/deploy.yml` GHA workflow that builds container images and restarts workflows (on Spin and GKE), so that it no longer restart workloads on Spin. It still restarts them on GKE.

Nowadays, we host things on GKE instead of Spin. Attempting to restart workloads on Spin causes the job (and its containing workflow) to fail. That triggers a notification to the committer, and causes the GitHub UI to show a red icon next to the workflow run, both of which degrade the "developer experience."

Fixes #2178

This is the `nmdc-server` analogue to the following `nmdc-runtime` PR: https://github.com/microbiomedata/nmdc-runtime/pull/1522