### PR TITLE
Inner panels should not have rounded corners

### DIFF
--- a/web/src/components/HelpWrapper.vue
+++ b/web/src/components/HelpWrapper.vue
@@ -46,7 +46,7 @@ const close = () => {
       to="body"
       :disabled="!isFullscreen"
     >
-      <v-card :class="['fullscreen-container elevation-0', { 'fullscreen-container--fullscreen': isFullscreen }]">
+      <v-card :class="['fullscreen-container rounded-0 elevation-0', { 'fullscreen-container--fullscreen': isFullscreen }]">
         <div class="fullscreen-toolbar">
           <v-tooltip
             v-if="helpText"


### PR DESCRIPTION
Resolves #2214 

The inner visualization panels, especially the map, should not have rounded corners. This was caused by the `<v-card>` in in `<HelpWrapper>` . A utility class has been added to ensure corners of those cards are not rounded.