### PR TITLE
Implement condensed tab layout and new URL params

### DIFF
--- a/web/src/colors.js
+++ b/web/src/colors.js
@@ -7,6 +7,7 @@ const orangeLight = '#EEA359';
 const orangeLighter = '#EEC295';
 const green = colors.lightGreen.darken2;
 const blue = '#00AAE7';
+const blueLight = '#5CD3FF';
 const blueDark = '#0087B8';
 const blueDarker = '#004B66';
 const purple = '#4F3B80';
@@ -29,8 +30,8 @@ export default {
   accent: orange,
   link: purple,
   visited: purpleLight,
-  visualization: orangeLight,
-  visualizationLight: orangeLighter,
+  visualization: blue,
+  visualizationLight: blueLight,
   aquatic: blue,
   terrestrial: green,
   hostAssociated: red,

--- a/web/src/colors.js
+++ b/web/src/colors.js
@@ -3,6 +3,8 @@ import colors from 'vuetify/lib/util/colors';
 const red = '#ED5338';
 const red2 = '#ff5252'
 const orange = '#E88320';
+const orangeLight = '#EEA359';
+const orangeLighter = '#EEC295';
 const green = colors.lightGreen.darken2;
 const blue = '#00AAE7';
 const blueDark = '#0087B8';
@@ -13,6 +15,8 @@ const purpleLight = '#7D6FA1';
 export default {
   red,
   orange,
+  orangeLight,
+  orangeLighter,
   green,
   blue,
   blueDark,
@@ -25,6 +29,8 @@ export default {
   accent: orange,
   link: purple,
   visited: purpleLight,
+  visualization: orangeLight,
+  visualizationLight: orangeLighter,
   aquatic: blue,
   terrestrial: green,
   hostAssociated: red,

--- a/web/src/components.d.ts
+++ b/web/src/components.d.ts
@@ -39,6 +39,7 @@ declare module 'vue' {
     FilterList: typeof import('./components/Presentation/FilterList.vue')['default']
     FilterSankeyTree: typeof import('./components/FilterSankeyTree.vue')['default']
     FilterTree: typeof import('./components/FilterTree.vue')['default']
+    HelpWrapper: typeof import('./components/HelpWrapper.vue')['default']
     LoadingOverlay: typeof import('./components/LoadingOverlay.vue')['default']
     MenuContent: typeof import('./components/MenuContent.vue')['default']
     OrcidId: typeof import('./components/Presentation/OrcidId.vue')['default']

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -50,11 +50,12 @@ Icon.Default.mergeOptions({
 const props = withDefaults(defineProps<{
   conditions?: Condition[];
   height?: string | number;
-  visTab?: string | null;
+  /** The name of the currently active visualization tab */
+  activeVisTab?: string | null;
 }>(), {
   conditions: () => [],
   height: 360,
-  visTab: null,
+  activeVisTab: null,
 });
 
 const emit = defineEmits<{
@@ -84,7 +85,7 @@ const mapCenter = computed(() => {
 });
 
 async function getMapData() {
-  if (props.visTab !== VisualizationTabs.DataTypes) {
+  if (props.activeVisTab !== VisualizationTabs.DataTypes) {
     return;
   }
   const data = await request(() => api.getEnvironmentGeospatialAggregation(props.conditions));

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -27,6 +27,7 @@ import shadowurl from 'leaflet/dist/images/marker-shadow.png';
 import { api, Condition, EnvironmentGeospatialEntity } from '@/data/api';
 import useRequest from '@/use/useRequest';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
+import { VisualizationTabs } from '@/views/Search/types';
 
 /**
  * LEAFLET icon missing hack fix
@@ -83,7 +84,7 @@ const mapCenter = computed(() => {
 });
 
 async function getMapData() {
-  if (props.visTab !== 'data') {
+  if (props.visTab !== VisualizationTabs.DataTypes) {
     return;
   }
   const data = await request(() => api.getEnvironmentGeospatialAggregation(props.conditions));

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -49,7 +49,7 @@ Icon.Default.mergeOptions({
 const props = withDefaults(defineProps<{
   conditions?: Condition[];
   height?: number;
-  visTab?: number | null;
+  visTab?: string | null;
 }>(), {
   conditions: () => [],
   height: 360,
@@ -83,7 +83,7 @@ const mapCenter = computed(() => {
 });
 
 async function getMapData() {
-  if (props.visTab === 1) {
+  if (props.visTab !== 'data') {
     return;
   }
   const data = await request(() => api.getEnvironmentGeospatialAggregation(props.conditions));

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -48,7 +48,7 @@ Icon.Default.mergeOptions({
 
 const props = withDefaults(defineProps<{
   conditions?: Condition[];
-  height?: number;
+  height?: string | number;
   visTab?: string | null;
 }>(), {
   conditions: () => [],
@@ -216,10 +216,17 @@ watch([toRef(props, 'conditions')], () => {
     getMapData();
   }
 });
+
+watch(() => props.height, () => {
+  setTimeout(() => {
+    mapRef.value?.leafletObject?.invalidateSize(true);
+    mapRef.value?.leafletObject?.fitBounds(mapCenter.value);
+  }, 500);
+});
 </script>
 
 <template>
-  <div style="position: relative">
+  <div style="position: relative; width: 100%;">
     <LoadingOverlay
       :loading="loading"
       :error="errorMessage"
@@ -239,26 +246,30 @@ watch([toRef(props, 'conditions')], () => {
     >
       Search this region
     </v-btn>
-    <l-map
-      ref="mapRef"
-      :max-bounds="[[[-85, -180], [85, 180]]]"
+    <div
       :style="{
-        height: `${height}px`,
+        position: 'relative',
+        height: typeof height === 'string' ? height : `${height}px`,
         width: '100%',
         zIndex: 1,
       }"
-      @ready="onMapReady"
-      @update:bounds="mapProps.bounds = $event"
     >
-      <l-tile-layer
-        :url="mapProps.url"
-        :attribution="mapProps.attribution"
-        :options="{
-          maxZoom: 22,
-          maxNativeZoom: 18,
-        }"
-      />
-    </l-map>
+      <l-map
+        ref="mapRef"
+        :max-bounds="[[[-85, -180], [85, 180]]]"      
+        @ready="onMapReady"
+        @update:bounds="mapProps.bounds = $event"
+      >
+        <l-tile-layer
+          :url="mapProps.url"
+          :attribution="mapProps.attribution"
+          :options="{
+            maxZoom: 22,
+            maxNativeZoom: 18,
+          }"
+        />
+      </l-map>
+    </div>
   </div>
 </template>
 

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -27,7 +27,7 @@ import shadowurl from 'leaflet/dist/images/marker-shadow.png';
 import { api, Condition, EnvironmentGeospatialEntity } from '@/data/api';
 import useRequest from '@/use/useRequest';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
-import { VisualizationTabs } from '@/views/Search/types';
+import { VISUALIZATION_HEIGHT, VisualizationTabs } from '@/views/Search/types';
 
 /**
  * LEAFLET icon missing hack fix
@@ -54,7 +54,7 @@ const props = withDefaults(defineProps<{
   activeVisTab?: string | null;
 }>(), {
   conditions: () => [],
-  height: 360,
+  height: VISUALIZATION_HEIGHT,
   activeVisTab: null,
 });
 

--- a/web/src/components/ClusterMap.vue
+++ b/web/src/components/ClusterMap.vue
@@ -220,7 +220,9 @@ watch([toRef(props, 'conditions')], () => {
 watch(() => props.height, () => {
   setTimeout(() => {
     mapRef.value?.leafletObject?.invalidateSize(true);
-    mapRef.value?.leafletObject?.fitBounds(mapCenter.value);
+    if (mapData.value.length > 0 && mapCenter.value) {
+      mapRef.value?.leafletObject?.fitBounds(mapCenter.value);
+    }
   }, 500);
 });
 </script>

--- a/web/src/components/EcosystemSankey.vue
+++ b/web/src/components/EcosystemSankey.vue
@@ -63,12 +63,6 @@ const sankeyOptions = computed(() => {
   return {
     // Make the chart height dependent on the number of nodes with a minimum of 500px
     height: Math.max(dataLength * 4, 500),
-    chartArea: {
-      width: '80%',   // Width of the data area (relative to SVG container)
-      height: '80%',  // Height of the data area
-      top: 50,     // Internal padding from the top
-      left: 50     // Internal padding from the left
-    },
     sankey: {
       link: {
         colorMode: 'source',

--- a/web/src/components/EcosystemSankey.vue
+++ b/web/src/components/EcosystemSankey.vue
@@ -63,6 +63,12 @@ const sankeyOptions = computed(() => {
   return {
     // Make the chart height dependent on the number of nodes with a minimum of 500px
     height: Math.max(dataLength * 4, 500),
+    chartArea: {
+      width: '80%',   // Width of the data area (relative to SVG container)
+      height: '80%',  // Height of the data area
+      top: 50,     // Internal padding from the top
+      left: 50     // Internal padding from the left
+    },
     sankey: {
       link: {
         colorMode: 'source',

--- a/web/src/components/EcosystemSankey.vue
+++ b/web/src/components/EcosystemSankey.vue
@@ -73,7 +73,7 @@ const sankeyOptions = computed(() => {
         width: 12,
         // Array needs to be of substantial length so the lines do not become too pale to see
         // Uses 'primary' and primary.darken2 alternatingly
-        colors: Array.from({ length: dataLength / 2 }, (_, i) => (i % 2 === 0 ? colors.primary : '#1c104e')),
+        colors: Array.from({ length: dataLength / 2 }, (_, i) => (i % 2 === 0 ? colors.visualization : colors.visualizationLight)),
       },
     },
   };

--- a/web/src/components/FacetedSearch.vue
+++ b/web/src/components/FacetedSearch.vue
@@ -124,7 +124,7 @@ watch(() => filterText, (newVal) => {
 </script>
 
 <template>
-  <div>
+  <div class="pt-3">
     <v-tooltip
       v-model="showSearchHelp"
       location="bottom"

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const { text } = defineProps<{
+  text: string;
+}>();
+</script>
+
+<template>
+  <v-sheet
+    class="h-100"
+  >
+    <v-tooltip
+      location="left"
+      offset="20"
+      min-width="300px"
+      max-width="300px"
+    >
+      <template #activator="{ props }">
+        <v-icon
+          v-bind="props"
+          color="grey-darken-1"
+          style="position: absolute; right: 6px; top: 6px; z-index: 2;"
+        >
+          mdi-help-circle
+        </v-icon>
+      </template>
+      <span v-html="text" />
+    </v-tooltip>
+    <slot />
+  </v-sheet>
+</template>

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -41,7 +41,7 @@ const close = () => { isFullscreen.value = false; };
     to="body"
     :disabled="!isFullscreen"
   >
-    <v-card :class="['fullscreen-container', { 'fullscreen-container--fullscreen': isFullscreen }]">
+    <v-card :class="['fullscreen-container elevation-0', { 'fullscreen-container--fullscreen': isFullscreen }]">
       <div class="fullscreen-toolbar">
         <v-tooltip
           v-if="helpText"

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -1,30 +1,160 @@
 <script setup lang="ts">
-const { text } = defineProps<{
-  text: string;
-}>();
+import { ref } from 'vue';
+
+/**
+ * Component for wrapping visualizations and other panels that
+ * should have a help tooltip in the upper-right corner.
+ */
+const props = withDefaults(defineProps<{
+  /** If true, include a button to open this panel in a fullscreen modal */
+  allowFullscreen?: boolean;
+  /** Fixed height for the panel (if number, defaults to pixels) */
+  height?: string | number;
+  /** Text to show in the help tooltip */
+  helpText?: string | null;
+}>(), {
+  height: '360px',
+  helpText: null,
+});
+
+const isFullscreen = ref(false);
+const heightString = typeof props.height === 'string' ? props.height : `${props.height}px`;
+const toggle = () => {
+  isFullscreen.value = !isFullscreen.value;
+  window.dispatchEvent(new Event('resize'));
+};
+const close = () => { isFullscreen.value = false; };
 </script>
 
 <template>
-  <v-sheet
-    class="h-100"
+  <Teleport
+    v-if="allowFullscreen"
+    to="body"
   >
-    <v-tooltip
-      location="left"
-      offset="20"
-      min-width="300px"
-      max-width="300px"
-    >
-      <template #activator="{ props }">
-        <v-icon
-          v-bind="props"
-          color="grey-darken-1"
-          style="position: absolute; right: 6px; top: 6px; z-index: 2;"
+    <div
+      class="fullscreen-backdrop"
+      :class="{ 'fullscreen-backdrop--visible': isFullscreen }"
+      @click="close"
+    />
+  </Teleport>
+  <Teleport
+    to="body"
+    :disabled="!isFullscreen"
+  >
+    <v-card :class="['fullscreen-container', { 'fullscreen-container--fullscreen': isFullscreen }]">
+      <div class="fullscreen-toolbar">
+        <v-tooltip
+          v-if="helpText"
+          location="left"
+          offset="20"
+          min-width="300px"
+          max-width="300px"
+          :z-index="isFullscreen ? 2500 : undefined"
         >
-          mdi-help-circle
-        </v-icon>
-      </template>
-      <span v-html="text" />
-    </v-tooltip>
-    <slot />
-  </v-sheet>
+          <template #activator="{ props }">
+            <v-btn
+              v-bind="props"
+              icon="mdi-help-circle"
+              size="large"
+              variant="text"
+              color="grey-darken-1"
+              density="compact"
+            />
+          </template>
+          <span v-html="helpText" />
+        </v-tooltip>
+        <v-btn
+          v-if="allowFullscreen"
+          :icon="isFullscreen ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'"
+          size="x-large"
+          variant="text"
+          density="compact"
+          :title="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
+          @click="toggle"
+        />
+      </div>
+      <div
+        class="fullscreen-scroll-area"
+        :style="{ 
+          height: isFullscreen ? '90vh' : heightString,
+        }"
+      >
+        <slot 
+          :is-fullscreen="isFullscreen"
+          :toggle="toggle"
+        />
+      </div>
+    </v-card>
+  </Teleport>
 </template>
+
+<style scoped>
+.fullscreen-container {
+  position: relative;
+  width: 100%;
+}
+
+.fullscreen-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 4px;
+  min-height: 36px;
+  position: absolute;
+  top: 0;
+  right: 0.75rem;
+  z-index: 2;
+}
+
+.fullscreen-container--fullscreen .fullscreen-toolbar {
+  right: 0.25rem;
+}
+
+.fullscreen-title {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.fullscreen-scroll-area {
+  overflow-y: auto;
+  overflow-x: hidden;
+  width: 100%;
+}
+
+.fullscreen-container--fullscreen {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90vw;
+  height: 90vh;
+  z-index: 2400;
+  background: rgb(var(--v-theme-surface));
+  display: flex;
+  flex-direction: column;
+}
+
+.fullscreen-container--fullscreen .fullscreen-scroll-area {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.fullscreen-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2399;
+  background: #000;
+  opacity: 0;
+  pointer-events: none;
+  transition: 0.3s;
+}
+
+.fullscreen-backdrop--visible {
+  opacity: 0.32;
+  pointer-events: auto;
+}
+</style>

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -23,7 +23,10 @@ const toggle = () => {
   isFullscreen.value = !isFullscreen.value;
   window.dispatchEvent(new Event('resize'));
 };
-const close = () => { isFullscreen.value = false; };
+const close = () => {
+  isFullscreen.value = false;
+  window.dispatchEvent(new Event('resize'));
+};
 </script>
 
 <template>

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { VISUALIZATION_HEIGHT } from '@/views/Search/types';
 import { ref } from 'vue';
 
 /**
@@ -13,7 +14,7 @@ const props = withDefaults(defineProps<{
   /** Text to show in the help tooltip */
   helpText?: string | null;
 }>(), {
-  height: '360px',
+  height: VISUALIZATION_HEIGHT,
   helpText: null,
 });
 

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -51,9 +51,9 @@ const close = () => { isFullscreen.value = false; };
           max-width="300px"
           :z-index="isFullscreen ? 2500 : undefined"
         >
-          <template #activator="{ props }">
+          <template #activator="{ props: tooltipProps }">
             <v-btn
-              v-bind="props"
+              v-bind="tooltipProps"
               icon="mdi-help-circle"
               size="large"
               variant="text"

--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -30,65 +30,67 @@ const close = () => {
 </script>
 
 <template>
-  <Teleport
-    v-if="allowFullscreen"
-    to="body"
-  >
-    <div
-      class="fullscreen-backdrop"
-      :class="{ 'fullscreen-backdrop--visible': isFullscreen }"
-      @click="close"
-    />
-  </Teleport>
-  <Teleport
-    to="body"
-    :disabled="!isFullscreen"
-  >
-    <v-card :class="['fullscreen-container elevation-0', { 'fullscreen-container--fullscreen': isFullscreen }]">
-      <div class="fullscreen-toolbar">
-        <v-tooltip
-          v-if="helpText"
-          location="left"
-          offset="20"
-          min-width="300px"
-          max-width="300px"
-          :z-index="isFullscreen ? 2500 : undefined"
-        >
-          <template #activator="{ props: tooltipProps }">
-            <v-btn
-              v-bind="tooltipProps"
-              icon="mdi-help-circle"
-              size="large"
-              variant="text"
-              color="grey-darken-1"
-              density="compact"
-            />
-          </template>
-          <span v-html="helpText" />
-        </v-tooltip>
-        <v-btn
-          v-if="allowFullscreen"
-          :icon="isFullscreen ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'"
-          size="x-large"
-          variant="text"
-          density="compact"
-          :title="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
-          @click="toggle"
-        />
-      </div>
+  <div>
+    <Teleport
+      v-if="allowFullscreen"
+      to="body"
+    >
       <div
-        class="fullscreen-scroll-area"
-        :style="{ 
-          height: isFullscreen ? '90vh' : heightString,
-        }"
-      >
-        <slot 
-          :is-fullscreen="isFullscreen"
-          :toggle="toggle"
-        />
-      </div>
-    </v-card>
-  </Teleport>
+        class="fullscreen-backdrop"
+        :class="{ 'fullscreen-backdrop--visible': isFullscreen }"
+        @click="close"
+      />
+    </Teleport>
+    <Teleport
+      to="body"
+      :disabled="!isFullscreen"
+    >
+      <v-card :class="['fullscreen-container elevation-0', { 'fullscreen-container--fullscreen': isFullscreen }]">
+        <div class="fullscreen-toolbar">
+          <v-tooltip
+            v-if="helpText"
+            location="left"
+            offset="20"
+            min-width="300px"
+            max-width="300px"
+            :z-index="isFullscreen ? 2500 : undefined"
+          >
+            <template #activator="{ props: tooltipProps }">
+              <v-btn
+                v-bind="tooltipProps"
+                icon="mdi-help-circle"
+                size="large"
+                variant="text"
+                color="grey-darken-1"
+                density="compact"
+              />
+            </template>
+            <span v-html="helpText" />
+          </v-tooltip>
+          <v-btn
+            v-if="allowFullscreen"
+            :icon="isFullscreen ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'"
+            size="x-large"
+            variant="text"
+            density="compact"
+            :title="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
+            @click="toggle"
+          />
+        </div>
+        <div
+          class="fullscreen-scroll-area"
+          :style="{ 
+            height: isFullscreen ? '90vh' : heightString,
+          }"
+        >
+          <slot 
+            :is-fullscreen="isFullscreen"
+            :toggle="toggle"
+          />
+        </div>
+      </v-card>
+    </Teleport>
+  </div>
 </template>
 
 <style scoped>

--- a/web/src/components/LoadingOverlay.vue
+++ b/web/src/components/LoadingOverlay.vue
@@ -3,7 +3,7 @@
 const props = withDefaults(defineProps<{
   error?: string | null;
   loading?: boolean;
-  height: number;
+  height: string | number;
 }>(), {
   error: null,
   loading: false,
@@ -17,7 +17,7 @@ const props = withDefaults(defineProps<{
     :style="{
       position: 'absolute',
       zIndex: 2,
-      height: `${height}px`,
+      height: typeof height === 'string' ? height : `${height}px`,
       width: '100%',
       background: '#fff',
       opacity: 0.5,

--- a/web/src/components/Presentation/AppHeader.vue
+++ b/web/src/components/Presentation/AppHeader.vue
@@ -20,6 +20,7 @@ export default defineComponent({
 
 <template>
   <v-app-bar
+    tag="nav"
     class="navigation-button-text-animate"
     color="white"
     :height="APP_HEADER_HEIGHT"
@@ -84,6 +85,7 @@ export default defineComponent({
           <v-list-item
             v-for="item in menu.items"
             :key="item.label"
+            class="nav-link"
             :href="item.href"
             :to="item.to"
             :ripple="false"

--- a/web/src/components/Presentation/ChartContainer.vue
+++ b/web/src/components/Presentation/ChartContainer.vue
@@ -69,3 +69,9 @@ export default defineComponent({
     />
   </div>
 </template>
+
+<style scoped>
+svg {
+  display: block;
+}
+</style>

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -111,16 +111,9 @@ watch(() => props.myConditions, () => {
       <template #default="{ width }">
         <TimeHistogram
           ref="histogram"
-          v-bind="{ width, height, selectedData: facetSummary, totalData: facetSummaryUnconditional, range: range || [] }"
+          v-bind="{ width, height, selectedData: facetSummary, totalData: facetSummaryUnconditional, range: range || [], xAxisLabel: 'Collection Date' }"
           @on-brush-end="onBrushEnd"
         />
-      </template>
-      <template #below>
-        <div class="mx-4 d-flex">
-          <v-spacer />
-          <h4>Collection Date</h4>
-          <v-spacer />
-        </div>
       </template>
     </ChartContainer>
     <div

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -115,20 +115,22 @@ watch(() => props.myConditions, () => {
           @on-brush-end="onBrushEnd"
         />
       </template>
-      <!-- <template #below>
+      <template #below>
         <div class="mx-4 d-flex">
           <v-spacer />
           <h4>Collection Date</h4>
           <v-spacer />
         </div>
-      </template> -->
+      </template>
     </ChartContainer>
     <div
       v-else-if="!loading && facetSummaryUnconditional"
       class="d-flex align-center justify-center"
       :style="{ height: `${height}px` }"
     >
-      <p class="text-grey">No results for this search</p>
+      <p class="text-grey">
+        No results for this search
+      </p>
     </div>
   </div>
 </template>

--- a/web/src/components/Presentation/DateHistogram.vue
+++ b/web/src/components/Presentation/DateHistogram.vue
@@ -115,13 +115,13 @@ watch(() => props.myConditions, () => {
           @on-brush-end="onBrushEnd"
         />
       </template>
-      <template #below>
+      <!-- <template #below>
         <div class="mx-4 d-flex">
           <v-spacer />
           <h4>Collection Date</h4>
           <v-spacer />
         </div>
-      </template>
+      </template> -->
     </ChartContainer>
     <div
       v-else-if="!loading && facetSummaryUnconditional"

--- a/web/src/components/Presentation/FacetBarChart.vue
+++ b/web/src/components/Presentation/FacetBarChart.vue
@@ -89,17 +89,19 @@ const chartData = computed(() => {
           const excludedCount = facet.count - ((currentFacetSummary.find(
             (e) => e.facet === facet.facet,
           ) || {}).count || 0);
+          const matchColor = count > 0 ? (
+            ecosystems.find((e) => e.name === facet.facet)
+            || { color: theme.current.value.colors.visualization }
+          ).color : 'lightgray';
+          const noMatchColor = excludedCount > 0 ? 'lightgray' : 'transparent';
           return [
             fieldDisplayName(facet.facet),
             count,
             true,
-            count > 0 ? (
-              ecosystems.find((e) => e.name === facet.facet)
-              || { color: theme.current.value.colors.visualization }
-            ).color : 'lightgray',
+            `color: ${matchColor}; stroke-width: 0; stroke-color: transparent`,
             excludedCount,
             false,
-            excludedCount > 0 ? 'lightgray' : theme.current.value.colors.primary,
+            `color: ${noMatchColor}; stroke-width: 0; stroke-color: transparent`,
             count > 0 ? `${count}` : 'No match',
           ];
         },
@@ -136,7 +138,7 @@ const barChartOptions = computed(() => ({
     },
   },
   legend: { position: 'none' },
-  annotations: { alwaysOutside: true, stem: { color: 'transparent' } },
+  annotations: { alwaysOutside: true, stem: { color: 'transparent' }, textStyle: { color: 'black' } },
   title: props.showTitle ? fieldDisplayName(props.field) : null,
   isStacked: true,
 }));

--- a/web/src/components/Presentation/FacetBarChart.vue
+++ b/web/src/components/Presentation/FacetBarChart.vue
@@ -89,19 +89,17 @@ const chartData = computed(() => {
           const excludedCount = facet.count - ((currentFacetSummary.find(
             (e) => e.facet === facet.facet,
           ) || {}).count || 0);
-          const matchColor = count > 0 ? (
-            ecosystems.find((e) => e.name === facet.facet)
-            || { color: theme.current.value.colors.visualization }
-          ).color : 'lightgray';
-          const noMatchColor = excludedCount > 0 ? 'lightgray' : 'transparent';
           return [
             fieldDisplayName(facet.facet),
             count,
             true,
-            `color: ${matchColor}; stroke-width: 0; stroke-color: transparent`,
+            count > 0 ? (
+              ecosystems.find((e) => e.name === facet.facet)
+              || { color: theme.current.value.colors.visualization }
+            ).color : 'lightgray',
             excludedCount,
             false,
-            `color: ${noMatchColor}; stroke-width: 0; stroke-color: transparent`,
+            excludedCount > 0 ? 'lightgray' : theme.current.value.colors.visualization,
             count > 0 ? `${count}` : 'No match',
           ];
         },
@@ -138,7 +136,7 @@ const barChartOptions = computed(() => ({
     },
   },
   legend: { position: 'none' },
-  annotations: { alwaysOutside: true, stem: { color: 'transparent' }, textStyle: { color: 'black' } },
+  annotations: { alwaysOutside: true, stem: { color: 'transparent' } },
   title: props.showTitle ? fieldDisplayName(props.field) : null,
   isStacked: true,
 }));

--- a/web/src/components/Presentation/FacetBarChart.vue
+++ b/web/src/components/Presentation/FacetBarChart.vue
@@ -95,7 +95,7 @@ const chartData = computed(() => {
             true,
             count > 0 ? (
               ecosystems.find((e) => e.name === facet.facet)
-              || { color: theme.current.value.colors.primary }
+              || { color: theme.current.value.colors.visualization }
             ).color : 'lightgray',
             excludedCount,
             false,

--- a/web/src/components/Presentation/SearchResults.vue
+++ b/web/src/components/Presentation/SearchResults.vue
@@ -28,6 +28,31 @@ const rows = ref(props.itemsPerPage);
 
 <template>
   <div>
+    <div
+      v-if="!disablePagination && count > 0"
+      class="d-flex pt-2 align-end justify-center"
+    >
+      <v-pagination
+        :model-value="page"
+        :length="Math.ceil(count / rows)"
+        :total-visible="7"
+        active-color="primary"
+        size="default"
+        @update:model-value="emit('set-page', $event)"
+      />
+      <!-- flex-basis is based on the "Items per page" label. Since it is absolutely
+           positioned it doesn't count towards the `auto` width -->
+      <v-select
+        v-model="rows"
+        :items="[5, 10, 15, 20]"
+        label="Items per page"
+        class="ml-4 mb-1 flex-grow-0"
+        :style="{ 'flex-basis': '6rem' }"
+        hide-details
+        variant="plain"
+        @update:model-value="emit('set-items-per-page', $event)"
+      />
+    </div>
     <v-list>
       <template
         v-for="(result, resultIndex) in results"
@@ -96,7 +121,7 @@ const rows = ref(props.itemsPerPage);
     </v-list>
     <div
       v-if="!disablePagination && count > 0"
-      class="d-flex pt-2 pb-0 align-end justify-center"
+      class="d-flex pb-2 align-end justify-center"
     >
       <v-pagination
         :model-value="page"

--- a/web/src/components/Presentation/TimeHistogram.vue
+++ b/web/src/components/Presentation/TimeHistogram.vue
@@ -147,7 +147,7 @@ emits: ['onBrushEnd'],
         .append('rect')
         .attr('class', 'bar')
         .attr('x', 1)
-        .attr('fill', theme.current.value.colors.primary)
+        .attr('fill', theme.current.value.colors.visualization)
         .attr('transform', (d) => 'translate('.concat(x(d.x0), ',', y(d.length), ')'))
         .attr('width', (d) => {
           const w = x(d.x1) - x(d.x0);

--- a/web/src/components/Presentation/TimeHistogram.vue
+++ b/web/src/components/Presentation/TimeHistogram.vue
@@ -41,6 +41,10 @@ export default defineComponent({
       type: Array,
       required: true,
     },
+    xAxisLabel: {
+      type: String,
+      required: true,
+    },
   },
 emits: ['onBrushEnd'],
 
@@ -51,7 +55,7 @@ emits: ['onBrushEnd'],
     const margin = {
       top: 20,
       right: 30,
-      bottom: 30,
+      bottom: 70,
       left: 30,
     };
     const drawn = ref(false);
@@ -195,6 +199,16 @@ emits: ['onBrushEnd'],
         .append('g')
         .attr('transform', 'translate(0,'.concat(height + 10, ')'))
         .call(axisBottom(x));
+      
+      // add the x Axis label
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height + 50)
+        .attr('text-anchor', 'middle')
+        .attr('font-size', '1rem')
+        .attr('font-weight', 'bold')
+        .text(props.xAxisLabel);
 
       svg.select('path').remove();
 
@@ -222,6 +236,10 @@ emits: ['onBrushEnd'],
 </template>
 
 <style scoped>
+svg {
+  display: block;
+}
+
 .bar {
   color: purple;
 }

--- a/web/src/components/Presentation/UpSet.vue
+++ b/web/src/components/Presentation/UpSet.vue
@@ -133,7 +133,7 @@ export default defineComponent({
         .attr('y1', (d, i) => y(i) + y.step() / 2)
         .attr('y2', (d, i) => y(i) + y.step() / 2)
         .attr('stroke-width', 3)
-        .attr('stroke', colors.blue);
+        .attr('stroke', colors.visualization);
 
       svg.selectAll('circle')
         .data(setMembers)
@@ -141,7 +141,7 @@ export default defineComponent({
         .attr('cx', (d) => membershipX(d.set))
         .attr('cy', (d) => y(d.index) + y.step() / 2)
         .attr('r', 5)
-        .attr('fill', colors.blue);
+        .attr('fill', colors.visualization);
 
       uniqueCounts.forEach((count, _i) => {
         const barX = scaleLinear()
@@ -166,7 +166,7 @@ export default defineComponent({
               .attr('y', (d, i) => y(i))
               .attr('width', (d) => barX(d.counts[count]))
               .attr('height', y.bandwidth())
-              .attr('fill', colors.blue)
+              .attr('fill', colors.visualization)
               .classed('upset-bar-clickable', true)
               .on('click', selectSamples);
             parent.append('text')

--- a/web/src/plugins/vuetify.ts
+++ b/web/src/plugins/vuetify.ts
@@ -26,6 +26,7 @@ export default createVuetify({
           info: colors.info,
           link: colors.link,
           visited: colors.visited,
+          visualization: colors.visualization,
         },
       },
     },

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -48,8 +48,10 @@ function setConditions(conditions: Condition[], push = false) {
       && a.op === b.op
       && a.table === b.table);
   if (router) {
+    console.log('current params', router.currentRoute.value.query);
+    const { conditions, q, ...rest } = router.currentRoute.value.query;
     // @ts-ignore
-    router[push ? 'push' : 'replace']({ query: { conditions: state.conditions }, name: 'Search' }).catch(noop);
+    router[push ? 'push' : 'replace']({ query: { ...rest, conditions: state.conditions }, name: 'Search' }).catch(noop);
   }
 }
 

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -48,7 +48,6 @@ function setConditions(conditions: Condition[], push = false) {
       && a.op === b.op
       && a.table === b.table);
   if (router) {
-    console.log('current params', router.currentRoute.value.query);
     const { conditions, q, ...rest } = router.currentRoute.value.query;
     // @ts-ignore
     router[push ? 'push' : 'replace']({ query: { ...rest, conditions: state.conditions }, name: 'Search' }).catch(noop);

--- a/web/src/styles/settings.scss
+++ b/web/src/styles/settings.scss
@@ -24,31 +24,22 @@
   color: inherit;
 }
 
-a, .v-theme--light a {
+a:not(.v-btn, .v-list-item),
+.v-theme--light a:not(.v-btn, .v-list-item) {
   color: rgb(var(--v-theme-link));
   text-decoration: none;
   transition: color 0.2s ease, opacity 0.2s ease;
 }
 
-a:hover, .v-theme--light a:hover {
+a:hover:not(.v-btn, .v-list-item),
+.v-theme--light a:hover:not(.v-btn, .v-list-item) {
   text-decoration: underline;
   opacity: 0.85;
 }
 
-a:visited, .v-theme--light a:visited {
+a:visited:not(.v-btn, .v-list-item),
+.v-theme--light a:visited:not(.v-btn, .v-list-item) {
   color: rgb(var(--v-theme-visited));
-}
-
-a.nav-link,
-a.nav-link:visited {
-  color: #707070;
-  opacity: 1;
-}
-
-.v-app-bar a:hover,
-a.nav-link:hover {
-  color: rgb(var(--v-theme-primary));
-  text-decoration: none;
 }
 
 // Utilities

--- a/web/src/styles/settings.scss
+++ b/web/src/styles/settings.scss
@@ -39,6 +39,18 @@ a:visited, .v-theme--light a:visited {
   color: rgb(var(--v-theme-visited));
 }
 
+a.nav-link,
+a.nav-link:visited {
+  color: #707070;
+  opacity: 1;
+}
+
+.v-app-bar a:hover,
+a.nav-link:hover {
+  color: rgb(var(--v-theme-primary));
+  text-decoration: none;
+}
+
 // Utilities
 .stack-sm {
   display: flex;

--- a/web/src/views/Search/AnalysisVizGroup.vue
+++ b/web/src/views/Search/AnalysisVizGroup.vue
@@ -169,7 +169,7 @@ function setBoundsFromMap(val: Condition[]) {
             <template #default="slotProps">
               <DateHistogram
                 v-bind="slotProps"
-                :height="240"
+                :height="360"
                 @select="setUniqueCondition(['collection_date'], ['biosample'], $event.conditions)"
               />
             </template>
@@ -187,10 +187,10 @@ function setBoundsFromMap(val: Condition[]) {
           <LoadingOverlay
             :loading="upSetLoading"
             :error="upSetError"
-            :height="240"
+            :height="360"
           />
           <ChartContainer
-            :height="240"
+            :height="331"
           >
             <template #default="{ width, height }">
               <UpSet
@@ -222,6 +222,7 @@ function setBoundsFromMap(val: Condition[]) {
 
 <style scoped>
 .upset-legend {
+  height: 29px;
   display: flex;
   flex-wrap: wrap;
   line-height: 0.9em;

--- a/web/src/views/Search/AnalysisVizGroup.vue
+++ b/web/src/views/Search/AnalysisVizGroup.vue
@@ -101,6 +101,7 @@ watchEffect(async () => {
         cols="6"
       >
         <HelpWrapper
+          :height="360"
           :help-text="helpTimeline"
         >
           <BinnedSummaryWrapper
@@ -124,6 +125,7 @@ watchEffect(async () => {
         cols="6"
       >
         <HelpWrapper
+          :height="360"
           :help-text="helpUpset"
           class="py-0 d-flex flex-column justify-center fill-height"
         >

--- a/web/src/views/Search/AnalysisVizGroup.vue
+++ b/web/src/views/Search/AnalysisVizGroup.vue
@@ -112,11 +112,8 @@ function setBoundsFromMap(val: Condition[]) {
 
 <template>
   <div>
-    <v-row>
-      <v-col
-        class="border-e"
-        :cols="5"
-      >
+    <!-- <v-row>
+      <v-col :cols="5">
         <HelpWrapper :text="helpBarchart">
           <FacetSummaryWrapper
             table="omics_processing"
@@ -144,6 +141,7 @@ function setBoundsFromMap(val: Condition[]) {
       >
         <HelpWrapper
           :text="helpMap"
+          class="pa-1"
         >
           <ClusterMap
             :conditions="conditions"
@@ -153,12 +151,14 @@ function setBoundsFromMap(val: Condition[]) {
           />
         </HelpWrapper>
       </v-col>
-    </v-row>
-    <!-- <v-row class="mt-0">
-      <v-col cols="6">
-        <TooltipCard
+    </v-row> -->
+    <v-row class="mt-0">
+      <v-col
+        class="border-e"
+        cols="6"
+      >
+        <HelpWrapper
           :text="helpTimeline"
-          class="py-2"
         >
           <BinnedSummaryWrapper
             table="biosample"
@@ -174,13 +174,13 @@ function setBoundsFromMap(val: Condition[]) {
               />
             </template>
           </BinnedSummaryWrapper>
-        </TooltipCard>
+        </HelpWrapper>
       </v-col>
       <v-col
         class="pl-0"
         cols="6"
       >
-        <TooltipCard
+        <HelpWrapper
           :text="helpUpset"
           class="py-0 d-flex flex-column justify-center fill-height"
         >
@@ -214,9 +214,9 @@ function setBoundsFromMap(val: Condition[]) {
               {{ key }}: {{ value }}
             </span>
           </div>
-        </TooltipCard>
+        </HelpWrapper>
       </v-col>
-    </v-row> -->
+    </v-row>
   </div>
 </template>
 

--- a/web/src/views/Search/AnalysisVizGroup.vue
+++ b/web/src/views/Search/AnalysisVizGroup.vue
@@ -44,7 +44,7 @@ const staticUpsetTooltips = {
 
 const props = withDefaults(defineProps<{
   conditions: Condition[];
-  visTab?: number | null;
+  visTab?: string | null;
 }>(), {
   visTab: null,
 });

--- a/web/src/views/Search/AnalysisVizGroup.vue
+++ b/web/src/views/Search/AnalysisVizGroup.vue
@@ -158,7 +158,7 @@ function setBoundsFromMap(val: Condition[]) {
         cols="6"
       >
         <HelpWrapper
-          :text="helpTimeline"
+          :help-text="helpTimeline"
         >
           <BinnedSummaryWrapper
             table="biosample"
@@ -181,7 +181,7 @@ function setBoundsFromMap(val: Condition[]) {
         cols="6"
       >
         <HelpWrapper
-          :text="helpUpset"
+          :help-text="helpUpset"
           class="py-0 d-flex flex-column justify-center fill-height"
         >
           <LoadingOverlay

--- a/web/src/views/Search/AnalysisVizGroup.vue
+++ b/web/src/views/Search/AnalysisVizGroup.vue
@@ -1,34 +1,21 @@
 <script setup lang="ts">
-import { computed, ref, watchEffect } from 'vue';
-import FacetBarChart from '@/components/Presentation/FacetBarChart.vue';
+import ChartContainer from '@/components/Presentation/ChartContainer.vue';
 import DateHistogram from '@/components/Presentation/DateHistogram.vue';
 import UpSet from '@/components/Presentation/UpSet.vue';
-import ChartContainer from '@/components/Presentation/ChartContainer.vue';
+import { computed, ref, watchEffect } from 'vue';
 // TODO: replace with composition functions
-import FacetSummaryWrapper from '@/components/Wrappers/FacetSummaryWrapper.vue';
 import BinnedSummaryWrapper from '@/components/Wrappers/BinnedSummaryWrapper.vue';
 // ENDTODO
 import HelpWrapper from '@/components/HelpWrapper.vue';
-import ClusterMap from '@/components/ClusterMap.vue';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
 
-import {
-  toggleConditions, setUniqueCondition,
-} from '@/store';
 import { api, Condition, FacetSummaryResponse } from '@/data/api';
 import { makeSetsFromBitmask } from '@/encoding';
+import {
+  setUniqueCondition
+} from '@/store';
 import useRequest from '@/use/useRequest';
 
-const helpBarchart = 'Displays the number of omics processing runs for each data type available. Click on a bar to filter by data type.';
-const helpMap = `
-  Shows the geographic locations (latitude and longitude) where samples were collected.
-  <ul>
-    <li>Click on a cluster to zoom in.</li>
-    <li>Click "Search this region" to filter results to the current map view.</li>
-  </ul>
-  <strong>Note:</strong> Samples collected at the poles may not appear on the map due to projection limits,
-  but they are included in other visualizations and the biosample table.
-`;
 const helpTimeline = 'Displays sample collections grouped by collection date. Click and drag on the timeline to filter by collection date. The selected region can be moved by dragging it from the center. The region can be resized by clicking and dragging at the edges. Click outside the region to clear it.';
 const helpUpset = 'This UpSet plot shows the number of samples with corresponding omic data associated. For example: a sample could have metagenomics, metatranscriptomics, and natural organic matter characterizations. You can select samples by clicking on the bar chart or counts to the right of the bar chart';
 
@@ -104,54 +91,10 @@ watchEffect(async () => {
   sampleFacetSummary.value = await sampleRequest.request(() => api.getFacetSummary('biosample', 'multiomics', props.conditions));
   studyFacetSummary.value = await studyRequest.request(() => api.getFacetSummary('study', 'multiomics', props.conditions));
 });
-
-function setBoundsFromMap(val: Condition[]) {
-  setUniqueCondition(['latitude', 'longitude'], ['biosample'], val);
-}
 </script>
 
 <template>
   <div>
-    <!-- <v-row>
-      <v-col :cols="5">
-        <HelpWrapper :text="helpBarchart">
-          <FacetSummaryWrapper
-            table="omics_processing"
-            field="omics_type"
-            :conditions="conditions"
-            use-all-conditions
-          >
-            <template #default="slotProps">
-              <FacetBarChart
-                v-bind="slotProps"
-                :height="360"
-                :show-title="false"
-                :show-baseline="false"
-                :left-margin="120"
-                :right-margin="80"
-                @selected="toggleConditions($event.conditions)"
-              />
-            </template>
-          </FacetSummaryWrapper>
-        </HelpWrapper>
-      </v-col>
-      <v-col
-        class="pl-0"
-        :cols="7"
-      >
-        <HelpWrapper
-          :text="helpMap"
-          class="pa-1"
-        >
-          <ClusterMap
-            :conditions="conditions"
-            :height="360"
-            :vis-tab="visTab"
-            @selected="setBoundsFromMap($event)"
-          />
-        </HelpWrapper>
-      </v-col>
-    </v-row> -->
     <v-row class="mt-0">
       <v-col
         class="border-e"

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -117,7 +117,7 @@ function setBoundsFromMap(val: Condition[]) {
         class="border-e"
         :cols="5"
       >
-        <HelpWrapper :text="helpBarchart">
+        <HelpWrapper :help-text="helpBarchart">
           <FacetSummaryWrapper
             table="omics_processing"
             field="omics_type"
@@ -143,14 +143,18 @@ function setBoundsFromMap(val: Condition[]) {
         :cols="7"
       >
         <HelpWrapper
-          :text="helpMap"
+          :help-text="helpMap"
+          :height="360"
+          allow-fullscreen
         >
-          <ClusterMap
-            :conditions="conditions"
-            :height="360"
-            :vis-tab="visTab"
-            @selected="setBoundsFromMap($event)"
-          />
+          <template #default="{ isFullscreen }">
+            <ClusterMap
+              :conditions="conditions"
+              :height="isFullscreen ? '90vh' : 360"
+              :vis-tab="visTab"
+              @selected="setBoundsFromMap($event)"
+            />
+          </template>
         </HelpWrapper>
       </v-col>
     </v-row>

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -1,22 +1,16 @@
 <script setup lang="ts">
-import { computed, ref, watchEffect } from 'vue';
+import { ref, watchEffect } from 'vue';
 import FacetBarChart from '@/components/Presentation/FacetBarChart.vue';
-import DateHistogram from '@/components/Presentation/DateHistogram.vue';
-import UpSet from '@/components/Presentation/UpSet.vue';
-import ChartContainer from '@/components/Presentation/ChartContainer.vue';
 // TODO: replace with composition functions
 import FacetSummaryWrapper from '@/components/Wrappers/FacetSummaryWrapper.vue';
-import BinnedSummaryWrapper from '@/components/Wrappers/BinnedSummaryWrapper.vue';
 // ENDTODO
 import HelpWrapper from '@/components/HelpWrapper.vue';
 import ClusterMap from '@/components/ClusterMap.vue';
-import LoadingOverlay from '@/components/LoadingOverlay.vue';
 
 import {
   toggleConditions, setUniqueCondition,
 } from '@/store';
 import { api, Condition, FacetSummaryResponse } from '@/data/api';
-import { makeSetsFromBitmask } from '@/encoding';
 import useRequest from '@/use/useRequest';
 
 const helpBarchart = 'Displays the number of omics processing runs for each data type available. Click on a bar to filter by data type.';
@@ -29,18 +23,6 @@ const helpMap = `
   <strong>Note:</strong> Samples collected at the poles may not appear on the map due to projection limits,
   but they are included in other visualizations and the biosample table.
 `;
-const helpTimeline = 'Displays sample collections grouped by collection date. Click and drag on the timeline to filter by collection date. The selected region can be moved by dragging it from the center. The region can be resized by clicking and dragging at the edges. Click outside the region to clear it.';
-const helpUpset = 'This UpSet plot shows the number of samples with corresponding omic data associated. For example: a sample could have metagenomics, metatranscriptomics, and natural organic matter characterizations. You can select samples by clicking on the bar chart or counts to the right of the bar chart';
-
-const staticUpsetTooltips = {
-  MG: 'Metagenomics',
-  MP: 'Metaproteomics',
-  MB: 'Metabolomics',
-  MT: 'Metatranscriptomics',
-  NOM: 'Natural Organic Matter',
-  LIP: 'Lipidomics',
-  AMP: 'Amplicon',
-};
 
 const props = withDefaults(defineProps<{
   conditions: Condition[];
@@ -53,52 +35,6 @@ const sampleFacetSummary = ref<FacetSummaryResponse[] | null>(null);
 const studyFacetSummary = ref<FacetSummaryResponse[] | null>(null);
 const sampleRequest = useRequest();
 const studyRequest = useRequest();
-const upSetLoading = computed(() => sampleRequest.loading.value || studyRequest.loading.value);
-const upSetError = computed(() => {
-  if (sampleRequest.error.value) {
-    return 'Could not retrieve sample summary values for UpSet plot';
-  } else if (studyRequest.error.value) {
-    return 'Could not retrieve study summary values for UpSet plot';
-  }
-  return null;
-});
-
-const upsetData = computed(() => {
-  const multiomicsObj: Record<string, { counts: any, sets: any }> = {};
-  if (sampleFacetSummary.value) {
-    sampleFacetSummary.value.forEach(({ facet, count }) => {
-      if (parseInt(facet, 10) === 0) {
-        return;
-      }
-      multiomicsObj[facet] = {
-        counts: {
-          Samples: count,
-          Studies: 0,
-        },
-        sets: makeSetsFromBitmask(facet),
-      };
-    });
-  }
-  if (studyFacetSummary.value) {
-    studyFacetSummary.value.forEach(({ facet, count }) => {
-      if (parseInt(facet, 10) === 0) {
-        return;
-      }
-      if (!multiomicsObj[facet]) {
-        multiomicsObj[facet] = {
-          counts: {
-            Samples: 0,
-          },
-          sets: makeSetsFromBitmask(facet),
-        };
-      }
-      multiomicsObj[facet].counts.Studies = count;
-    });
-  }
-  return Object.keys(multiomicsObj)
-    .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
-    .map((k) => multiomicsObj[k]);
-});
 
 watchEffect(async () => {
   sampleFacetSummary.value = await sampleRequest.request(() => api.getFacetSummary('biosample', 'multiomics', props.conditions));
@@ -158,81 +94,5 @@ function setBoundsFromMap(val: Condition[]) {
         </HelpWrapper>
       </v-col>
     </v-row>
-    <!-- <v-row class="mt-0">
-      <v-col cols="6">
-        <TooltipCard
-          :text="helpTimeline"
-          class="py-2"
-        >
-          <BinnedSummaryWrapper
-            table="biosample"
-            field="collection_date"
-            :conditions="conditions"
-            use-all-conditions
-          >
-            <template #default="slotProps">
-              <DateHistogram
-                v-bind="slotProps"
-                :height="240"
-                @select="setUniqueCondition(['collection_date'], ['biosample'], $event.conditions)"
-              />
-            </template>
-          </BinnedSummaryWrapper>
-        </TooltipCard>
-      </v-col>
-      <v-col
-        class="pl-0"
-        cols="6"
-      >
-        <TooltipCard
-          :text="helpUpset"
-          class="py-0 d-flex flex-column justify-center fill-height"
-        >
-          <LoadingOverlay
-            :loading="upSetLoading"
-            :error="upSetError"
-            :height="240"
-          />
-          <ChartContainer
-            :height="240"
-          >
-            <template #default="{ width, height }">
-              <UpSet
-                v-bind="{
-                  width,
-                  height,
-                  data: upsetData,
-                  tooltips: staticUpsetTooltips,
-                  order: 'Samples',
-                }"
-                @select="setUniqueCondition(
-                  ['omics_type'], ['omics_processing'], $event.conditions)"
-              />
-            </template>
-          </ChartContainer>
-          <div class="mx-5 upset-legend">
-            <span
-              v-for="value, key in staticUpsetTooltips"
-              :key="key"
-            >
-              {{ key }}: {{ value }}
-            </span>
-          </div>
-        </TooltipCard>
-      </v-col>
-    </v-row> -->
   </div>
 </template>
-
-<style scoped>
-.upset-legend {
-  display: flex;
-  flex-wrap: wrap;
-  line-height: 0.9em;
-}
-.upset-legend > span {
-  font-size: 10px;
-  padding: 0 4px;
-  white-space: nowrap;
-}
-</style>

--- a/web/src/views/Search/BiosampleVisGroup.vue
+++ b/web/src/views/Search/BiosampleVisGroup.vue
@@ -44,7 +44,7 @@ const staticUpsetTooltips = {
 
 const props = withDefaults(defineProps<{
   conditions: Condition[];
-  visTab?: number | null;
+  visTab?: string | null;
 }>(), {
   visTab: null,
 });

--- a/web/src/views/Search/DataTypesVisGroup.vue
+++ b/web/src/views/Search/DataTypesVisGroup.vue
@@ -26,9 +26,10 @@ const helpMap = `
 
 const props = withDefaults(defineProps<{
   conditions: Condition[];
-  visTab?: string | null;
+  /** The name of the currently active visualization tab */
+  activeVisTab?: string | null;
 }>(), {
-  visTab: null,
+  activeVisTab: null,
 });
 
 const sampleFacetSummary = ref<FacetSummaryResponse[] | null>(null);
@@ -87,7 +88,7 @@ function setBoundsFromMap(val: Condition[]) {
             <ClusterMap
               :conditions="conditions"
               :height="isFullscreen ? '90vh' : 360"
-              :vis-tab="visTab"
+              :active-vis-tab="activeVisTab"
               @selected="setBoundsFromMap($event)"
             />
           </template>

--- a/web/src/views/Search/DataTypesVisGroup.vue
+++ b/web/src/views/Search/DataTypesVisGroup.vue
@@ -12,6 +12,7 @@ import {
 } from '@/store';
 import { api, Condition, FacetSummaryResponse } from '@/data/api';
 import useRequest from '@/use/useRequest';
+import { VISUALIZATION_HEIGHT } from '@/views/Search/types';
 
 const helpBarchart = 'Displays the number of omics processing runs for each data type available. Click on a bar to filter by data type.';
 const helpMap = `
@@ -64,7 +65,7 @@ function setBoundsFromMap(val: Condition[]) {
             <template #default="slotProps">
               <FacetBarChart
                 v-bind="slotProps"
-                :height="360"
+                :height="VISUALIZATION_HEIGHT"
                 :show-title="false"
                 :show-baseline="false"
                 :left-margin="120"
@@ -81,13 +82,13 @@ function setBoundsFromMap(val: Condition[]) {
       >
         <HelpWrapper
           :help-text="helpMap"
-          :height="360"
+          :height="VISUALIZATION_HEIGHT"
           allow-fullscreen
         >
           <template #default="{ isFullscreen }">
             <ClusterMap
               :conditions="conditions"
-              :height="isFullscreen ? '90vh' : 360"
+              :height="isFullscreen ? '90vh' : VISUALIZATION_HEIGHT"
               :active-vis-tab="activeVisTab"
               @selected="setBoundsFromMap($event)"
             />

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -5,7 +5,7 @@ import { toggleConditions } from '@/store';
 import { Condition } from '@/data/api';
 import { VISUALIZATION_HEIGHT } from '@/views/Search/types';
 
-const helpSankey = 'This Sankey diagram shows samples by their ecosystem. There is a hierarchical relationship between ecosystems, ecosystem categories, ecosystem types, ecosystem subtypes, and specific ecosystems. Click on a section to filter by that ecosystem.';
+const helpSankey = 'This Sankey diagram shows samples by their ecosystem. There is a hierarchical relationship between ecosystem categories, ecosystem types, ecosystem subtypes, and specific ecosystems. Click on a section to filter by that ecosystem.';
 
 defineProps<{
   conditions: Condition[];

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -4,9 +4,11 @@ import HelpWrapper from '@/components/HelpWrapper.vue';
 import { toggleConditions } from '@/store';
 import { Condition } from '@/data/api';
 
+const helpSankey = 'This Sankey diagram shows samples by the hierarchical relationships between ecosystems, ecosystem categories, ecosystem types, ecosystem subtypes, and specific ecosystems. Click on a section to filter by that ecosystem.';
+
 defineProps<{
   conditions: Condition[];
-}>();
+}>(); 
 </script>
 
 <template>
@@ -14,7 +16,7 @@ defineProps<{
     <v-col :cols="12">
       <HelpWrapper
         height="360px"
-        help-text="this is cool"
+        :help-text="helpSankey"
         allow-fullscreen
       >
         <EcosystemSankey

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -5,7 +5,7 @@ import { toggleConditions } from '@/store';
 import { Condition } from '@/data/api';
 import { VISUALIZATION_HEIGHT } from '@/views/Search/types';
 
-const helpSankey = 'This Sankey diagram shows samples by the hierarchical relationships between ecosystems, ecosystem categories, ecosystem types, ecosystem subtypes, and specific ecosystems. Click on a section to filter by that ecosystem.';
+const helpSankey = 'This Sankey diagram shows samples by their ecosystem. There is a hierarchical relationship between ecosystems, ecosystem categories, ecosystem types, ecosystem subtypes, and specific ecosystems. Click on a section to filter by that ecosystem.';
 
 defineProps<{
   conditions: Condition[];

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -3,6 +3,7 @@ import EcosystemSankey from '@/components/EcosystemSankey.vue';
 import HelpWrapper from '@/components/HelpWrapper.vue';
 import { toggleConditions } from '@/store';
 import { Condition } from '@/data/api';
+import { VISUALIZATION_HEIGHT } from '@/views/Search/types';
 
 const helpSankey = 'This Sankey diagram shows samples by the hierarchical relationships between ecosystems, ecosystem categories, ecosystem types, ecosystem subtypes, and specific ecosystems. Click on a section to filter by that ecosystem.';
 
@@ -15,7 +16,7 @@ defineProps<{
   <v-row>
     <v-col :cols="12">
       <HelpWrapper
-        height="360px"
+        :height="VISUALIZATION_HEIGHT"
         :help-text="helpSankey"
         allow-fullscreen
       >

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -1,49 +1,28 @@
-<script lang="ts">
-import { defineComponent, PropType } from 'vue';
+<script setup lang="ts">
 import EcosystemSankey from '@/components/EcosystemSankey.vue';
-
-import {
-  toggleConditions,
-} from '@/store';
+import HelpWrapper from '@/components/HelpWrapper.vue';
+import { toggleConditions } from '@/store';
 import { Condition } from '@/data/api';
 
-export default defineComponent({
-  components: {
-    EcosystemSankey,
-  },
-
-  props: {
-    conditions: {
-      type: Array as PropType<Condition[]>,
-      required: true,
-    },
-  },
-
-  setup() {
-    return {
-      toggleConditions,
-    };
-  },
-});
+defineProps<{
+  conditions: Condition[];
+}>();
 </script>
 
 <template>
   <v-row>
     <v-col :cols="12">
-      <div
-        class="pr-2 overflow-y-auto overflow-x-hidden"
-        style="
-            height: 360px;
-            width: 100%;
-            max-width: 100%;
-          "
+      <HelpWrapper
+        height="360px"
+        help-text="this is cool"
+        allow-fullscreen
       >
         <EcosystemSankey
           :conditions="conditions"
-          style="width: 100%"
+          style="width: 100%; padding: 1rem"
           @selected="toggleConditions($event.conditions)"
         />
-      </div>
+      </HelpWrapper>
     </v-col>
   </v-row>
 </template>

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -21,7 +21,10 @@ defineProps<{
       >
         <EcosystemSankey
           :conditions="conditions"
-          style="width: 100%; padding: 1rem"
+          :style="{
+            width: '100%',
+            padding: '1rem',
+          }"
           @selected="toggleConditions($event.conditions)"
         />
       </HelpWrapper>

--- a/web/src/views/Search/EnvironmentVisGroup.vue
+++ b/web/src/views/Search/EnvironmentVisGroup.vue
@@ -33,7 +33,7 @@ export default defineComponent({
       <div
         class="pr-2 overflow-y-auto overflow-x-hidden"
         style="
-            height: 700px;
+            height: 360px;
             width: 100%;
             max-width: 100%;
           "

--- a/web/src/views/Search/SearchHelpMenu.vue
+++ b/web/src/views/Search/SearchHelpMenu.vue
@@ -12,13 +12,12 @@ export default defineComponent({});
   >
     <template #activator="{ props }">
       <v-btn
-        icon
         variant="plain"
+        size="x-small"
         v-bind="props"
+        style="text-transform: none; font-size: 0.875rem;"
       >
-        <v-icon>
-          mdi-help-circle
-        </v-icon>
+        Need help?
       </v-btn>
     </template>
 

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -173,7 +173,7 @@ function toggleChildren(value:StudySearchResult) {
                 <v-icon class="mr-1">
                   mdi-map-marker-outline
                 </v-icon>
-                Sampling
+                Data
               </v-tab>
               <v-tab key="analysis">
                 <v-icon class="mr-1">

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -24,8 +24,8 @@ import AppBanner from '@/components/AppBanner.vue';
 import BulkDownload from '@/components/BulkDownload.vue';
 import ClickToCopyText from '@/components/Presentation/ClickToCopyText.vue';
 import EnvironmentVisGroup from './EnvironmentVisGroup.vue';
-import BiosampleVisGroup from './BiosampleVisGroup.vue';
-import AnalysisVizGroup from './AnalysisVizGroup.vue';
+import DataTypesVisGroup from './DataTypesVisGroup.vue';
+import TimelineVisGroup from './TimelineVisGroup.vue';
 import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
@@ -205,15 +205,14 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
               v-model="activeVisTab"
             >
               <v-window-item :value="VisualizationTabs.DataTypes">
-                <BiosampleVisGroup
+                <DataTypesVisGroup
                   :conditions="gatedDataVisConditions"
                   :vis-tab="activeVisTab"
                 />
               </v-window-item>
               <v-window-item :value="VisualizationTabs.Timeline">
-                <AnalysisVizGroup
+                <TimelineVisGroup
                   :conditions="gatedAnalysisVisConditions"
-                  :vis-tab="activeVisTab"
                 />
               </v-window-item>
               <v-window-item :value="VisualizationTabs.Environment">

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -30,6 +30,7 @@ import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
 import { useRoute, useRouter } from 'vue-router';
+import { ResultsTabs, VisualizationTabs } from '@/views/Search/types.ts';
 
 const biosampleDescription = NmdcSchema.classes[types.biosample.schemaName].description;
 const studyDescription = NmdcSchema.classes[types.study.schemaName].description;
@@ -114,21 +115,18 @@ const studyResults = computed<StudySearchResult[]>(() => Object.values(study.dat
   })));
 
 const loggedInUser = computed(() => stateRefs.user.value !== null);
-
-const visTabs = ref(['data', 'analysis', 'environment']);
-const resultsTabs = ref(['studies', 'samples']);
-const activeVisTab = ref(route.query.view as string || visTabs.value[0]);
-const activeResultsTab = ref(route.query.results as string || resultsTabs.value[0]);
+const activeVisTab = ref(route.query.view as string || VisualizationTabs.DataTypes);
+const activeResultsTab = ref(route.query.results as string || ResultsTabs.Studies);
 const gatedDataVisConditions = useClockGate(
-  computed(() => (activeVisTab.value === visTabs.value[0])),
+  computed(() => (activeVisTab.value === VisualizationTabs.DataTypes)),
   stateRefs.conditions,
 );
 const gatedAnalysisVisConditions = useClockGate(
-  computed(() => (activeVisTab.value === visTabs.value[1])),
+  computed(() => (activeVisTab.value === VisualizationTabs.Timeline)),
   stateRefs.conditions,
 );
 const gatedEnvironmentVisConditions = useClockGate(
-  computed(() => (activeVisTab.value === visTabs.value[2])),
+  computed(() => (activeVisTab.value === VisualizationTabs.Environment)),
   stateRefs.conditions,
 );
 const showChildren: Ref<any[]> = ref([]);
@@ -183,19 +181,19 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
               v-model="activeVisTab"
               color="primary"
             >
-              <v-tab :value="visTabs[0]">
+              <v-tab :value="VisualizationTabs.DataTypes">
                 <v-icon class="mr-1">
                   mdi-map-marker-outline
                 </v-icon>
-                Omics & Map
+                Data Types & Map
               </v-tab>
-              <v-tab :value="visTabs[1]">
+              <v-tab :value="VisualizationTabs.Timeline">
                 <v-icon class="mr-1">
                   mdi-chart-box-outline
                 </v-icon>
                 Timeline & Multi-omics
               </v-tab>
-              <v-tab :value="visTabs[2]">
+              <v-tab :value="VisualizationTabs.Environment">
                 <v-icon class="mr-1">
                   mdi-chart-sankey-variant
                 </v-icon>
@@ -206,19 +204,19 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
             <v-window
               v-model="activeVisTab"
             >
-              <v-window-item :value="visTabs[0]">
+              <v-window-item :value="VisualizationTabs.DataTypes">
                 <BiosampleVisGroup
                   :conditions="gatedDataVisConditions"
                   :vis-tab="activeVisTab"
                 />
               </v-window-item>
-              <v-window-item :value="visTabs[1]">
+              <v-window-item :value="VisualizationTabs.Timeline">
                 <AnalysisVizGroup
                   :conditions="gatedAnalysisVisConditions"
                   :vis-tab="activeVisTab"
                 />
               </v-window-item>
-              <v-window-item :value="visTabs[2]">
+              <v-window-item :value="VisualizationTabs.Environment">
                 <EnvironmentVisGroup :conditions="gatedEnvironmentVisConditions" />
               </v-window-item>
             </v-window>
@@ -228,7 +226,7 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
               v-model="activeResultsTab"
               color="primary"
             >
-              <v-tab :value="resultsTabs[0]">
+              <v-tab :value="ResultsTabs.Studies">
                 <div class="d-flex align-center ga-2">
                   <span>Studies ({{ study.data.results.count }})</span>
                   <v-tooltip
@@ -247,7 +245,7 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
                   </v-tooltip>
                 </div>
               </v-tab>
-              <v-tab :value="resultsTabs[1]">
+              <v-tab :value="ResultsTabs.Samples">
                 <div class="d-flex align-center ga-2">
                   <span>Samples ({{ biosample.data.results.count }})</span>
                   <v-tooltip
@@ -281,7 +279,7 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
             <v-tabs-window
               v-model="activeResultsTab"
             >
-              <v-tabs-window-item :value="resultsTabs[0]">
+              <v-tabs-window-item :value="ResultsTabs.Studies">
                 <SearchResults
                   :count="study.data.results.count"
                   :icon="studyType.icon"
@@ -470,7 +468,7 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
                   </template>
                 </SearchResults>
               </v-tabs-window-item>
-              <v-tabs-window-item :value="resultsTabs[1]">
+              <v-tabs-window-item :value="ResultsTabs.Samples">
                 <BiosampleSearchResults
                   :data-object-filter="dataObjectFilter"
                   :biosample-search="biosample"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -143,20 +143,23 @@ function toggleChildren(value:StudySearchResult) {
     <AppBanner />
     <v-container
       fluid
-      class="py-2"
+      class="py-3"
     >
       <v-row>
         <v-col>
-          <div class="font-weight-bold text-title-2 text-primary mb-3">
-            <span v-if="biosample.loading.value">
-              Loading results...
-            </span>
-            <span
-              v-else
-              class="d-flex align-center"
-            >
-              <span>Found {{ biosample.data.results.count }} samples</span>
-            </span>
+          <div class="d-flex align-center mb-3">
+            <div class="font-weight-bold text-title-2 text-primary flex-grow-1">
+              <span v-if="biosample.loading.value">
+                Loading results...
+              </span>
+              <span
+                v-else
+                class="d-flex align-center"
+              >
+                <span>Found {{ biosample.data.results.count }} samples</span>
+              </span>
+            </div>
+            <SearchHelpMenu />
           </div>
           <v-card
             class="mb-3" 
@@ -175,7 +178,6 @@ function toggleChildren(value:StudySearchResult) {
               <v-tab key="environments">
                 Environment
               </v-tab>
-              <search-help-menu />
             </v-tabs>
             <v-divider />
             <v-window

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -24,6 +24,7 @@ import BulkDownload from '@/components/BulkDownload.vue';
 import ClickToCopyText from '@/components/Presentation/ClickToCopyText.vue';
 import EnvironmentVisGroup from './EnvironmentVisGroup.vue';
 import BiosampleVisGroup from './BiosampleVisGroup.vue';
+import AnalysisVizGroup from './AnalysisVizGroup.vue';
 import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
@@ -142,42 +143,61 @@ function toggleChildren(value:StudySearchResult) {
     <AppBanner />
     <v-container
       fluid
-      class="py-0"
+      class="py-2"
     >
       <v-row>
         <v-col>
-          <v-row class="align-center">
-            <v-col>
-              <v-tabs
-                v-model="visTab"
-                color="primary"
-              >
-                <v-tab key="omics">
-                  Data Type
-                </v-tab>
-                <v-tab key="environments">
-                  Environment
-                </v-tab>
-              </v-tabs>
-            </v-col>
-            <v-col class="d-flex justify-end flex-grow-0 flex-shrink-0">
-              <search-help-menu />
-            </v-col>
-          </v-row>
-          <v-window
-            v-model="visTab"
-            class="my-3"
+          <div class="font-weight-bold text-title-2 text-primary mb-3">
+            <span v-if="biosample.loading.value">
+              Loading results...
+            </span>
+            <span
+              v-else
+              class="d-flex align-center"
+            >
+              <span>Found {{ biosample.data.results.count }} samples</span>
+            </span>
+          </div>
+          <v-card
+            class="mb-3" 
+            variant="outlined"
           >
-            <v-window-item key="omics">
-              <BiosampleVisGroup
-                :conditions="gatedOmicsVisConditions"
-                :vis-tab="visTab"
-              />
-            </v-window-item>
-            <v-window-item key="environments">
-              <EnvironmentVisGroup :conditions="gatedEnvironmentVisConditions" />
-            </v-window-item>
-          </v-window>
+            <v-tabs
+              v-model="visTab"
+              color="primary"
+            >
+              <v-tab key="sampling">
+                Sampling
+              </v-tab>
+              <v-tab key="analysis">
+                Analysis
+              </v-tab>
+              <v-tab key="environments">
+                Environment
+              </v-tab>
+              <search-help-menu />
+            </v-tabs>
+            <v-divider />
+            <v-window
+              v-model="visTab"
+            >
+              <v-window-item key="sampling">
+                <BiosampleVisGroup
+                  :conditions="gatedOmicsVisConditions"
+                  :vis-tab="visTab"
+                />
+              </v-window-item>
+              <v-window-item key="analysis">
+                <AnalysisVizGroup
+                  :conditions="gatedOmicsVisConditions"
+                  :vis-tab="visTab"
+                />
+              </v-window-item>
+              <v-window-item key="environments">
+                <EnvironmentVisGroup :conditions="gatedEnvironmentVisConditions" />
+              </v-window-item>
+            </v-window>
+          </v-card>
           <v-card variant="outlined">
             <v-tabs
               v-model="resultsTab"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -231,7 +231,10 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
               <v-tab :value="resultsTabs[0]">
                 <div class="d-flex align-center ga-2">
                   <span>Studies ({{ study.data.results.count }})</span>
-                  <v-tooltip location="top">
+                  <v-tooltip
+                    location="top"
+                    max-width="300px"
+                  >
                     <template #activator="{ props }">
                       <v-icon
                         v-bind="props"
@@ -247,7 +250,10 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
               <v-tab :value="resultsTabs[1]">
                 <div class="d-flex align-center ga-2">
                   <span>Samples ({{ biosample.data.results.count }})</span>
-                  <v-tooltip location="top">
+                  <v-tooltip
+                    location="top"
+                    max-width="300px"
+                  >
                     <template #activator="{ props }">
                       <v-icon
                         v-bind="props"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -118,8 +118,9 @@ const studyResults = computed<StudySearchResult[]>(() => Object.values(study.dat
 const loggedInUser = computed(() => stateRefs.user.value !== null);
 
 const visTabs = ref(['data', 'analysis', 'environment']);
-const activeVisTab = ref(route.query.view as string || visTabs.value[0])
-const resultsTab = ref(0);
+const resultsTabs = ref(['studies', 'samples']);
+const activeVisTab = ref(route.query.view as string || visTabs.value[0]);
+const activeResultsTab = ref(route.query.results as string || resultsTabs.value[0]);
 const gatedOmicsVisConditions = useClockGate(
   computed(() => (activeVisTab.value === visTabs.value[0])),
   stateRefs.conditions,
@@ -133,9 +134,9 @@ function toggleChildren(value:StudySearchResult) {
   showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
 }
 
-watch(activeVisTab, (newVisTab) => {
-  const { view, ...rest } = route.query;
-  router.replace({ query: { view: newVisTab, ...rest } })
+watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
+  const { view, results, ...rest } = route.query;
+  router.replace({ query: { view: newVisTab, results: newResultsTab, ...rest } })
 });
 </script>
 
@@ -222,10 +223,10 @@ watch(activeVisTab, (newVisTab) => {
           </v-card>
           <v-card variant="outlined">
             <v-tabs
-              v-model="resultsTab"
+              v-model="activeResultsTab"
               color="primary"
             >
-              <v-tab key="studies">
+              <v-tab :value="resultsTabs[0]">
                 <div class="d-flex align-center ga-2">
                   <span>Studies ({{ study.data.results.count }})</span>
                   <v-tooltip location="top">
@@ -241,7 +242,7 @@ watch(activeVisTab, (newVisTab) => {
                   </v-tooltip>
                 </div>
               </v-tab>
-              <v-tab key="samples">
+              <v-tab :value="resultsTabs[1]">
                 <div class="d-flex align-center ga-2">
                   <span>Samples ({{ biosample.data.results.count }})</span>
                   <v-tooltip location="top">
@@ -270,9 +271,9 @@ watch(activeVisTab, (newVisTab) => {
             </v-tabs>
             <v-divider />
             <v-tabs-window
-              v-model="resultsTab"
+              v-model="activeResultsTab"
             >
-              <v-tabs-window-item key="studies">
+              <v-tabs-window-item :value="resultsTabs[0]">
                 <SearchResults
                   :count="study.data.results.count"
                   :icon="studyType.icon"
@@ -461,7 +462,7 @@ watch(activeVisTab, (newVisTab) => {
                   </template>
                 </SearchResults>
               </v-tabs-window-item>
-              <v-tabs-window-item key="samples">
+              <v-tabs-window-item :value="resultsTabs[1]">
                 <BiosampleSearchResults
                   :data-object-filter="dataObjectFilter"
                   :biosample-search="biosample"

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -121,8 +121,12 @@ const visTabs = ref(['data', 'analysis', 'environment']);
 const resultsTabs = ref(['studies', 'samples']);
 const activeVisTab = ref(route.query.view as string || visTabs.value[0]);
 const activeResultsTab = ref(route.query.results as string || resultsTabs.value[0]);
-const gatedOmicsVisConditions = useClockGate(
+const gatedDataVisConditions = useClockGate(
   computed(() => (activeVisTab.value === visTabs.value[0])),
+  stateRefs.conditions,
+);
+const gatedAnalysisVisConditions = useClockGate(
+  computed(() => (activeVisTab.value === visTabs.value[1])),
   stateRefs.conditions,
 );
 const gatedEnvironmentVisConditions = useClockGate(
@@ -206,13 +210,13 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
             >
               <v-window-item :value="visTabs[0]">
                 <BiosampleVisGroup
-                  :conditions="gatedOmicsVisConditions"
+                  :conditions="gatedDataVisConditions"
                   :vis-tab="activeVisTab"
                 />
               </v-window-item>
               <v-window-item :value="visTabs[1]">
                 <AnalysisVizGroup
-                  :conditions="gatedOmicsVisConditions"
+                  :conditions="gatedAnalysisVisConditions"
                   :vis-tab="activeVisTab"
                 />
               </v-window-item>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -32,9 +32,7 @@ import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchRes
 import { useRoute, useRouter } from 'vue-router';
 
 const biosampleDescription = NmdcSchema.classes[types.biosample.schemaName].description;
-// TODO: would we rather use the study description from the schema?
-// const studyDescription = NmdcSchema.classes[types.study.schemaName].description;
-const studyDescription = 'Research-driven experimental datasets and standardized data collections.';
+const studyDescription = NmdcSchema.classes[types.study.schemaName].description;
 
 const route = useRoute();
 const router = useRouter();

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -170,12 +170,21 @@ function toggleChildren(value:StudySearchResult) {
               color="primary"
             >
               <v-tab key="sampling">
+                <v-icon class="mr-1">
+                  mdi-map-marker-outline
+                </v-icon>
                 Sampling
               </v-tab>
               <v-tab key="analysis">
+                <v-icon class="mr-1">
+                  mdi-chart-box-outline
+                </v-icon>
                 Analysis
               </v-tab>
               <v-tab key="environments">
+                <v-icon class="mr-1">
+                  mdi-chart-sankey-variant
+                </v-icon>
                 Environment
               </v-tab>
             </v-tabs>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   computed, Ref, ref,
+  watch,
 
 } from 'vue';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc_materialized_patterns.json';
@@ -28,11 +29,15 @@ import AnalysisVizGroup from './AnalysisVizGroup.vue';
 import SearchSidebar from './SearchSidebar.vue';
 import SearchHelpMenu from './SearchHelpMenu.vue';
 import BiosampleSearchResults from '@/components/Presentation/BiosampleSearchResults.vue';
+import { useRoute, useRouter } from 'vue-router';
 
 const biosampleDescription = NmdcSchema.classes[types.biosample.schemaName].description;
 // TODO: would we rather use the study description from the schema?
 // const studyDescription = NmdcSchema.classes[types.study.schemaName].description;
 const studyDescription = 'Research-driven experimental datasets and standardized data collections.';
+
+const route = useRoute();
+const router = useRouter();
 
 /**
  * Study checkbox state logic
@@ -112,20 +117,26 @@ const studyResults = computed<StudySearchResult[]>(() => Object.values(study.dat
 
 const loggedInUser = computed(() => stateRefs.user.value !== null);
 
-const visTab = ref(0);
+const visTabs = ref(['data', 'analysis', 'environment']);
+const activeVisTab = ref(route.query.view as string || visTabs.value[0])
 const resultsTab = ref(0);
 const gatedOmicsVisConditions = useClockGate(
-  computed(() => (visTab.value === 0)),
+  computed(() => (activeVisTab.value === visTabs.value[0])),
   stateRefs.conditions,
 );
 const gatedEnvironmentVisConditions = useClockGate(
-  computed(() => (visTab.value === 1)),
+  computed(() => (activeVisTab.value === visTabs.value[2])),
   stateRefs.conditions,
 );
 const showChildren: Ref<any[]> = ref([]);
 function toggleChildren(value:StudySearchResult) {
   showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
 }
+
+watch(activeVisTab, (newVisTab) => {
+  const { view, ...rest } = route.query;
+  router.replace({ query: { view: newVisTab, ...rest } })
+});
 </script>
 
 <template>
@@ -166,22 +177,22 @@ function toggleChildren(value:StudySearchResult) {
             variant="outlined"
           >
             <v-tabs
-              v-model="visTab"
+              v-model="activeVisTab"
               color="primary"
             >
-              <v-tab key="sampling">
+              <v-tab :value="visTabs[0]">
                 <v-icon class="mr-1">
                   mdi-map-marker-outline
                 </v-icon>
                 Data
               </v-tab>
-              <v-tab key="analysis">
+              <v-tab :value="visTabs[1]">
                 <v-icon class="mr-1">
                   mdi-chart-box-outline
                 </v-icon>
                 Analysis
               </v-tab>
-              <v-tab key="environments">
+              <v-tab :value="visTabs[2]">
                 <v-icon class="mr-1">
                   mdi-chart-sankey-variant
                 </v-icon>
@@ -190,21 +201,21 @@ function toggleChildren(value:StudySearchResult) {
             </v-tabs>
             <v-divider />
             <v-window
-              v-model="visTab"
+              v-model="activeVisTab"
             >
-              <v-window-item key="sampling">
+              <v-window-item :value="visTabs[0]">
                 <BiosampleVisGroup
                   :conditions="gatedOmicsVisConditions"
-                  :vis-tab="visTab"
+                  :vis-tab="activeVisTab"
                 />
               </v-window-item>
-              <v-window-item key="analysis">
+              <v-window-item :value="visTabs[1]">
                 <AnalysisVizGroup
                   :conditions="gatedOmicsVisConditions"
-                  :vis-tab="visTab"
+                  :vis-tab="activeVisTab"
                 />
               </v-window-item>
-              <v-window-item key="environments">
+              <v-window-item :value="visTabs[2]">
                 <EnvironmentVisGroup :conditions="gatedEnvironmentVisConditions" />
               </v-window-item>
             </v-window>

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -207,7 +207,7 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
               <v-window-item :value="VisualizationTabs.DataTypes">
                 <DataTypesVisGroup
                   :conditions="gatedDataVisConditions"
-                  :vis-tab="activeVisTab"
+                  :active-vis-tab="activeVisTab"
                 />
               </v-window-item>
               <v-window-item :value="VisualizationTabs.Timeline">

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -187,13 +187,13 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
                 <v-icon class="mr-1">
                   mdi-map-marker-outline
                 </v-icon>
-                Data
+                Omics & Map
               </v-tab>
               <v-tab :value="visTabs[1]">
                 <v-icon class="mr-1">
                   mdi-chart-box-outline
                 </v-icon>
-                Analysis
+                Timeline & Multi-omics
               </v-tab>
               <v-tab :value="visTabs[2]">
                 <v-icon class="mr-1">

--- a/web/src/views/Search/SearchSidebar.vue
+++ b/web/src/views/Search/SearchSidebar.vue
@@ -2,20 +2,21 @@
 import {
   ref, watch,
 } from 'vue';
-import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc_materialized_patterns.json';
 
-import { geneFunctionTables, types } from '@/encoding';
 import {
   api, AttributeSummary, Condition, DatabaseSummaryResponse, EntityType,
 } from '@/data/api';
+import { geneFunctionTables } from '@/encoding';
 
 import ConditionChips from '@/components/Presentation/ConditionChips.vue';
 
-import MenuContent from '@/components/MenuContent.vue';
 import FacetedSearch, { SearchFacet } from '@/components/FacetedSearch.vue';
+import MenuContent from '@/components/MenuContent.vue';
 
 import {
-  stateRefs, removeConditions, setConditions, toggleConditions,
+  removeConditions, setConditions,
+  stateRefs,
+  toggleConditions,
 } from '@/store';
 import { event } from 'vue-gtag';
 
@@ -122,18 +123,9 @@ const FunctionSearchFacets: SearchFacet[] = [
   },
 ];
 
-withDefaults(defineProps<{
-  resultsCount?: number;
-  isLoading?: boolean;
-}>(), {
-  resultsCount: 0,
-  isLoading: false,
-});
-
 const filterText = ref('');
 const textSearchResults = ref([] as Condition[]);
 const dbSummary = ref({} as DatabaseSummaryResponse);
-const biosampleDescription = NmdcSchema.classes[types.biosample.schemaName].description;
 const conditions = stateRefs.conditions;
 
 api.getDatabaseSummary().then((s) => { dbSummary.value = s; });
@@ -213,8 +205,11 @@ watch(stateRefs.conditions, trackFilterConditions);
     permanent
     width="320"
   >
-    <template #prepend>
-      <div class="mx-3 my-2">
+    <template
+      v-if="conditions.length > 0"
+      #prepend
+    >
+      <div class="mx-3 mt-3">
         <div
           v-if="conditions.length"
           class="text-subtitle-2 text-primary d-flex align-center"
@@ -241,12 +236,11 @@ watch(stateRefs.conditions, trackFilterConditions);
           </v-tooltip>
         </div>
       </div>
-
       <ConditionChips
         v-if="conditions.length"
         :conditions="conditions"
         :db-summary="dbSummary"
-        class="ma-3"
+        class="mx-3"
         style="max-height: 50vh; overflow: auto;"
         @remove="removeConditions([$event])"
       >
@@ -265,37 +259,7 @@ watch(stateRefs.conditions, trackFilterConditions);
           />
         </template>
       </ConditionChips>
-
-      <div class="font-weight-bold text-subtitle-2 text-primary mx-3">
-        <span v-if="isLoading">
-          Loading results...
-        </span>
-        <span
-          v-else
-          class="d-flex align-center"
-        >
-          <span>Found {{ resultsCount }} samples.</span>
-          <v-tooltip
-            location="bottom"
-            open-delay="600"
-          >
-            <template #activator="{ props }">
-              <v-btn
-                icon
-                variant="text"
-                size="small"
-                v-bind="props"
-                density="comfortable"
-              >
-                <v-icon>mdi-help-circle</v-icon>
-              </v-btn>
-            </template>
-            <span>{{ biosampleDescription }}</span>
-          </v-tooltip>
-        </span>
-      </div>
-
-      <v-divider class="my-3" />
+      <v-divider class="mt-3" />
     </template>
 
     <FacetedSearch

--- a/web/src/views/Search/TimelineVisGroup.vue
+++ b/web/src/views/Search/TimelineVisGroup.vue
@@ -15,6 +15,7 @@ import {
   setUniqueCondition
 } from '@/store';
 import useRequest from '@/use/useRequest';
+import { VISUALIZATION_HEIGHT } from '@/views/Search/types';
 
 const helpTimeline = 'Displays sample collections grouped by collection date. Click and drag on the timeline to filter by collection date. The selected region can be moved by dragging it from the center. The region can be resized by clicking and dragging at the edges. Click outside the region to clear it.';
 const helpUpset = 'This UpSet plot shows the number of samples with corresponding omic data associated. For example: a sample could have metagenomics, metatranscriptomics, and natural organic matter characterizations. You can select samples by clicking on the bar chart or counts to the right of the bar chart';
@@ -98,7 +99,7 @@ watchEffect(async () => {
         cols="6"
       >
         <HelpWrapper
-          :height="360"
+          :height="VISUALIZATION_HEIGHT"
           :help-text="helpTimeline"
         >
           <BinnedSummaryWrapper
@@ -110,7 +111,7 @@ watchEffect(async () => {
             <template #default="slotProps">
               <DateHistogram
                 v-bind="slotProps"
-                :height="360"
+                :height="VISUALIZATION_HEIGHT"
                 @select="setUniqueCondition(['collection_date'], ['biosample'], $event.conditions)"
               />
             </template>
@@ -122,14 +123,14 @@ watchEffect(async () => {
         cols="6"
       >
         <HelpWrapper
-          :height="360"
+          :height="VISUALIZATION_HEIGHT"
           :help-text="helpUpset"
           class="py-0 d-flex flex-column justify-center fill-height"
         >
           <LoadingOverlay
             :loading="upSetLoading"
             :error="upSetError"
-            :height="360"
+            :height="VISUALIZATION_HEIGHT"
           />
           <ChartContainer
             :height="331"

--- a/web/src/views/Search/TimelineVisGroup.vue
+++ b/web/src/views/Search/TimelineVisGroup.vue
@@ -29,12 +29,9 @@ const staticUpsetTooltips = {
   AMP: 'Amplicon',
 };
 
-const props = withDefaults(defineProps<{
+const props = defineProps<{
   conditions: Condition[];
-  visTab?: string | null;
-}>(), {
-  visTab: null,
-});
+}>();
 
 const sampleFacetSummary = ref<FacetSummaryResponse[] | null>(null);
 const studyFacetSummary = ref<FacetSummaryResponse[] | null>(null);

--- a/web/src/views/Search/types.ts
+++ b/web/src/views/Search/types.ts
@@ -1,0 +1,10 @@
+export enum VisualizationTabs {
+  DataTypes = 'data-types',
+  Timeline = 'timeline',
+  Environment = 'environment',
+}
+
+export enum ResultsTabs {
+  Studies = 'studies',
+  Samples = 'samples',
+}

--- a/web/src/views/Search/types.ts
+++ b/web/src/views/Search/types.ts
@@ -1,3 +1,5 @@
+export const VISUALIZATION_HEIGHT = 360;
+
 export enum VisualizationTabs {
   DataTypes = 'data-types',
   Timeline = 'timeline',


### PR DESCRIPTION
Resolves #2186 and resolves #2187 

This PR updates the Data Portal UI such that there are now 3 visualization tabs. This helps reduce the cognitive load of the interface and should improve discovery of the bulk download feature and results in general. The active tab is now captured in the URL with the `view=...` search param. The lower results tab (implemented in a previous PR) is also now captured in the URL with the `results=...` tab. If a URL does not contain one or both of those parameters, a default tab will be applied to the UI.

The `HelpWrapper` component has been expanded to enable inner content to go into fullscreen mode with an optional prop. This is currently enabled for the map and sankey diagram.

The visualization colors have also been changed to all be blue with the intention of distinguishing them from the interactive buttons and making those buttons more visible.

This PR also fixes some issues with link styles introduced from a previous PR.

### Screenshot

<img width="2560" height="1316" alt="Screenshot 2026-06-22 at 4 30 48 PM" src="https://github.com/user-attachments/assets/5e2b4a95-8818-4969-b7f1-8d71f339ab0d" />

AI disclosure: portions of this PR were assisted by the Claude Sonnet 4.6 model.