### PR TITLE
add unsaved image dialogue to `SubmissionForm` pages

### DIFF
--- a/web/src/views/SubmissionPortal/Components/ImageUpload.vue
+++ b/web/src/views/SubmissionPortal/Components/ImageUpload.vue
@@ -2,8 +2,10 @@
 import {
   computed,
   defineComponent,
+  onUnmounted,
   PropType,
   ref,
+  watch,
 } from 'vue';
 // WARNING: The useForm composable is not part of the Vuetify public API yet
 //          https://github.com/vuetifyjs/vuetify/issues/19315
@@ -75,12 +77,22 @@ export default defineComponent({
       return props.imageUrl;
     });
 
+    // add selected but not yet uploaded to the list of pending uploads
+    watch(fileRef, (file) => {
+      store.setImageUploadPending(props.imageType, !!file);
+    })
+
+    onUnmounted(() => {
+      store.setImageUploadPending(props.imageType, false);
+    });
+
     const { request: uploadRequest, loading: uploading, error: uploadError } = useRequest();
     const handleUpload = () => uploadRequest(async () => {
       if (!fileRef.value) {
         return;
       }
       await store.uploadSubmissionImage(fileRef.value, props.imageType);
+      fileRef.value = null;
     });
 
     const { request: deleteRequest, loading: deleting, error: deleteError } = useRequest();

--- a/web/src/views/SubmissionPortal/Components/SubmissionForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionForm.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, onMounted, useTemplateRef, watch, ref } from 'vue';
 import { isEqual } from 'lodash';
 import { SubmissionEditorRole } from '@/views/SubmissionPortal/types.ts';
 import { useSubmissionStore } from '../store';
