### PR TITLE
Add new settings for disabling download features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ NMDC_GOOGLE_MAP_API_KEY=thiscanbeanythingfortesting
 #NMDC_ZIP_STREAMER_NERSC_DATA_BASE_URL="https://data.microbiomedata.org/data"
 #NMDC_NERSC_DATA_URL_EXTERNAL_REPLACEMENT_PREFIX="https://data.microbiomedata.org/data"
 
+# These environment variables can be used to disable data file download widgets on the UI;
+# e.g. during periods when the file hosting infrastructure is down for maintenance.
+NMDC_DISABLE_BULK_DATA_PRODUCT_DOWNLOAD=False
+NMDC_DISABLE_INDIVIDUAL_DATA_PRODUCT_DOWNLOAD=False
+
 # == GitHub NMDC Submission Bot setting ==
 # These environment variables are used to authenticate with the GitHub API using
 # the NMDC Submission Bot, which is responsible for creating GitHub issues when

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -91,7 +91,8 @@ def get_health(
 @router.get("/settings", name="Get application settings")
 async def get_settings() -> Dict[str, Any]:
     return {
-        "disable_bulk_download": settings.disable_bulk_download.upper() == "YES",
+        "disable_bulk_data_product_download": settings.disable_bulk_data_product_download.upper() == "YES",
+        "disable_individual_data_product_download": settings.disable_individual_data_product_download.upper() == "YES",
         "portal_banner_message": settings.portal_banner_message,
         "portal_banner_title": settings.portal_banner_title,
     }

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -91,8 +91,8 @@ def get_health(
 @router.get("/settings", name="Get application settings")
 async def get_settings() -> Dict[str, Any]:
     return {
-        "disable_bulk_data_product_download": settings.disable_bulk_data_product_download.upper() == "YES",
-        "disable_individual_data_product_download": settings.disable_individual_data_product_download.upper() == "YES",
+        "disable_bulk_data_product_download": settings.disable_bulk_data_product_download,
+        "disable_individual_data_product_download": settings.disable_individual_data_product_download,
         "portal_banner_message": settings.portal_banner_message,
         "portal_banner_title": settings.portal_banner_title,
     }

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -179,7 +179,14 @@ class Settings(BaseSettings):
     print_sql: bool = False
 
     # App settings related to UI behavior
-    disable_bulk_download: str = ""
+    # TODO: add settings for:
+    # - disable_bulk_metadata_download
+    # - disable_individual_metadata_download
+    disable_bulk_data_product_download: str = "yes"
+    """Disable bulk data product download feature in the UI if this is set to a non-empty string."""
+    disable_individual_data_product_download: str = "yes"
+    """Disable individual data product download feature (and HTML preview modals) in the UI if this is set to a non-empty string."""
+    
     portal_banner_title: Optional[str] = None
     portal_banner_message: Optional[str] = None
 

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -182,11 +182,15 @@ class Settings(BaseSettings):
     # TODO: add settings for:
     # - disable_bulk_metadata_download
     # - disable_individual_metadata_download
-    disable_bulk_data_product_download: str = "yes"
-    """Disable bulk data product download feature in the UI if this is set to a non-empty string."""
-    disable_individual_data_product_download: str = "yes"
-    """Disable individual data product download feature (and HTML preview modals) in the UI if this is set to a non-empty string."""
-    
+    disable_bulk_data_product_download: bool = False
+    """Whether you want to disable the bulk download of data products."""
+    disable_individual_data_product_download: bool = False
+
+    """
+    Whether you want to disable the non-bulk download (i.e. individual download) of data products.
+    This will also disable the HTML previews (e.g. Krona plots) that rely on those data products.
+    """
+
     portal_banner_title: Optional[str] = None
     portal_banner_message: Optional[str] = None
 

--- a/web/src/components/BulkDownload.vue
+++ b/web/src/components/BulkDownload.vue
@@ -42,6 +42,11 @@ const {
   download,
 } = useBulkDownload(stateRefs.conditions, dataObjectFilter);
 
+const disableBulkDataProductDownload = ref(true);
+api.getAppSettings().then((appSettings) => {
+  disableBulkDataProductDownload.value = appSettings.disable_bulk_data_product_download;
+});
+
 function createLabelString(label: string, count: number, size: number): string {
   const labelString = `${label} (${count}`;
   if (size > 0) {
@@ -234,6 +239,17 @@ watch(
       >
         <v-tabs-window-item value="data-products">
           <v-sheet
+            v-if="disableBulkDataProductDownload"
+            class="pa-3 d-flex flex-column"
+          >
+            <span
+              class="text-caption font-weight-bold"
+            >
+              Bulk downloading data products is temporarily disabled.
+            </span>
+          </v-sheet>
+          <v-sheet
+            v-if="!disableBulkDataProductDownload"
             class="pa-3 d-flex flex-column"
           >
             <span

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -97,6 +97,11 @@ export default defineComponent({
       },
     ];
 
+    const disableIndividualDataProductDownload = ref(true);
+    api.getAppSettings().then((appSettings) => {
+      disableIndividualDataProductDownload.value = appSettings.disable_individual_data_product_download;
+    });
+
     const selectedHtmlDataObject: Ref<any | null> = ref(null);
     const dataModal = ref(false);
     const iframeDataSource = ref('');
@@ -258,6 +263,7 @@ export default defineComponent({
       getRelatedBiosampleIds,
       metaproteomicCategoryEnumToDisplay,
       nomMetadataString,
+      disableIndividualDataProductDownload,
     };
   },
 });
@@ -393,22 +399,37 @@ export default defineComponent({
           </td>
           <td>
             {{ item.file_type }}
-            <v-btn
-              v-if="hasHtmlData(item.file_type)"
-              color="primary"
-              icon
-              variant="plain"
-              @click="openHtmlDataModal(item)"
+            <v-tooltip
+              :disabled="!disableIndividualDataProductDownload"
+              location="bottom"
             >
-              <v-icon>mdi-magnify</v-icon>
-            </v-btn>
+              <template #activator="{ props }">
+                <span v-bind="props">
+                  <v-btn
+                    v-if="hasHtmlData(item.file_type)"
+                    :disabled="disableIndividualDataProductDownload"
+                    color="primary"
+                    icon
+                    variant="plain"
+                    @click="openHtmlDataModal(item)"
+                  >
+                    <v-icon>mdi-magnify</v-icon>
+                  </v-btn>
+                </span>
+              </template>
+              <template #default>
+                <span>
+                  HTML preview is temporarily disabled.
+                </span>
+              </template>
+            </v-tooltip>
           </td>
           <td>{{ item.file_type_description }}</td>
           <td>{{ humanFileSize(item.file_size_bytes) }}</td>
           <td>{{ item.downloads }}</td>
           <td>
             <v-tooltip
-              :disabled="!!(loggedInUser && item.url)"
+              :disabled="!!(loggedInUser && item.url && !disableIndividualDataProductDownload)"
               location="bottom"
             >
               <template #activator="{ props }">
@@ -416,7 +437,7 @@ export default defineComponent({
                   <v-btn
                     v-if="item.url"
                     icon
-                    :disabled="!loggedInUser"
+                    :disabled="!loggedInUser || disableIndividualDataProductDownload"
                     variant="text"
                     color="primary"
                     @click="handleDownload(item as unknown as OmicsProcessingResult)"
@@ -436,8 +457,11 @@ export default defineComponent({
                 </span>
               </template>
               <template #default>
-                <span v-if="item.url">
-                  You must be logged in
+                <span v-if="item.url && !loggedInUser">
+                  You must be logged in.
+                </span>
+                <span v-else-if="item.url && loggedInUser && disableIndividualDataProductDownload">
+                  Downloading individual data products is temporarily disabled.
                 </span>
                 <span v-else>
                   File unavailable

--- a/web/src/data/api.ts
+++ b/web/src/data/api.ts
@@ -906,7 +906,8 @@ async function updateUser(id: string, body: User) {
 interface PortalSettings {
   portal_banner_title: string | null;
   portal_banner_message: string | null;
-  disable_bulk_download: boolean;
+  disable_bulk_data_product_download: boolean;
+  disable_individual_data_product_download: boolean;
 }
 
 async function getAppSettings(): Promise<PortalSettings> {

--- a/web/src/views/Search/SearchLayout.vue
+++ b/web/src/views/Search/SearchLayout.vue
@@ -89,14 +89,6 @@ function selectStudyAndOmics(studyId: string, omicsType: string) {
   setConditions([...stateRefs.conditions.value, ...conditions]);
 }
 
-/**
- * SearchLayout-level settings
- */
-const disableBulkDownload = ref(true);
-api.getAppSettings().then((appSettings) => {
-  disableBulkDownload.value = appSettings.disable_bulk_download;
-});
-
 const biosample = usePaginatedResults(stateRefs.conditions, api.searchBiosample, dataObjectFilter, 10);
 const studyType = types.study;
 const studySummaryData = useFacetSummaryData({
@@ -282,8 +274,7 @@ watch([activeVisTab, activeResultsTab], ([newVisTab, newResultsTab], [oldVisTab,
                 </div>
               </v-tab>
               <v-spacer />
-              <div 
-                v-if="!disableBulkDownload"
+              <div
                 class="d-flex align-center mr-4"
               >
                 <BulkDownload


### PR DESCRIPTION
#### Summary

On this branch, @codytodonnell made it so people configuring instances of the Portal can disable bulk downloads, disable individual file downloads, disable both, or (default) disable neither. That involved replacing the original settings attribute (named `disable_bulk_download`) with a pair of more granular ones (named `disable_bulk_data_product_download` and `disable_individual_data_product_download `).

He also made it so the popups that show rendered HTML (e.g. Krona plots) sourced from data files, are disabled when individual data product download is disabled; with the rationale that, in situations where we would disable individual data product downloads, we are probably doing so because the Portal wouldn't be able to access those files.

#### Screenshots

<img width="598" height="164" alt="image" src="https://github.com/user-attachments/assets/b6e64e78-5952-45b6-b46b-ed15db0ea06c" />

<img width="450" height="221" alt="image" src="https://github.com/user-attachments/assets/bca310f7-8101-4c13-8e72-a5488d04a3ab" />

<img width="467" height="143" alt="image" src="https://github.com/user-attachments/assets/429c63c8-73f2-49e5-b4ca-ad8765195158" />

#### Testing

In addition to confirming environment variable values of `True` and `False` do what I expect, I also confirmed that an environment variable value of `Nope` triggers an error while the application is booting.

<img width="718" height="231" alt="image" src="https://github.com/user-attachments/assets/b487238a-2af3-41ba-b304-e037717d7c50" />

