### PR TITLE
Fix bug where "Save" button does not dismiss email address modal

### DIFF
--- a/web/src/components/UserEmailModal.vue
+++ b/web/src/components/UserEmailModal.vue
@@ -49,7 +49,7 @@ const updateUser = async (value:string) => {
 /**
  * Returns `true` if the specified string resembles an email address.
  * 
- * Note: This basic checks still accepts things like ` h e l l o @ example . com `.
+ * Note: This basic check still accepts things like ` u s e r @ example . com `.
  *
  * Docs: https://en.wikipedia.org/wiki/Email_address#Validation_and_verification
  */

--- a/web/src/components/UserEmailModal.vue
+++ b/web/src/components/UserEmailModal.vue
@@ -46,6 +46,13 @@ const updateUser = async (value:string) => {
   user.value = await updateUserRequest.request(() => api.updateUser(user.value!.id, update));
 };
 
+/**
+ * Returns `true` if the specified string resembles an email address (per a basic check).
+ *
+ * Docs: https://en.wikipedia.org/wiki/Email_address#Validation_and_verification 
+ */
+const validateEmailAddr = (s: string) => /.+@.+\..+/.test(s);
+
 const submitterEmail = ref(user.value?.email ?? '');
 
 // dialog is bound to the modal to determine whether to display or not
@@ -54,10 +61,15 @@ const dialog = computed({
   set: (v: boolean) => emit('update:value', v),
 });
 
+/**
+ * Updates the user's email address to be the trimmed, submitted one if the latter is valid.
+ */
 const updateEmail = async () => {
   const email = submitterEmail.value?.trim();
-  await updateUser(email);
-  dialog.value = false;
+  if (validateEmailAddr(email)) {
+    await updateUser(email);
+    dialog.value = false;
+  }
 };
 </script>
 
@@ -68,18 +80,19 @@ const updateEmail = async () => {
     max-width="600"
   >
     <v-card title="Update Email Address">
-      <v-card-text>
-        We were unable to obtain your email address from ORCID. Please provide your email address below to continue.
-      </v-card-text>
-      <v-card-text>
-        <v-form
-          ref="formRef"
-          class="my-6"
-        >
+      <v-form
+        ref="formRef"
+        class="my-6"
+        @submit.prevent="updateEmail"
+      >
+        <v-card-text>
+          We were unable to obtain your email address from ORCID. Please provide your email address below to continue.
+        </v-card-text>
+        <v-card-text>
           <v-text-field
             v-model="submitterEmail"
             :rules="requiredRules('Email is required', [
-              v => /.+@.+\..+/.test(v) || 'Email must be valid',
+              v => validateEmailAddr(v) || 'Email must be valid',
             ])"
             validate-on-blur
             label="User Email *"