+import { onBeforeRouteLeave } from 'vue-router';
 
 const {
   allowedRoles = ['owner', 'editor'],
@@ -17,6 +18,8 @@ const emit = defineEmits<{
 }>();
 
 const store = useSubmissionStore();
+const leaveDialog = ref(false);
+const pendingNext = ref<(() => void) | null>(null);
 
 const formRef = useTemplateRef('formRef');
 const isDisabled = computed(() => store.getUneditableReason(allowedRoles, inSampleSetContext) !== undefined);
@@ -51,6 +54,25 @@ onMounted(() => {
   void validate();
 });
 
+onBeforeRouteLeave((to, from, next) => {
+  if (store.hasPendingImageUploads) {
+    leaveDialog.value = true;
+    pendingNext.value = next;
+  } else {
+    next();
+  }
+});
+
+function handleLeaveDialog(leave: boolean) {
+  leaveDialog.value = false;
+  if (leave) {
+    pendingNext.value?.();
+    pendingNext.value = null;
+  } else {
+    pendingNext.value = null;
+  }
+}
+
 defineExpose({
   validate,
   isDisabled,
@@ -65,4 +87,35 @@ defineExpose({
   >
     <slot />
   </v-form>
+  <v-dialog
+    v-model="leaveDialog"
+    persistent
+    max-width="500"
+  >
+    <v-card>
+      <v-card-title class="text-h5">
+        Unsaved Image
+      </v-card-title>
+      <v-card-text>
+        You have an image selected that hasn't been uploaded yet. If you leave now, it will be lost.
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn
+          color="grey"
+          text
+          @click="handleLeaveDialog(false)"
+        >
+          Cancel
+        </v-btn>
+        <v-btn
+          color="primary"
+          text
+          @click="handleLeaveDialog(true)"
+        >
+          Leave
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>

--- a/web/src/views/SubmissionPortal/Components/SubmissionForm.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionForm.vue
@@ -18,8 +18,9 @@ const emit = defineEmits<{
 }>();
 
 const store = useSubmissionStore();
-const leaveDialog = ref(false);
-const pendingNext = ref<(() => void) | null>(null);
+const leaveDialogOpen = ref(false);
+let leaveDialogPromise: Promise<boolean> | null = null;
+let leaveDialogResolve: ((value: boolean) => void) | null = null;
 
 const formRef = useTemplateRef('formRef');
 const isDisabled = computed(() => store.getUneditableReason(allowedRoles, inSampleSetContext) !== undefined);
@@ -54,23 +55,38 @@ onMounted(() => {
   void validate();
 });
 
-onBeforeRouteLeave((to, from, next) => {
-  if (store.hasPendingImageUploads) {
-    leaveDialog.value = true;
-    pendingNext.value = next;
-  } else {
-    next();
+function confirmLeave() {
+  if (leaveDialogPromise) {
+    return leaveDialogPromise;
   }
+  leaveDialogOpen.value = true;
+
+  leaveDialogPromise = new Promise<boolean>((resolve) => {
+    // Stash the resolve function for use in handleLeaveDialog
+    leaveDialogResolve = resolve;
+  }).finally(() => {
+    // Tidy up whenever the promise settles
+    leaveDialogOpen.value = false;
+    leaveDialogPromise = null;
+    leaveDialogResolve = null;
+  });
+  return leaveDialogPromise;
+}
+
+onBeforeRouteLeave(async () => {
+  if (!store.hasPendingImageUploads) {
+    // No pending uploads, allow navigation
+    return true;
+  }
+  // There are pending uploads, show dialog and proceed based on user choice
+  return await confirmLeave();
 });
 
 function handleLeaveDialog(leave: boolean) {
-  leaveDialog.value = false;
-  if (leave) {
-    pendingNext.value?.();
-    pendingNext.value = null;
-  } else {
-    pendingNext.value = null;
+  if (leaveDialogResolve === null) {
+    return;
   }
+  leaveDialogResolve(leave);
 }
 
 defineExpose({
@@ -88,19 +104,15 @@ defineExpose({
     <slot />
   </v-form>
   <v-dialog
-    v-model="leaveDialog"
+    v-model="leaveDialogOpen"
     persistent
     max-width="500"
   >
-    <v-card>
-      <v-card-title class="text-h5">
-        Unsaved Image
-      </v-card-title>
-      <v-card-text>
-        You have an image selected that hasn't been uploaded yet. If you leave now, it will be lost.
-      </v-card-text>
+    <v-card
+      title="Unsaved Image"
+      text="You have an image selected that hasn't been uploaded yet. If you leave now, it will be lost."
+    >
       <v-card-actions>
-        <v-spacer></v-spacer>
         <v-btn
           color="grey"
           text

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -165,6 +165,7 @@ type SampleSetStoreState = {
 type UiState = {
   suggestionMode: SuggestionsMode
   suggestionType: SuggestionType
+  pendingImageUploads: Set<SubmissionImageType>
 }
 
 /* STATE-FREE HELPERS */
@@ -209,6 +210,7 @@ export const useSubmissionStore = defineStore('submission', () => {
   const ui = reactive<UiState>({
     suggestionMode: SuggestionsMode.LIVE,
     suggestionType: SuggestionType.ALL,
+    pendingImageUploads: new Set(),
   });
 
   /* GETTERS */
@@ -309,6 +311,7 @@ export const useSubmissionStore = defineStore('submission', () => {
     }
     return newTemplates;
   });
+  const hasPendingImageUploads = computed(() => ui.pendingImageUploads.size > 0);
 
   /* WATCHERS */
   // When "Have data already been generated for your study?" changes, reset the answers to dependent questions
@@ -749,6 +752,17 @@ export const useSubmissionStore = defineStore('submission', () => {
     submission.record = await api.deleteSubmissionImage(submissionId, imageType);
   }
 
+   /**
+   * If a file is selected for upload then we add it to the list of pending uploads
+   */
+  function setImageUploadPending(image: SubmissionImageType, isPending: boolean) {
+    if (isPending) {
+      ui.pendingImageUploads.add(image);
+    } else {
+      ui.pendingImageUploads.delete(image);
+    }
+  }
+
   /**
    * Request the edit lock on the submission.
    *
@@ -1063,6 +1077,7 @@ export const useSubmissionStore = defineStore('submission', () => {
     submissionIsDirty,
     sampleSetIsDirty,
     templateList,
+    hasPendingImageUploads,
 
     /* ACTIONS */
     loadSubmission,
@@ -1072,6 +1087,7 @@ export const useSubmissionStore = defineStore('submission', () => {
     saveSubmissionFormEdits,
     uploadSubmissionImage,
     deleteSubmissionImage,
+    setImageUploadPending,
     lockSubmission,
     unlockSubmission,
     getUneditableReason,


### PR DESCRIPTION
This PR resolves https://github.com/microbiomedata/nmdc-server/issues/2237 

These changes add a dialog that appears if a user tries to navigate away from a page where they've selected an image to upload but they did not click the `upload` button. These changes are applied to `SubmissionForm` so they should be present in any future image upload options added to other forms as well.

This functionality is added by adding a new bit of state to the store that tracks any pending selected images. When an image is uploaded that pending image is cleared from the set. 

Considerations:
Do we want to add an 'upload pending images and continue' option? 
Are there cases where `ImageUpload` would be included outside of Submission Portal forms?