### PR TITLE
Add SubmissionSampleSet to post-ingest copy step

### DIFF
--- a/nmdc_server/jobs.py
+++ b/nmdc_server/jobs.py
@@ -136,6 +136,7 @@ def do_ingest(function_limit, skip_annotation) -> Dict[str, ETLReport]:
                 merge_download_artifact(ingest_db, prod_db.query(models.SubmissionImagesObject))
                 merge_download_artifact(ingest_db, prod_db.query(models.SubmissionMetadata))
                 merge_download_artifact(ingest_db, prod_db.query(models.SubmissionRole))
+                merge_download_artifact(ingest_db, prod_db.query(models.SubmissionSampleSet))
 
     logger.info("Ingest finished successfully")
 


### PR DESCRIPTION
Follow-on to https://github.com/microbiomedata/nmdc-server/pull/2148

Missed this when the `submission_sample_set` table was originally introduced. Without this the table remained empty after ingest.