@@ -89,27 +102,27 @@ const updateEmail = async () => {
             dense
             class="my-2"
           />
-        </v-form>
-        <v-alert
-          v-if="updateUserRequest.error.value"
-          type="error"
-          class="mt-4"
-        >
-          Something went wrong while updating your email address. Please try again, and if the problem persists, contact us for assistance.
-        </v-alert>
-      </v-card-text>
-      <v-card-actions>
-        <v-spacer class="text-center">
-          <v-btn
-            color="primary"
-            :disabled="!formRef?.isValid || updateUserRequest.loading.value"
-            :loading="updateUserRequest.loading.value"
-            @click="updateEmail"
+          <v-alert
+            v-if="updateUserRequest.error.value"
+            type="error"
+            class="mt-4"
           >
-            Save
-          </v-btn>
-        </v-spacer>
-      </v-card-actions>
+            Something went wrong while updating your email address. Please try again, and if the problem persists, contact us for assistance.
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer class="text-center">
+            <v-btn
+              color="primary"
+              :disabled="!formRef?.isValid || updateUserRequest.loading.value"
+              :loading="updateUserRequest.loading.value"
+              type="submit"
+            >
+              Save
+            </v-btn>
+          </v-spacer>
+        </v-card-actions>
+      </v-form>
     </v-card>
   </v-dialog>
 </template>

--- a/web/src/components/UserEmailModal.vue
+++ b/web/src/components/UserEmailModal.vue
@@ -64,12 +64,14 @@ const dialog = computed({
 });
 
 /**
- * Updates the user's email address to be the one in the form, trimmed of leading/trailing whitespace.
+ * Updates the user's email address to be the one in the form (trimmed), if the latter is valid.
  */
 const updateEmail = async () => {
   const trimmedEmailAddr = submitterEmail.value.trim();
-  await updateUser(trimmedEmailAddr);
-  dialog.value = false;
+  if (validateEmailAddr(trimmedEmailAddr)) {
+    await updateUser(trimmedEmailAddr);
+    dialog.value = false;
+  }
 };
 </script>
 

--- a/web/src/components/UserEmailModal.vue
+++ b/web/src/components/UserEmailModal.vue
@@ -47,9 +47,11 @@ const updateUser = async (value:string) => {
 };
 
 /**
- * Returns `true` if the specified string resembles an email address (per a basic check).
+ * Returns `true` if the specified string resembles an email address.
+ * 
+ * Note: This basic checks still accepts things like ` h e l l o @ example . com `.
  *
- * Docs: https://en.wikipedia.org/wiki/Email_address#Validation_and_verification 
+ * Docs: https://en.wikipedia.org/wiki/Email_address#Validation_and_verification
  */
 const validateEmailAddr = (s: string) => /.+@.+\..+/.test(s);
 
@@ -62,14 +64,12 @@ const dialog = computed({
 });
 
 /**
- * Updates the user's email address to be the trimmed, submitted one if the latter is valid.
+ * Updates the user's email address to be the one in the form, trimmed of leading/trailing whitespace.
  */
 const updateEmail = async () => {
-  const email = submitterEmail.value?.trim();
-  if (validateEmailAddr(email)) {
-    await updateUser(email);
-    dialog.value = false;
-  }
+  const trimmedEmailAddr = submitterEmail.value.trim();
+  await updateUser(trimmedEmailAddr);
+  dialog.value = false;
 };
 </script>
 
@@ -92,7 +92,7 @@ const updateEmail = async () => {
           <v-text-field
             v-model="submitterEmail"
             :rules="requiredRules('Email is required', [
-              v => validateEmailAddr(v) || 'Email must be valid',
+              v => validateEmailAddr(v.trim()) || 'Email must be valid',
             ])"
             validate-on-blur
             label="User Email *"

--- a/web/src/components/UserEmailModal.vue
+++ b/web/src/components/UserEmailModal.vue
@@ -51,7 +51,7 @@ const updateUser = async (value:string) => {
  * 
  * Note: This basic check still accepts things like ` u s e r @ example . com `.
  *
- * Docs: https://en.wikipedia.org/wiki/Email_address#Validation_and_verification
+ * Reference: https://en.wikipedia.org/wiki/Email_address#Validation_and_verification
  */
 const validateEmailAddr = (s: string) => /.+@.+\..+/.test(s);
 


### PR DESCRIPTION
On this branch, I made it so clicking the "Save" button and pressing the "Enter" key both cause the email address form to be submitted. To do that, I moved the "Save" button to _within_ the `v-form` (previously, it was outside of it), made the "Save" button be of type `"submit"`, and removed the "Save" button's sideband way of triggering a submission.

While doing that, I also extracted the email address validation function into a named helper function.

Finally, I made it so both the validation and the storage are happening with the same value (previously, validation was happening with a non-trimmed version of the entered string, but storage was happening with a _trimmed_ version of it).

Most of the changed lines in the diff are indentation-only changes (due to moving the `v-form` tag to an "outer" level of the tree).

### Testing

I tested both clicking the "Save" button and pressing the "Enter" key (when focused on the text field) locally, and both successfully updated the email address in the database. I also confirmed the value stored in the database was the trimmed one, even when the textbox contains leading/trailing whitespace.

### Tickets

Fixes #2208