### PR TITLE
Apply deterministic ordering to computed `templateList`

### DIFF
--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -585,6 +585,7 @@ watch(() => multiOmicsForm.ship, (newVal) => {
 /**
  * Environmental Package Step
  */
+const HARMONIZER_KEYS = Object.keys(HARMONIZER_TEMPLATES) as (keyof typeof HARMONIZER_TEMPLATES)[];
 const sampleEnvironmentFormDefault = {
   validation: null as null | string[],
   packageName: [] as (keyof typeof HARMONIZER_TEMPLATES)[],
@@ -672,7 +673,12 @@ const templateList = computed<string[]>((prevTemplates) => {
       }
     }
   }
-  const newTemplates = Array.from(templates);
+  const newTemplates = Array.from(templates)
+    .sort((a, b) => {
+      const aIndex = HARMONIZER_KEYS.indexOf(a);
+      const bIndex = HARMONIZER_KEYS.indexOf(b);
+      return aIndex - bIndex;
+    });
   if (prevTemplates !== undefined && isEqual(prevTemplates, newTemplates)) {
     return prevTemplates;
   }

--- a/web/src/views/SubmissionPortal/types.ts
+++ b/web/src/views/SubmissionPortal/types.ts
@@ -25,6 +25,8 @@ export interface HarmonizerTemplateInfo {
   // This value comes from annotations in the schema. It will be populated once the schema is loaded.
   excelWorksheetName?: string,
 }
+// Holds a mapping between template names stored in Postgres and various related pieces of information about them.
+// Note: the key order determines the order in which tabs are shown on the Sample Metadata screen.
 export const HARMONIZER_TEMPLATES: Record<string, HarmonizerTemplateInfo> = {
   air: {
     displayName: 'air',


### PR DESCRIPTION
Fixes #2204 

These changes ensure that the computed `templateList` (which determines the tabs on the Sample Metadata screen) are ordered according to the keys of the `HARMONIZER_TEMPLATES` constant. I have verified that the existing order of those keys matches the order referenced in the issue.