### PR TITLE
Account for parent studies when populating `biosample_related_document` table

### DIFF
--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -207,7 +207,10 @@ def load_studies(
         # Keep track of this newly-created `BiosampleRelatedDocument` row for future reference.
         # Note: These look-up tables will come in handy when we traverse study ancestry chains below.
         rows_by_study_id[base_study_id] = biosample_related_document
-        parent_study_ids_by_base_study_id[base_study_id] = study_document.get("part_of", [])
+        parent_study_ids = study_document.get("part_of", None)
+        if parent_study_ids is None:  # true if `part_of` was either missing or contained `None`
+            parent_study_ids = []
+        parent_study_ids_by_base_study_id[base_study_id] = parent_study_ids
 
     # For each study that has any parent studies, ensure the `downstream_neighbor_ids` column of
     # each of those parent study rows contains the `id` of that study (i.e. their child). As a

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -129,102 +129,60 @@ def load_studies(
     they, too, are biosample-related documents (albeit, further than a single "hop" away).
     """
 
-    # Note: We opted not to use the SQLAlchemy session as a "cache" of `BiosampleRelatedDocument`
-    #       instances created within this invocation of the function. That is after reading:
-    #       https://docs.sqlalchemy.org/en/21/orm/session_basics.html#is-the-session-a-cache
-    #       Instead, we maintain our own list of instances (or "rows") here, and add them to the
-    #       session at the very end of the function.
-    rows: List[BiosampleRelatedDocument] = []
+    study_documents = list(study_set.find({}, projection_omitting_oid))
+    rows_by_study_id: dict[str, BiosampleRelatedDocument] = {}
+    parent_study_ids_by_base_study_id: dict[str, list[str]] = {}
 
-    def create_or_update_rows_for_ancestor_studies(
-        study_set: Collection,
-        biosample_ids: list[str],
-        base_study: dict,
-    ):
-        """
-        Recursive helper function that ensures that each study that is upstream of the current one,
-        recursively, is represented by a `BiosampleRelatedDocument` row whose `biosample_ids` column
-        includes all of the biosample `id`s that are related to the base study.
-
-        Example "graph":
-
-          [sty_a]
-             ↑
-          [sty_b, sty_c]
-             ↑     ↑
-              sty_d (base) ← [bsm_1, bsm_2]
-        """
-
-        for parent_study_id in base_study.get("part_of", []):
-            # Get the `BiosampleRelatedDocument` row, if any, that exists for this parent study.
-            row = next(
-                (row_ for row_ in rows if row_.id == parent_study_id),
-                None,
-            )
-            # If the row does exist, ensure its `biosample_ids` column includes each of the
-            # biosample `id`s related to the base study. Otherwise, create a new row in which
-            # that is true.
-            if row is None:
-                document = study_set.find_one({"id": parent_study_id}, projection_omitting_oid)
-                row = BiosampleRelatedDocument()
-                row.id = document["id"]
-                row.biosample_ids = []
-                row.high_level_type = "nmdc:Study"
-                row.document = document
-                row.downstream_neighbor_ids = []
-                rows.append(row)
-
-            # Add to the lists, then deduplicate them.
-            row.biosample_ids.extend(biosample_ids)
-            row.biosample_ids = dedupe(row.biosample_ids)
-            row.downstream_neighbor_ids.append(base_study["id"])
-            row.downstream_neighbor_ids = dedupe(row.downstream_neighbor_ids)
-
-            # Treat this parent study as a base study and do the same thing.
-            create_or_update_rows_for_ancestor_studies(
-                study_set=study_set,
-                biosample_ids=biosample_related_document.biosample_ids,
-                base_study=row.document,
-            )
-
-
-    for study_document in study_set.find({}, projection_omitting_oid):
+    # Initialize a `BiosampleRelatedDocument` row for each study study.
+    for study_document in study_documents:
+        base_study_id = study_document["id"]
         biosample_related_document = BiosampleRelatedDocument()
-        biosample_related_document.id = study_document["id"]
-        biosample_related_document.biosample_ids = []
+        biosample_related_document.id = base_study_id
         biosample_related_document.high_level_type = "nmdc:Study"
         biosample_related_document.document = study_document
 
-        # Identify downstream neighbors.
+        # Identify downstream neighbors (i.e. all biosamples that identify this study as an
+        # one of their `associated_studies`).
         #
         # Note: Instead of querying the `biosample_set` MongoDB collection here,
-        #       we take advantage of the look-up tables passed in.
+        #       we take advantage of the look-up table passed in.
         #
-        biosample_related_document.downstream_neighbor_ids = []
-        if study_document["id"] in biosample_ids_by_associated_study_id:
-            biosample_ids = biosample_ids_by_associated_study_id[study_document["id"]]
-            biosample_related_document.downstream_neighbor_ids.extend(biosample_ids)
+        biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
+        biosample_related_document.downstream_neighbor_ids = dedupe(biosample_ids)
 
-            # Also store the biosamples' `id`s as related biosample `id`s; given that our
-            # later step of traversing the schema will only go _downstream_ (not upstream)
-            # of biosamples (whereas studies are _upstream_ of biosamples).
-            biosample_related_document.biosample_ids.extend(biosample_ids)
+        # While we have the opportunity, also store those biosample `id`s in the `biosample_id`s
+        # column; given that the later step of traversing the schema will only go _downstream_
+        # (not upstream) of biosamples (whereas studies are _upstream_ of biosamples).
+        biosample_related_document.biosample_ids = dedupe(biosample_ids)
 
-        biosample_related_document.downstream_neighbor_ids = dedupe(
-            biosample_related_document.downstream_neighbor_ids
-        )
-        biosample_related_document.biosample_ids = dedupe(biosample_related_document.biosample_ids)
+        # Keep track of this newly-created `BiosampleRelatedDocument` row for future reference.
+        # Note: These look-up tables will come in handy when we traverse study ancestry chains below.
+        rows_by_study_id[base_study_id] = biosample_related_document
+        parent_study_ids_by_base_study_id[base_study_id] = study_document.get("part_of", [])
 
-        rows.append(biosample_related_document)
+    # For each study that has any parent studies, ensure the `downstream_neighbor_ids` column of
+    # each of those parent study rows contains the `id` of that study (i.e. their child). As a
+    # reminder, we are only dealing with direct parents here, not more distant ancestors.
+    for base_study_id, parent_study_ids in parent_study_ids_by_base_study_id.items():
+        for parent_study_id in parent_study_ids:
+            row = rows_by_study_id[parent_study_id]
+            if base_study_id not in row.downstream_neighbor_ids:
+                row.downstream_neighbor_ids.append(base_study_id)
 
-        create_or_update_rows_for_ancestor_studies(
-            study_set=study_set,
-            biosample_ids=biosample_related_document.biosample_ids,
-            base_study=biosample_related_document.document,
-        )
+    # For each study row, propagate its `biosample_id`s to each of its ancestor study rows;
+    # preserving any `biosample_id`s those ancestor study rows already contain (e.g. those
+    # propagated up from other descendant studies).
+    for base_study_id in rows_by_study_id.keys():
+        biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
+        parent_study_ids = parent_study_ids_by_base_study_id[base_study_id]
+        for parent_study_id in parent_study_ids:
+            row = rows_by_study_id[parent_study_id]
+            for id_ in biosample_ids:
+                if id_ not in row.biosample_ids:
+                    row.biosample_ids.append(id_)
 
     # Add all the `BiosampleRelatedDocument` rows to the session.
-    for row in rows:
+    for row in rows_by_study_id.values():
         db.add(row)
 
 

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -198,7 +198,7 @@ def load_studies(
         biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
         biosample_related_document.downstream_neighbor_ids = dedupe(biosample_ids)
 
-        # While we have the opportunity, also store those biosample `id`s in the `biosample_id`s
+        # While we have the opportunity, also store those biosample `id`s in the `biosample_ids`
         # column; given that the later step of traversing the schema will only go _downstream_
         # (not upstream) of biosamples (whereas studies are _upstream_ of biosamples).
         biosample_related_document.biosample_ids = dedupe(biosample_ids)
@@ -220,15 +220,15 @@ def load_studies(
             if base_study_id not in row.downstream_neighbor_ids:
                 row.downstream_neighbor_ids.append(base_study_id)
 
-    # For each study row, propagate its `biosample_id`s to each of its ancestor study rows, all the
-    # way up the ancestry chain; preserving any `biosample_id`s those ancestor study rows already
+    # For each study row, propagate its `biosample_ids` to each of its ancestor study rows, all the
+    # way up the ancestry chain; preserving any biosample `id`s those ancestor study rows already
     # contain (e.g. those propagated up from other descendant studies).
     for base_study_id in rows_by_study_id.keys():
 
-        # Get the `biosample_id`s of this study (i.e. the "base" study).
+        # Get the `biosample_ids` of this study (i.e. the "base" study).
         biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
 
-        # Propagate those `biosample_id`s to all studies in this study's ancestry chain.
+        # Propagate those biosample IDs to all studies in this study's ancestry chain.
         _propagate_biosample_ids_to_ancestor_study_rows(
             base_study_id=base_study_id,
             biosample_ids=biosample_ids,

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -123,7 +123,18 @@ def load_studies(
     that represents that document.
 
     Also identifies the biosample(s) associated with each study, since it's so readily accessible.
+
+    Finally, accounts for the fact that a study can be `part_of` other studies (recursively), and we
+    want each of those ancestor studies, too, to have its own `BiosampleRelatedDocument` row; since
+    they are biosample-related documents (albeit, further than a single "hop" away).
     """
+
+    # Note: We opted not to use the SQLAlchemy session as a "cache" of `BiosampleRelatedDocument`
+    #       instances created within this invocation of the function. That is after reading:
+    #       https://docs.sqlalchemy.org/en/21/orm/session_basics.html#is-the-session-a-cache
+    #       Instead, we maintain our own list of instances (or "rows") here, and add them to the
+    #       session at the very end of the function.
+    rows: List[BiosampleRelatedDocument] = []
 
     for study_document in study_set.find({}, projection_omitting_oid):
         biosample_related_document = BiosampleRelatedDocument()
@@ -152,7 +163,44 @@ def load_studies(
         )
         biosample_related_document.biosample_ids = dedupe(biosample_related_document.biosample_ids)
 
-        db.add(biosample_related_document)
+        rows.append(biosample_related_document)
+
+        # TODO: Do this recursively until either the parent study is not `part_of` any studies or
+        #       all of the studies in its ancestry are ones we already processed for this base study.
+        #
+        # Identify each study that is upstream of the current one. Do this by checking the latter's
+        # `part_of` field, following the chain recursively. For each study along the chain, ensure
+        # it is represented by a `BiosampleRelatedDocument` row whose `biosample_ids` column includes
+        # all of the same biosample `id`s that were related to the directly-biosample-related study.
+        if "part_of" in study_document:
+            parent_study_ids = study_document.get("part_of", [])
+            for parent_study_id in parent_study_ids:
+                # If a `BiosampleRelatedDocument` row exists for this study, get a reference to it.
+                parent_study_row = None
+                for row in rows:
+                    if row.id == parent_study_id:
+                        parent_study_row = row
+                        break
+                # If we weren't able to get a reference to it (i.e. it doesn't exist), create one.
+                if parent_study_row is None:
+                    parent_study_document = study_set.find_one(
+                        {"id": parent_study_id}, projection_omitting_oid,
+                    )
+                    parent_study_row = BiosampleRelatedDocument()
+                    parent_study_row.id = parent_study_document["id"]
+                    parent_study_row.biosample_ids = []  # we'll populate this below
+                    parent_study_row.high_level_type = "nmdc:Study"
+                    parent_study_row.document = parent_study_document
+                # Ensure that the parent study row's `biosample_ids` column includes (at least)
+                # all of the biosample `id`s that related to the directly-biosample-related study.
+                for biosample_id in biosample_related_document.biosample_ids:
+                    if biosample_id not in parent_study_row.biosample_ids:
+                        parent_study_row.biosample_ids.append(biosample_id)
+                # TODO: Do the same thing for any parent studies of _these_ parent studies.
+
+    # Add all the `BiosampleRelatedDocument` rows to the session.
+    for row in rows:
+        db.add(row)
 
 
 def load_data_generations(

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -126,7 +126,7 @@ def load_studies(
 
     Finally, accounts for the fact that a study can be `part_of` other studies (recursively), and we
     want each of those ancestor studies, too, to have its own `BiosampleRelatedDocument` row; since
-    they are biosample-related documents (albeit, further than a single "hop" away).
+    they, too, are biosample-related documents (albeit, further than a single "hop" away).
     """
 
     # Note: We opted not to use the SQLAlchemy session as a "cache" of `BiosampleRelatedDocument`
@@ -135,6 +135,58 @@ def load_studies(
     #       Instead, we maintain our own list of instances (or "rows") here, and add them to the
     #       session at the very end of the function.
     rows: List[BiosampleRelatedDocument] = []
+
+    def create_or_update_rows_for_ancestor_studies(
+        study_set: Collection,
+        biosample_ids: list[str],
+        base_study: dict,
+    ):
+        """
+        Recursive helper function that ensures that each study that is upstream of the current one,
+        recursively, is represented by a `BiosampleRelatedDocument` row whose `biosample_ids` column
+        includes all of the biosample `id`s that are related to the base study.
+
+        Example "graph":
+
+          [sty_a]
+             ↑
+          [sty_b, sty_c]
+             ↑     ↑
+              sty_d (base) ← [bsm_1, bsm_2]
+        """
+
+        for parent_study_id in base_study.get("part_of", []):
+            # Get the `BiosampleRelatedDocument` row, if any, that exists for this parent study.
+            row = next(
+                (row_ for row_ in rows if row_.id == parent_study_id),
+                None,
+            )
+            # If the row does exist, ensure its `biosample_ids` column includes each of the
+            # biosample `id`s related to the base study. Otherwise, create a new row in which
+            # that is true.
+            if row is None:
+                document = study_set.find_one({"id": parent_study_id}, projection_omitting_oid)
+                row = BiosampleRelatedDocument()
+                row.id = document["id"]
+                row.biosample_ids = []
+                row.high_level_type = "nmdc:Study"
+                row.document = document
+                row.downstream_neighbor_ids = []
+                rows.append(row)
+
+            # Add to the lists, then deduplicate them.
+            row.biosample_ids.extend(biosample_ids)
+            row.biosample_ids = dedupe(row.biosample_ids)
+            row.downstream_neighbor_ids.append(base_study["id"])
+            row.downstream_neighbor_ids = dedupe(row.downstream_neighbor_ids)
+
+            # Treat this parent study as a base study and do the same thing.
+            create_or_update_rows_for_ancestor_studies(
+                study_set=study_set,
+                biosample_ids=biosample_related_document.biosample_ids,
+                base_study=row.document,
+            )
+
 
     for study_document in study_set.find({}, projection_omitting_oid):
         biosample_related_document = BiosampleRelatedDocument()
@@ -165,38 +217,11 @@ def load_studies(
 
         rows.append(biosample_related_document)
 
-        # TODO: Do this recursively until either the parent study is not `part_of` any studies or
-        #       all of the studies in its ancestry are ones we already processed for this base study.
-        #
-        # Identify each study that is upstream of the current one. Do this by checking the latter's
-        # `part_of` field, following the chain recursively. For each study along the chain, ensure
-        # it is represented by a `BiosampleRelatedDocument` row whose `biosample_ids` column includes
-        # all of the same biosample `id`s that were related to the directly-biosample-related study.
-        if "part_of" in study_document:
-            parent_study_ids = study_document.get("part_of", [])
-            for parent_study_id in parent_study_ids:
-                # If a `BiosampleRelatedDocument` row exists for this study, get a reference to it.
-                parent_study_row = None
-                for row in rows:
-                    if row.id == parent_study_id:
-                        parent_study_row = row
-                        break
-                # If we weren't able to get a reference to it (i.e. it doesn't exist), create one.
-                if parent_study_row is None:
-                    parent_study_document = study_set.find_one(
-                        {"id": parent_study_id}, projection_omitting_oid,
-                    )
-                    parent_study_row = BiosampleRelatedDocument()
-                    parent_study_row.id = parent_study_document["id"]
-                    parent_study_row.biosample_ids = []  # we'll populate this below
-                    parent_study_row.high_level_type = "nmdc:Study"
-                    parent_study_row.document = parent_study_document
-                # Ensure that the parent study row's `biosample_ids` column includes (at least)
-                # all of the biosample `id`s that related to the directly-biosample-related study.
-                for biosample_id in biosample_related_document.biosample_ids:
-                    if biosample_id not in parent_study_row.biosample_ids:
-                        parent_study_row.biosample_ids.append(biosample_id)
-                # TODO: Do the same thing for any parent studies of _these_ parent studies.
+        create_or_update_rows_for_ancestor_studies(
+            study_set=study_set,
+            biosample_ids=biosample_related_document.biosample_ids,
+            base_study=biosample_related_document.document,
+        )
 
     # Add all the `BiosampleRelatedDocument` rows to the session.
     for row in rows:

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -133,7 +133,7 @@ def load_studies(
     rows_by_study_id: dict[str, BiosampleRelatedDocument] = {}
     parent_study_ids_by_base_study_id: dict[str, list[str]] = {}
 
-    # Initialize a `BiosampleRelatedDocument` row for each study study.
+    # Initialize a `BiosampleRelatedDocument` row for each study.
     for study_document in study_documents:
         base_study_id = study_document["id"]
         biosample_related_document = BiosampleRelatedDocument()
@@ -141,7 +141,7 @@ def load_studies(
         biosample_related_document.high_level_type = "nmdc:Study"
         biosample_related_document.document = study_document
 
-        # Identify downstream neighbors (i.e. all biosamples that identify this study as an
+        # Identify downstream neighbors (i.e. all biosamples that identify this study as
         # one of their `associated_studies`).
         #
         # Note: Instead of querying the `biosample_set` MongoDB collection here,
@@ -174,7 +174,7 @@ def load_studies(
     # contain (e.g. those propagated up from other descendant studies).
     for base_study_id in rows_by_study_id:
 
-        # The the `biosample_id`s of this study (i.e. the "base" study).
+        # Get the `biosample_id`s of this study (i.e. the "base" study).
         biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
 
         # Initialize a list of the `id`s of the ancestor studies we intend to visit.

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -169,17 +169,46 @@ def load_studies(
             if base_study_id not in row.downstream_neighbor_ids:
                 row.downstream_neighbor_ids.append(base_study_id)
 
-    # For each study row, propagate its `biosample_id`s to each of its ancestor study rows;
-    # preserving any `biosample_id`s those ancestor study rows already contain (e.g. those
-    # propagated up from other descendant studies).
-    for base_study_id in rows_by_study_id.keys():
+    # For each study row, propagate its `biosample_id`s to each of its ancestor study rows, all the
+    # way up the ancestry chain; preserving any `biosample_id`s those ancestor study rows already
+    # contain (e.g. those propagated up from other descendant studies).
+    for base_study_id in rows_by_study_id:
+
+        # The the `biosample_id`s of this study (i.e. the "base" study).
         biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
-        parent_study_ids = parent_study_ids_by_base_study_id[base_study_id]
-        for parent_study_id in parent_study_ids:
-            row = rows_by_study_id[parent_study_id]
+
+        # Initialize a list of the `id`s of the ancestor studies we intend to visit.
+        # Note: We make a _copy_ of the list, since we may add to it as we iterate
+        #       (e.g. if any of these parent studies, themselves, has parent studies).
+        unvisited_ancestor_study_ids = parent_study_ids_by_base_study_id[base_study_id].copy()
+
+        # Initialize a set of studies we have visited for this "base" study. This set will grow
+        # as we iterate.
+        visited_study_ids = set([base_study_id])
+
+        while len(unvisited_ancestor_study_ids) > 0:
+            ancestor_study_id = unvisited_ancestor_study_ids.pop()  # removes it from the list
+
+            # If we've already visited this ancestor study (e.g. multiple studies here have it as
+            # a parent), abort this iteration.
+            if ancestor_study_id in visited_study_ids:
+                continue
+            visited_study_ids.add(ancestor_study_id)
+
+            # Get the `BiosampleRelatedDocument` row for this ancestor study.
+            row = rows_by_study_id[ancestor_study_id]
+
+            # Ensure the biosamples of the "base" study appear in the `biosample_ids` column of
+            # this ancestor study.
             for id_ in biosample_ids:
                 if id_ not in row.biosample_ids:
                     row.biosample_ids.append(id_)
+
+            # If this ancestor study, itself, has any parent studies and we haven't already visited
+            # them while processing this "base" study; add them to the list of ones to visit.
+            for ancestor_parent_study_id in parent_study_ids_by_base_study_id[ancestor_study_id]:
+                if ancestor_parent_study_id not in visited_study_ids:
+                    unvisited_ancestor_study_ids.append(ancestor_parent_study_id)
 
     # Add all the `BiosampleRelatedDocument` rows to the session.
     for row in rows_by_study_id.values():

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -178,12 +178,11 @@ def load_studies(
     they, too, are biosample-related documents (albeit, further than a single "hop" away).
     """
 
-    study_documents = list(study_set.find({}, projection_omitting_oid))
     rows_by_study_id: dict[str, BiosampleRelatedDocument] = {}
     parent_study_ids_by_base_study_id: dict[str, list[str]] = {}
 
     # Initialize a `BiosampleRelatedDocument` row for each study.
-    for study_document in study_documents:
+    for study_document in study_set.find({}, projection_omitting_oid):
         base_study_id = study_document["id"]
         biosample_related_document = BiosampleRelatedDocument()
         biosample_related_document.id = base_study_id

--- a/nmdc_server/ingest/biosample_related_document.py
+++ b/nmdc_server/ingest/biosample_related_document.py
@@ -51,6 +51,55 @@ def invert_dict_of_lists(dict_of_lists: dict[str, List[str]]) -> dict[str, List[
     return inverted_dict
 
 
+def _propagate_biosample_ids_to_ancestor_study_rows(
+    base_study_id: str,
+    biosample_ids: list[str],
+    rows_by_study_id: dict[str, BiosampleRelatedDocument],
+    parent_study_ids_by_base_study_id: dict[str, list[str]],
+) -> None:
+    """
+    Helper function that ensures that the `biosample_ids` column of each ancestor study (row)
+    of the specified base study includes each of the specified biosample IDs.
+
+    Note: The only reason we define this at the top-level of the module instead of within the
+          `load_studies` function that invokes it is that, when we defined it within the latter,
+          the linter said the resulting `load_studies` function was too complex.
+          Docs: https://www.flake8rules.com/rules/C901.html
+    """
+
+    # Initialize a list of the `id`s of the ancestor studies we intend to visit.
+    # Note: We make a _copy_ of the list, since we may add to it as we iterate
+    #       (e.g. if any of these parent studies, themselves, has parent studies).
+    unvisited_ancestor_study_ids = parent_study_ids_by_base_study_id[base_study_id].copy()
+
+    # Initialize a set of studies we have visited (so far) for this "base" study.
+    visited_study_ids = set([base_study_id])
+
+    while len(unvisited_ancestor_study_ids) > 0:
+        ancestor_study_id = unvisited_ancestor_study_ids.pop()  # removes it from the list
+
+        # If we've already visited this ancestor study (e.g. multiple studies here have it as
+        # a parent), abort this iteration.
+        if ancestor_study_id in visited_study_ids:
+            continue
+        visited_study_ids.add(ancestor_study_id)
+
+        # Get the `BiosampleRelatedDocument` row for this ancestor study.
+        row = rows_by_study_id[ancestor_study_id]
+
+        # Ensure the biosamples of the "base" study appear in the `biosample_ids` column of
+        # this ancestor study.
+        for biosample_id in biosample_ids:
+            if biosample_id not in row.biosample_ids:
+                row.biosample_ids.append(biosample_id)
+
+        # If this ancestor study, itself, has any parent studies and we haven't already visited
+        # them while processing this "base" study; add them to the list of ones to visit.
+        for ancestor_parent_study_id in parent_study_ids_by_base_study_id[ancestor_study_id]:
+            if ancestor_parent_study_id not in visited_study_ids:
+                unvisited_ancestor_study_ids.append(ancestor_parent_study_id)
+
+
 def load_biosamples(
     db: Session,
     biosample_set: Collection,
@@ -172,43 +221,18 @@ def load_studies(
     # For each study row, propagate its `biosample_id`s to each of its ancestor study rows, all the
     # way up the ancestry chain; preserving any `biosample_id`s those ancestor study rows already
     # contain (e.g. those propagated up from other descendant studies).
-    for base_study_id in rows_by_study_id:
+    for base_study_id in rows_by_study_id.keys():
 
         # Get the `biosample_id`s of this study (i.e. the "base" study).
         biosample_ids = biosample_ids_by_associated_study_id.get(base_study_id, [])
 
-        # Initialize a list of the `id`s of the ancestor studies we intend to visit.
-        # Note: We make a _copy_ of the list, since we may add to it as we iterate
-        #       (e.g. if any of these parent studies, themselves, has parent studies).
-        unvisited_ancestor_study_ids = parent_study_ids_by_base_study_id[base_study_id].copy()
-
-        # Initialize a set of studies we have visited for this "base" study. This set will grow
-        # as we iterate.
-        visited_study_ids = set([base_study_id])
-
-        while len(unvisited_ancestor_study_ids) > 0:
-            ancestor_study_id = unvisited_ancestor_study_ids.pop()  # removes it from the list
-
-            # If we've already visited this ancestor study (e.g. multiple studies here have it as
-            # a parent), abort this iteration.
-            if ancestor_study_id in visited_study_ids:
-                continue
-            visited_study_ids.add(ancestor_study_id)
-
-            # Get the `BiosampleRelatedDocument` row for this ancestor study.
-            row = rows_by_study_id[ancestor_study_id]
-
-            # Ensure the biosamples of the "base" study appear in the `biosample_ids` column of
-            # this ancestor study.
-            for id_ in biosample_ids:
-                if id_ not in row.biosample_ids:
-                    row.biosample_ids.append(id_)
-
-            # If this ancestor study, itself, has any parent studies and we haven't already visited
-            # them while processing this "base" study; add them to the list of ones to visit.
-            for ancestor_parent_study_id in parent_study_ids_by_base_study_id[ancestor_study_id]:
-                if ancestor_parent_study_id not in visited_study_ids:
-                    unvisited_ancestor_study_ids.append(ancestor_parent_study_id)
+        # Propagate those `biosample_id`s to all studies in this study's ancestry chain.
+        _propagate_biosample_ids_to_ancestor_study_rows(
+            base_study_id=base_study_id,
+            biosample_ids=biosample_ids,
+            rows_by_study_id=rows_by_study_id,
+            parent_study_ids_by_base_study_id=parent_study_ids_by_base_study_id,
+        )
 
     # Add all the `BiosampleRelatedDocument` rows to the session.
     for row in rows_by_study_id.values():


### PR DESCRIPTION
On this branch, I updated the code (in the ingester) that populates the `biosample_related_document` table, so that, when it is populating the `biosample_ids` column for rows describing studies, it considers the full ancestries of the study/ies directly-referenced by the biosample's `associated_studies` field (i.e. its parent study/ies, grandparent study/ies, etc.) instead of only considering the study/ies **directly-referenced** by the biosample's `associated_studies` field.

### Previous behavior

Given this graph...

```
sty_great_grandparent 🙈
  ↑
sty_grandparent 🙈
  ↑
sty_parent 🙈
  ↑
sty_base ✅ <--associated_studies-- bsm_1
```

...the table would say that only `sty_base` is related to biosample `bsm_1`. It would **not** say it about `sty_parent`, `sty_grandparent`, or `sty_great_grantparent`.

### New behavior

Given this graph (the same one)...

```
sty_great_grandparent ✅
  ↑
sty_grandparent ✅
  ↑
sty_parent ✅
  ↑
sty_base ✅ <--associated_studies-- bsm_1
```

...the table will say that all of those studies are related to biosample `bsm_1`.

### Fixes

Fixes #2251