### PR TITLE
Fix pasted Data Portal filter URLs

### DIFF
--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -1,0 +1,43 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let routeHasConditions: typeof import('./index').routeHasConditions;
+
+function routeWithQuery(query: Record<string, unknown>) {
+  return { query } as Parameters<typeof routeHasConditions>[0];
+}
+
+beforeAll(async () => {
+  // The store imports the API client, which reads window.location at module load time.
+  // Provide just enough browser global for this focused helper test.
+  globalThis.window = {
+    location: { origin: 'http://localhost' },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => undefined,
+      removeItem: () => undefined,
+    },
+  } as unknown as Window & typeof globalThis;
+
+  ({ routeHasConditions } = await import('./index'));
+});
+
+describe('routeHasConditions', () => {
+  it('detects decoded URL conditions so startup does not overwrite pasted filters', () => {
+    expect(routeHasConditions(routeWithQuery({
+      conditions: [{
+        table: 'study',
+        field: 'principal_investigator_name',
+        op: '==',
+        value: 'Kate Thibault',
+      }],
+    }))).toBe(true);
+  });
+
+  it('treats an empty decoded conditions list as no URL filter state', () => {
+    expect(routeHasConditions(routeWithQuery({ conditions: [] }))).toBe(false);
+  });
+
+  it('treats routes without conditions as restorable from saved local query state', () => {
+    expect(routeHasConditions(routeWithQuery({ view: 'data-types' }))).toBe(false);
+  });
+});

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -9,6 +9,7 @@ import {
 import { User } from '@/types';
 import { clearQueryState, getQueryState, setQueryState } from '@/store/localStorage';
 import { Router } from 'vue-router';
+import { routeHasConditions } from '@/store/route';
 
 let router: Router | null = null;
 const state = reactive({
@@ -85,11 +86,6 @@ function restoreState() {
   }
 }
 
-function routeHasConditions(currentRoute: Router['currentRoute']['value']) {
-  const { conditions } = currentRoute.query;
-  return Array.isArray(conditions) ? conditions.length > 0 : !!conditions;
-}
-
 // @ts-ignore
 window.restoreState = restoreState;
 
@@ -133,8 +129,12 @@ async function init(_router: Router, loadUser = true, loginState = '' as string 
       // Login normally
       // @ts-ignore
       state.conditions = router.currentRoute.value.query.conditions || [];
-      if (state.user && !routeHasConditions(router.currentRoute.value)) {
-        restoreState();
+      if (state.user) {
+        if (routeHasConditions(router.currentRoute.value)) {
+          clearQueryState();
+        } else {
+          restoreState();
+        }
       }
       break;
   }
@@ -234,5 +234,4 @@ export {
   setUniqueCondition,
   setConditions,
   toggleConditions,
-  routeHasConditions,
 };

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -85,6 +85,11 @@ function restoreState() {
   }
 }
 
+function routeHasConditions(currentRoute: Router['currentRoute']['value']) {
+  const { conditions } = currentRoute.query;
+  return Array.isArray(conditions) ? conditions.length > 0 : !!conditions;
+}
+
 // @ts-ignore
 window.restoreState = restoreState;
 
@@ -128,7 +133,7 @@ async function init(_router: Router, loadUser = true, loginState = '' as string 
       // Login normally
       // @ts-ignore
       state.conditions = router.currentRoute.value.query.conditions || [];
-      if (state.user) {
+      if (state.user && !routeHasConditions(router.currentRoute.value)) {
         restoreState();
       }
       break;
@@ -229,4 +234,5 @@ export {
   setUniqueCondition,
   setConditions,
   toggleConditions,
+  routeHasConditions,
 };

--- a/web/src/store/route.test.ts
+++ b/web/src/store/route.test.ts
@@ -1,25 +1,10 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-let routeHasConditions: typeof import('./index').routeHasConditions;
+import { routeHasConditions } from './route';
 
 function routeWithQuery(query: Record<string, unknown>) {
   return { query } as Parameters<typeof routeHasConditions>[0];
 }
-
-beforeAll(async () => {
-  // The store imports the API client, which reads window.location at module load time.
-  // Provide just enough browser global for this focused helper test.
-  globalThis.window = {
-    location: { origin: 'http://localhost' },
-    localStorage: {
-      getItem: () => null,
-      setItem: () => undefined,
-      removeItem: () => undefined,
-    },
-  } as unknown as Window & typeof globalThis;
-
-  ({ routeHasConditions } = await import('./index'));
-});
 
 describe('routeHasConditions', () => {
   it('detects decoded URL conditions so startup does not overwrite pasted filters', () => {

--- a/web/src/store/route.ts
+++ b/web/src/store/route.ts
@@ -1,0 +1,8 @@
+import { RouteLocationNormalizedLoaded } from 'vue-router';
+
+function routeHasConditions(currentRoute: Pick<RouteLocationNormalizedLoaded, 'query'>) {
+  const { conditions } = currentRoute.query;
+  return Array.isArray(conditions) ? conditions.length > 0 : !!conditions;
+}
+
+export { routeHasConditions };


### PR DESCRIPTION
> [!IMPORTANT]
> Codex opened this PR on @eecavanna's behalf. He has not reviewed its contents yet.

### Motivation
- Pasted/search-filter URLs that include decoded `conditions` were being overwritten at app startup by previously persisted local query state, causing pasted filtered links to show unfiltered results.
- The issue affects the search state initialization logic in `web/src/store/index.ts` and required a small change to prefer explicit route-provided conditions.
- The intent is to ensure explicit URL filters always take precedence while preserving the existing behavior of restoring saved local state when no URL filters are present.

### Description
- Add a `routeHasConditions(currentRoute)` helper in `web/src/store/index.ts` that detects whether the current route query contains decoded `conditions`.
- Change `init()` so `restoreState()` is only called for logged-in users when the current route does not contain conditions, preventing URL filters from being overwritten.
- Export `routeHasConditions` and add a focused unit test `web/src/store/index.test.ts` that verifies detection of decoded URL conditions, empty condition arrays, and routes without conditions.
- The changes are limited to search-store initialization and tests and retain the original behavior of restoring persisted state when no URL conditions exist.

### Testing
- Ran the focused unit test with `yarn test src/store/index.test.ts`, which passed.
- Ran the full test suite with `yarn test`, and all tests passed (`13` tests in this environment). 
- Ran type checking with `yarn type-check` (`vue-tsc`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a44a0974d4c8331afac0c1c84b51be5)