### PR TITLE
Apply static column width to ribosomal sequence columns

### DIFF
--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -146,7 +146,22 @@ export default class HarmonizerApi {
   }
 
   _getFieldSettings() {
-    const fieldSettings: any = {};
+    const fieldSettings: any = {
+      isolate_ribosomal_seq: {
+        getColumn: (_: any, col: {[key: string]: any}) => {
+          const newCol = { ...col };
+          newCol.width = 180;
+          return newCol;
+        }
+      },
+      isolate_second_ribosomal_seq: {
+        getColumn: (_: any, col: {[key: string]: any}) => {
+          const newCol = { ...col };
+          newCol.width = 180;
+          return newCol;
+        }
+      },
+    };
     const fieldNames = Object.keys(GOLD_FIELDS);
     for (let i = 0; i < fieldNames.length; i += 1) {
       const field = fieldNames[i] as keyof typeof GOLD_FIELDS;


### PR DESCRIPTION
Fixes #2205 

These changes use a DataHarmonizer feature we were already leveraging which allows clients (like `nmdc-server`) to make [Handsontable column](https://handsontable.com/docs/13.1/javascript-data-grid/configuration-options/#set-column-options) customizations on a per-slot basis. In this case the `width` of the column (which is normally automatically calculated) is being manually set for the columns representing the `isolate_ribosomal_seq` and `isolate_second_ribosomal_seq` slots. These columns are expected to contain very long string that aren't intended to be human-readable (i.e. they're just a series of ATCGNs), so I think visually truncating at a predefined width is okay here.