### PR TITLE
Remove exclusion of lipidomics from study page data summary

### DIFF
--- a/web/src/views/IndividualResults/StudyPage.vue
+++ b/web/src/views/IndividualResults/StudyPage.vue
@@ -106,7 +106,7 @@ export default defineComponent({
       if (_study.omics_processing_counts !== null) {
         const counts: Record<string, number> = {};
         _study.omics_processing_counts.forEach(({type, count}) => {
-          if (type.toLowerCase() !== 'lipidomics' && count > 0) {
+          if (count > 0) {
             counts[type] = count;
           }
         });


### PR DESCRIPTION
Resolves #1996

For unknown reasons, `Lipidomics` has been being excluded from study page data summaries. This PR ensures any omics processing counts greater than 0 are shown on the study page data summary.