### PR TITLE
Fix bug where amplicon table shows only the first `DataGeneration` record

### DIFF
--- a/web/src/components/AmpliconObjectDataTable.vue
+++ b/web/src/components/AmpliconObjectDataTable.vue
@@ -25,7 +25,7 @@ export default defineComponent({
       { title: 'Target Subfragment', value: 'target_subfragment' },
     ];
 
-    // Derive the table rows from the `omicsProcessing` props (an array).
+    // Derive the table rows from the `omicsProcessing` prop (an array).
     const items = computed(() => props.omicsProcessing.map((op) => ({
       type: op.annotations.type,
       insdc_experiment_identifiers: op.annotations.insdc_experiment_identifiers,
@@ -33,10 +33,29 @@ export default defineComponent({
       target_subfragment: op.annotations.target_subfragment,
     })));
 
+    /**
+     * Returns the first INSDC Experiment Identifier represented by the specified item (of the kind
+     * of "items" that we derive from the `omicsProcessing` prop).
+     * 
+     * Note: We use this helper function because the relevant field can contain either a string or
+     *       an array of strings and we don't want to clutter the template with that logic.
+     *       "Why do we give special consideration to the first one?" I don't know. This is a
+     *       refactor of existing code, which did not include anyone's rationale for doing that.
+     */
+    const getFirstInsdcExperimentIdentifier = (item: {insdc_experiment_identifiers?: OmicsProcessingResult["annotations"]["insdc_experiment_identifiers"]}): string | null => {
+      const value = item.insdc_experiment_identifiers;
+      if (Array.isArray(value)) {
+        return typeof value[0] === "string" ? value[0] : null;
+      } else {
+        return typeof value === "string" ? value : null;
+      }
+    }
+
     return {
       headers,
       items,
       BioprojectLinkBase,
+      getFirstInsdcExperimentIdentifier,
     };
   },
 });
