### PR TITLE
Add GA event tracking for data portal tabs

### DIFF
--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -144,14 +144,12 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab], [oldVisTab,
     return;
   }
   if (newVisTab !== oldVisTab) {
-    console.log('Active visualization tab changed from', oldVisTab, 'to', newVisTab);
     event('tab_selected', {
       tab_group: 'visualizations',
       tab_name: newVisTab,
     });
   }
   if (newResultsTab !== oldResultsTab) {
-    console.log('Active results tab changed from', oldResultsTab, 'to', newResultsTab);
     event('tab_selected', {
       tab_group: 'results',
       tab_name: newResultsTab,

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -5,6 +5,7 @@ import {
 
 } from 'vue';
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc_materialized_patterns.json';
+import { event } from 'vue-gtag';
 
 import SearchResults from '@/components/Presentation/SearchResults.vue';
 import { types } from '@/encoding';
@@ -134,10 +135,29 @@ function toggleChildren(value:StudySearchResult) {
   showChildren.value.includes(value.id) ? showChildren.value.splice(showChildren.value.indexOf(value.id), 1) : showChildren.value.push(value.id);
 }
 
-watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab]) => {
+watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab], [oldVisTab, oldResultsTab]) => {
   const { view, results, ...rest } = route.query;
-  router.replace({ query: { view: newVisTab, results: newResultsTab, ...rest } })
-});
+  router.replace({ query: { view: newVisTab, results: newResultsTab, ...rest } });
+  // Do nothing if Google Analytics is not available. This is expected in development mode.
+  // TODO: Consider making this check reusable because it should be used any time we track GA events.
+  if (import.meta.env.DEV) {
+    return;
+  }
+  if (newVisTab !== oldVisTab) {
+    console.log('Active visualization tab changed from', oldVisTab, 'to', newVisTab);
+    event('tab_selected', {
+      tab_group: 'visualizations',
+      tab_name: newVisTab,
+    });
+  }
+  if (newResultsTab !== oldResultsTab) {
+    console.log('Active results tab changed from', oldResultsTab, 'to', newResultsTab);
+    event('tab_selected', {
+      tab_group: 'results',
+      tab_name: newResultsTab,
+    });
+  }
+}, { immediate: true });
 </script>
 
 <template>


### PR DESCRIPTION
Resolves #2216 

Adds a new Google Analytics event called `tab_selected` which will get logged any time the new Data Portal UI tabs change (including on load/refresh). The particular tab group is specified in `tab_group` and the name of the tab in `tab_name`. I think we will need to create two new custom dimensions in GA, one for Tab Group and one for Tab Name. I believe that's the only action we need to take on the GA side besides creating a new custom exploration for looking at tab selection data. We will need to do this in both the dev and prod GA instance.