### PR TITLE
Add validation failure when well ID is provided but container is not plate

### DIFF
--- a/web/src/views/SubmissionPortal/validation.test.ts
+++ b/web/src/views/SubmissionPortal/validation.test.ts
@@ -25,15 +25,17 @@ describe('validatePlateWellsForJgi', () => {
     ]);
   });
 
-  it ('flags rows with a well ID and cont_type other than "plate"', () => {
+  it('flags rows with a well ID and cont_type other than "plate"', () => {
     const issues = validatePlateWellsForJgi([
       { cont_type: 'tube', container_name: 'tube-1', cont_well: 'B1' },
       { cont_type: 'tube', container_name: 'tube-2', cont_well: 'C1' },
+      { cont_type: 'tube', container_name: 'tube-3', cont_well: 'Z99' },
     ]);
 
     expect(issues).toEqual([
       { row: 0, slot: 'cont_well', message: 'Well ID should only be provided if container type is "plate"' },
       { row: 1, slot: 'cont_well', message: 'Well ID should only be provided if container type is "plate"' },
+      { row: 2, slot: 'cont_well', message: 'Well ID should only be provided if container type is "plate"' },
     ]);
   });
 

--- a/web/src/views/SubmissionPortal/validation.test.ts
+++ b/web/src/views/SubmissionPortal/validation.test.ts
@@ -100,7 +100,6 @@ describe('validatePlateWellsForJgi', () => {
 
   it('ignores non-plate rows', () => {
     const issues = validatePlateWellsForJgi([
-      { cont_type: 'tube', container_name: 'tube-1', cont_well: 'Z99' },
       { cont_type: 'tube', container_name: 'tube-2', cont_well: '' },
       { cont_type: 'tube', container_name: 'tube-3' },
     ]);

--- a/web/src/views/SubmissionPortal/validation.test.ts
+++ b/web/src/views/SubmissionPortal/validation.test.ts
@@ -13,7 +13,7 @@ describe('validatePlateWellsForJgi', () => {
     expect(issues).toEqual([]);
   });
 
-  it('flags rows with no well ID', () => {
+  it('flags rows with cont_type "plate" and no well ID', () => {
     const issues = validatePlateWellsForJgi([
       { cont_type: 'plate', container_name: 'plate-1', cont_well: '' },
       { cont_type: 'plate', container_name: 'plate-1' },
@@ -22,6 +22,18 @@ describe('validatePlateWellsForJgi', () => {
     expect(issues).toEqual([
       { row: 0, slot: 'cont_well', message: 'Plate position is required if container type is "plate"' },
       { row: 1, slot: 'cont_well', message: 'Plate position is required if container type is "plate"' },
+    ]);
+  });
+
+  it ('flags rows with a well ID and cont_type other than "plate"', () => {
+    const issues = validatePlateWellsForJgi([
+      { cont_type: 'tube', container_name: 'tube-1', cont_well: 'B1' },
+      { cont_type: 'tube', container_name: 'tube-2', cont_well: 'C1' },
+    ]);
+
+    expect(issues).toEqual([
+      { row: 0, slot: 'cont_well', message: 'Well ID should only be provided if container type is "plate"' },
+      { row: 1, slot: 'cont_well', message: 'Well ID should only be provided if container type is "plate"' },
     ]);
   });
 

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -63,9 +63,9 @@ export function validatePlateWellsForJgi(data: DataHarmonizerData): ValidationIs
     const contWell = getTrimmedString(row.cont_well);
 
     if (contType !== 'plate') {
-      // When the container type is not "plate", only verify that the well ID is not provided then skip the rest of
-      // the validation logic which is based on the assumption that the container type is "plate".
-      if (validWellSet.has(contWell)) {
+      // When the container type is not "plate", only verify that a well ID is not provided, then skip the rest of the
+      // validation logic which assumes the container type is "plate".
+      if (contWell !== '') {
         issues.push({
           row: rowIndex,
           slot: CONT_WELL_SLOT,

--- a/web/src/views/SubmissionPortal/validation.ts
+++ b/web/src/views/SubmissionPortal/validation.ts
@@ -60,11 +60,21 @@ export function validatePlateWellsForJgi(data: DataHarmonizerData): ValidationIs
 
   data.forEach((row, rowIndex) => {
     const contType = getTrimmedString(row.cont_type);
+    const contWell = getTrimmedString(row.cont_well);
+
     if (contType !== 'plate') {
+      // When the container type is not "plate", only verify that the well ID is not provided then skip the rest of
+      // the validation logic which is based on the assumption that the container type is "plate".
+      if (validWellSet.has(contWell)) {
+        issues.push({
+          row: rowIndex,
+          slot: CONT_WELL_SLOT,
+          message: 'Well ID should only be provided if container type is "plate"',
+        });
+      }
       return;
     }
 
-    const contWell = getTrimmedString(row.cont_well);
     if (contWell === '') {
       issues.push({ row: rowIndex, slot: CONT_WELL_SLOT, message: 'Plate position is required if container type is "plate"' });
       return;


### PR DESCRIPTION
Fixes #2190 

The linked issue identifies two LinkML rules that are present in `submission-schema`. Because the rules fall into a bit of a LinkML grey area they aren't interpreted by DataHarmonizer they way one might expect. Therefore, the decision was to reimplement the rules in custom `nmdc-server` code. 

The existing code that checks container types, names, and well IDs for JGI standards already captured one of the LinkML rules (namely, when container type is `plate` then the well ID must be provided). These changes add the validation expressed by the other LinkML rule: if a well ID was provided the the container type must be `plate`.