@@ -50,11 +69,11 @@ export default defineComponent({
     <!-- eslint-disable-next-line -->
     <template #item.insdc_experiment_identifiers="{ item }">
       <a
-        :href="BioprojectLinkBase + item?.insdc_experiment_identifiers"
+        :href="BioprojectLinkBase + getFirstInsdcExperimentIdentifier(item)"
         target="_blank"
         rel="noopener noreferrer"
       >
-        {{ item && item.insdc_experiment_identifiers && item.insdc_experiment_identifiers[0] }}
+        {{ item && getFirstInsdcExperimentIdentifier(item) }}
       </a>
     </template>
   </v-data-table>

--- a/web/src/components/AmpliconObjectDataTable.vue
+++ b/web/src/components/AmpliconObjectDataTable.vue
@@ -55,16 +55,17 @@ export default defineComponent({
     /**
      * Returns a URL ready for use as the value of the `href` attribute of a link element.
      * 
-     * Note: If `insdcExperimentIdentifier` is `null`, we set the URL to "#" so that the link is a
-     *       valid HTML element, although clicking on it doesn't take the user anywhere. However,
+     * Note: If `insdcExperimentIdentifier` isn't a string, we set the URL to "#" so the link is a
+     *       valid HTML element, but clicking on it doesn't take the user anywhere. Note that, the
      *       the way we use this function today, we don't even _render_ the link in that situation.
      */
     const makeInsdcHref = (insdcExperimentIdentifier: string | null): string => {
+      let url = "#";
       if (typeof insdcExperimentIdentifier === "string") {
-        return new URL(insdcExperimentIdentifier, BioprojectLinkBase).toString();
-      } else {
-        return "#";
+        const urlSafeInsdcExperimentIdentifier = encodeURIComponent(insdcExperimentIdentifier); // e.g. "insdc:foo" -> "insdc%3Afoo"
+        url = BioprojectLinkBase.concat(urlSafeInsdcExperimentIdentifier); // e.g. "https://bioregistry.io/insdc%3Afoo"
       }
+      return url;
     };
 
     return {

--- a/web/src/components/AmpliconObjectDataTable.vue
+++ b/web/src/components/AmpliconObjectDataTable.vue
@@ -25,9 +25,13 @@ export default defineComponent({
       { title: 'Target Subfragment', value: 'target_subfragment' },
     ];
 
-    const items = computed(() => {
-      return props.omicsProcessing[0]?.annotations ? [props.omicsProcessing[0].annotations] : [];
-    });
+    // Derive the table rows from the `omicsProcessing` props (an array).
+    const items = computed(() => props.omicsProcessing.map((op) => ({
+      type: op.annotations.type,
+      insdc_experiment_identifiers: op.annotations.insdc_experiment_identifiers,
+      target_gene: op.annotations.target_gene,
+      target_subfragment: op.annotations.target_subfragment,
+    })));
 
     return {
       headers,

--- a/web/src/components/AmpliconObjectDataTable.vue
+++ b/web/src/components/AmpliconObjectDataTable.vue
@@ -37,10 +37,11 @@ export default defineComponent({
      * Returns the first INSDC Experiment Identifier represented by the specified item (of the kind
      * of "items" that we derive from the `omicsProcessing` prop).
      * 
-     * Note: We use this helper function because the relevant field can contain either a string or
-     *       an array of strings and we don't want to clutter the template with that logic.
-     *       "Why do we give special consideration to the first one?" I don't know. This is a
-     *       refactor of existing code, which did not include anyone's rationale for doing that.
+     * Note: We made this helper function because the relevant field can contain either a string or
+     *       an array of strings and we don't want to clutter the template with the necessary code
+     *       to pluck the right value from it. As for why we give special consideration to the
+     *       _first_ item in the array: I don't know. This is a refactor of some existing code,
+     *       and that existing code did not include an explanation/rationale for doing that.
      */
     const getFirstInsdcExperimentIdentifier = (item: {insdc_experiment_identifiers?: OmicsProcessingResult["annotations"]["insdc_experiment_identifiers"]}): string | null => {
       const value = item.insdc_experiment_identifiers;
@@ -49,13 +50,29 @@ export default defineComponent({
       } else {
         return typeof value === "string" ? value : null;
       }
-    }
+    };
+
+    /**
+     * Returns a URL ready for use as the value of the `href` attribute of a link element.
+     * 
+     * Note: If `insdcExperimentIdentifier` is `null`, we set the URL to "#" so that the link is a
+     *       valid HTML element, although clicking on it doesn't take the user anywhere. However,
+     *       the way we use this function today, we don't even _render_ the link in that situation.
+     */
+    const makeInsdcHref = (insdcExperimentIdentifier: string | null): string => {
+      if (typeof insdcExperimentIdentifier === "string") {
+        return new URL(insdcExperimentIdentifier, BioprojectLinkBase).toString();
+      } else {
+        return "#";
+      }
+    };
 
     return {
       headers,
       items,
       BioprojectLinkBase,
       getFirstInsdcExperimentIdentifier,
+      makeInsdcHref,
     };
   },
 });
@@ -69,11 +86,12 @@ export default defineComponent({
     <!-- eslint-disable-next-line -->
     <template #item.insdc_experiment_identifiers="{ item }">
       <a
-        :href="BioprojectLinkBase + getFirstInsdcExperimentIdentifier(item)"
+        v-if="typeof getFirstInsdcExperimentIdentifier(item) === 'string'"
+        :href="makeInsdcHref(getFirstInsdcExperimentIdentifier(item))"
         target="_blank"
         rel="noopener noreferrer"
       >
-        {{ item && getFirstInsdcExperimentIdentifier(item) }}
+        {{ getFirstInsdcExperimentIdentifier(item) }}
       </a>
     </template>
   </v-data-table>

--- a/web/src/components/AmpliconObjectDataTable.vue
+++ b/web/src/components/AmpliconObjectDataTable.vue
@@ -20,7 +20,7 @@ export default defineComponent({
   setup(props) {
     const headers: DataTableHeader[] = [
       { title: 'Type', value: 'type' },
-      { title: 'INSDC Expirement Identifiers', value: 'insdc_experiment_identifiers' },
+      { title: 'INSDC Experiment Identifiers', value: 'insdc_experiment_identifiers' },
       { title: 'Target Gene', value: 'target_gene' },
       { title: 'Target Subfragment', value: 'target_subfragment' },
     ];


### PR DESCRIPTION
On this branch, I fixed three things:
- a spelling error in a table header
- a bug where the table would only show a single amplicon item when the API had returned multiple amplicon items
- an issue where—when an item lacked an INSDC identifier—the DOM would contain an "empty" anchor element (nothing would appear on the page, but it was still in the DOM)

Three Amplicon items:

<img width="640" height="257" alt="image" src="https://github.com/user-attachments/assets/cccf62f7-0a57-44d7-93ec-6a8f03727ff1" />

Two Amplicon items:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/689f30a1-86ac-4d88-a7de-3395b6b64d68" />

One Amplicon item:

<img width="640" alt="image" src="https://github.com/user-attachments/assets/44bf36e0-28e7-49c7-90e1-ba71099c6e5b" />

Zero Amplicon items:

<img width="640" height="68" alt="image" src="https://github.com/user-attachments/assets/a72d443f-af3c-430c-b38c-76edf6aa18d9" />

Issues:

- Fixes #2244 
- Fixes #2245 

I did not fix the overall layout (i.e. table width) issue described in https://github.com/microbiomedata/nmdc-server/issues/2247.