### PR TITLE
Make `Study Description` text area scrollable for review

### DIFF
--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -180,7 +180,6 @@ export default defineComponent({
             v-model="studyForm.description"
             label="Study Description"
             :hint="Definitions.studyDescription"
-            :class="{ 'readonly-as-disabled': formRef?.isDisabled }"
             persistent-hint
             variant="outlined"
           >

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -180,8 +180,6 @@ export default defineComponent({
             v-model="studyForm.description"
             label="Study Description"
             :hint="Definitions.studyDescription"
-            :readonly="formRef?.isDisabled"
-            :disabled="false"
             :class="{ 'readonly-as-disabled': formRef?.isDisabled }"
             persistent-hint
             variant="outlined"
@@ -611,13 +609,8 @@ export default defineComponent({
     </div>
   </div>
 </template>
-<style scoped>
-.readonly-as-disabled :deep(.v-field),
-.readonly-as-disabled :deep(.v-input__details) {
-  opacity: var(--v-disabled-opacity, 0.6);
-}
-
-.readonly-as-disabled :deep(textarea) {
-  cursor: default;
+<style lang="scss">
+.v-input--disabled, .v-field--disabled {
+    pointer-events: initial;
 }
 </style>

--- a/web/src/views/SubmissionPortal/Components/StudyForm.vue
+++ b/web/src/views/SubmissionPortal/Components/StudyForm.vue
@@ -180,6 +180,9 @@ export default defineComponent({
             v-model="studyForm.description"
             label="Study Description"
             :hint="Definitions.studyDescription"
+            :readonly="formRef?.isDisabled"
+            :disabled="false"
+            :class="{ 'readonly-as-disabled': formRef?.isDisabled }"
             persistent-hint
             variant="outlined"
           >
@@ -608,3 +611,13 @@ export default defineComponent({
     </div>
   </div>
 </template>
+<style scoped>
+.readonly-as-disabled :deep(.v-field),
+.readonly-as-disabled :deep(.v-input__details) {
+  opacity: var(--v-disabled-opacity, 0.6);
+}
+
+.readonly-as-disabled :deep(textarea) {
+  cursor: default;
+}
+</style>


### PR DESCRIPTION
This PR resolves https://github.com/microbiomedata/issues/issues/1641

Previously the `Study Description` text area was not scrollable or expandable once a submission was submitted for review.
To fix this, the text area is now no longer disabled, but is set to read only and styling has been added to make it visually align with the disabled components in the form.