### PR TITLE
Ensure search conditions are restored on app initialization (persist hotfix `2026.6.1`)

### DIFF
--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -48,7 +48,7 @@ function setConditions(conditions: Condition[], push = false) {
       && a.op === b.op
       && a.table === b.table);
   if (router) {
-    const { conditions, q, ...rest } = router.currentRoute.value.query;
+    const { conditions, q, code, ...rest } = router.currentRoute.value.query;
     // @ts-ignore
     router[push ? 'push' : 'replace']({ query: { ...rest, conditions: state.conditions }, name: 'Search' }).catch(noop);
   }

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -31,7 +31,7 @@ const unreactive = {
  */
 function persistState() {
   /* If the user is browsing anonymously, stash their state in case they log in */
-  if (!state.user) {
+  if (!state.user && router && router.currentRoute.value.name === 'Search') {
     setQueryState({
       conditions: state.conditions,
       bulkDownloadSelected: state.bulkDownloadSelected,
@@ -115,7 +115,6 @@ async function init(_router: Router, loadUser = true, loginState = '' as string 
     state.bannerTitle = appSettings.portal_banner_title;
     state.bannerMessage = appSettings.portal_banner_message;
   } catch (exception) {
-     
     console.error(exception);
   }
   router = _router;

--- a/web/src/utils.ts
+++ b/web/src/utils.ts
@@ -42,23 +42,23 @@ function base64UrlencodedToArrayBuffer(base64Urlencoded: string) {
  * q parameter, and remove the conditions parameter.
  */
 export function stringifyQuery(params: any) {
-  if ('conditions' in params) {
-    if (params.conditions.length) {
-      const clone = cloneDeep(params);
+  // Make a shallow copy of the params object so we don't modify the original
+  const queryParams = { ...params };
+  if ('conditions' in queryParams) {
+    if (queryParams.conditions.length) {
+      const clone = cloneDeep(queryParams);
       clone.conditions.forEach((c: Condition) => {
-         
         c.value = JSON.stringify(c.value);
       });
       // https://github.com/protobufjs/protobuf.js/issues/1261#issuecomment-667430623
       const msg = QueryParams.fromObject(clone);
       const u8a = QueryParams.encode(msg).finish();
-       
-      params.q = arrayBufferToBase64Urlencoded(u8a);
+
+      queryParams.q = arrayBufferToBase64Urlencoded(u8a);
     }
-     
-    delete params.conditions;
+    delete queryParams.conditions;
   }
-  const queryParamsString = new URLSearchParams(params).toString();
+  const queryParamsString = new URLSearchParams(queryParams).toString();
   return queryParamsString ? `${queryParamsString}` : '';
 }
 
@@ -74,7 +74,6 @@ export function parseQuery(q: string) {
     const obj = QueryParams.toObject(msg, { enums: String });
     obj.conditions.forEach((c: Condition) => {
       // @ts-ignore
-       
       c.value = JSON.parse(c.value);
     });
     parsed.conditions = obj.conditions;


### PR DESCRIPTION
> [!NOTE]
> This PR is the same as PR https://github.com/microbiomedata/nmdc-server/pull/2236, except that the base branch of this one is `main`. The final step of the hotfix procedure is to "open a pull request to merge the hotfix branch into `main`." This PR is that pull request. The collapsed section below contains a copy of the description of that PR https://github.com/microbiomedata/nmdc-server/pull/2236:

<details>

<summary>Show/hide copy of description of PR #2236</summary>

---

Fixes #2230 

Supersedes https://github.com/microbiomedata/nmdc-server/pull/2233. Sadly codex really biffed it.

The relevant change in Release 2026.6 is the addition of this call to `router.replace` in `SearchLayout.vue`: https://github.com/microbiomedata/nmdc-server/blob/91cf2b6e95ca9eace5abfb03cb4cce18f5364bbd/web/src/views/Search/SearchLayout.vue#L138-L158

Calling `router.replace` (line 140) triggers a re-stringify-ing of the query params through our custom function: https://github.com/microbiomedata/nmdc-server/blob/91cf2b6e95ca9eace5abfb03cb4cce18f5364bbd/web/src/utils.ts#L40-L63

‼️ Note that this function **modifies the provided query params** by calling `delete params.conditions` (line 59).

Previously this wasn't a problem because the parsed conditions were loaded into application state before `stringifyQuery` was ever called: https://github.com/microbiomedata/nmdc-server/blob/91cf2b6e95ca9eace5abfb03cb4cce18f5364bbd/web/src/store/index.ts#L130

However now `router.replace` is called in an immediately-triggered watcher. This means that `stringifyQuery` gets called before the assignment of `state.conditions`.

So the fix here to **not** modify the params passed to `stringifyQuery`. Now it makes a shallow copy and operates on that, which makes the `delete` call safe. Vue Router's underlying params object is unchanged, and it is intact when `state.conditions` is assigned.

---

Some ancillary changes:

* Previously the `router.push`/`router.replace` call in `setConditions` only set the `conditions` query param. In Release 2026.6 this changed to pass through extra params (like the new `view` and `results` params). This also allowed the login token exchange code to remain the URL longer than needed. These changes add `code` to the list of query params intentionally dropped when calling `setConditions`.
* Previously the `persistState` was too aggressive about when it called `setQueryState`. This causes a bug where `setQueryState` is incorrectly called during the login process. These changes add an additional guard to ensure it is only called when the user is actually in the search interface.

---

</details>