### PR TITLE
Update `nmdc-schema` from `11.20.2` to `11.21.0` (Python and JavaScript)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "linkml-runtime",
     "nmdc-geoloc-tools",
     "nmdc-metadata-suggestor-ai-tool==1.1.2",
-    "nmdc-schema==11.20.2",
+    "nmdc-schema==11.21.0",
     "nmdc-submission-schema==11.20.1",
     "nmdc_api_utilities",
     "pint",

--- a/uv.lock
+++ b/uv.lock
@@ -2001,7 +2001,7 @@ wheels = [
 
 [[package]]
 name = "nmdc-schema"
-version = "11.20.2"
+version = "11.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2020,9 +2020,9 @@ dependencies = [
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/d5/cbfe802e5b23dd2bd6f643664c5403c6a6a9c4cd6617d56c1264378c000e/nmdc_schema-11.20.2.tar.gz", hash = "sha256:9ecaff739fd863a3b00e55668dc0ac7662ba3c06638b3e46330ed9420fbee091", size = 772415, upload-time = "2026-06-18T01:56:20.27Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/387548ca9721704a3a4a38568c39b61b3cbaa0d86ca04f797a8c127d46e5/nmdc_schema-11.21.0.tar.gz", hash = "sha256:6d2cf2793fc256666b524500a7a5b7a4b81c870de0dbcb66036f5606f7db97ad", size = 779295, upload-time = "2026-06-23T22:45:18.04Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/12/d00ed7174452b279e6dbd944452ba66f594d675683882d619031e97f4fd8/nmdc_schema-11.20.2-py3-none-any.whl", hash = "sha256:3ff27adb16b6e572a415f02acab5002c50f18be200857cec90e3310356cb7fb2", size = 847964, upload-time = "2026-06-18T01:56:18.202Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f7/5358fe192cf581e91b8ef60940cc8dfa3aa09ea8c946e55b1e54ec790fdc/nmdc_schema-11.21.0-py3-none-any.whl", hash = "sha256:093881b0aed97ff7898e2db978bdd4eab8101b7475417c61d49408250369f121", size = 856375, upload-time = "2026-06-23T22:45:16.131Z" },
 ]
 
 [[package]]
@@ -2100,7 +2100,7 @@ requires-dist = [
     { name = "nmdc-api-utilities" },
     { name = "nmdc-geoloc-tools" },
     { name = "nmdc-metadata-suggestor-ai-tool", specifier = "==1.1.2" },
-    { name = "nmdc-schema", specifier = "==11.20.2" },
+    { name = "nmdc-schema", specifier = "==11.21.0" },
     { name = "nmdc-submission-schema", specifier = "==11.20.1" },
     { name = "pint" },
     { name = "pydantic" },

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
     "linkify-it": "^4.0.1",
     "lodash": "^4.18.1",
     "moment": "^2.29.4",
-    "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v11.20.2",
+    "nmdc-schema": "https://github.com/microbiomedata/nmdc-schema#v11.21.0",
     "popper.js": "1.16.1",
     "protobufjs": "^7.5.6",
     "vue": "^3.5.21",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3461,9 +3461,9 @@ natural-orderby@^5.0.0:
   resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-5.0.0.tgz#bb655f669ee9c84e82cdc6cddbba25eb263cd9f4"
   integrity sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==
 
-"nmdc-schema@https://github.com/microbiomedata/nmdc-schema#v11.20.2":
+"nmdc-schema@https://github.com/microbiomedata/nmdc-schema#v11.21.0":
   version "0.0.0"
-  resolved "https://github.com/microbiomedata/nmdc-schema#8f1dc97bd80d887ad6f85b72074d6ef16da4ce1f"
+  resolved "https://github.com/microbiomedata/nmdc-schema#e4b86a6b523ef2cc7eff566c00ed7a1e650e0aab"
 
 node-addon-api@^7.0.0:
   version "7.1.1"


### PR DESCRIPTION
On this branch, I performed a routine update of the `nmdc-schema` Python package and NPM package.

```shell
# Sync the uv.lock lockfile.
uv lock

# Sync the package.json lockfile.
cd web
yarn install
```

Fixes #2220 