### PR TITLE
Improve UI for reviewer assignment

### DIFF
--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -58,7 +58,7 @@ const options = ref({
 const isDeleteDialogOpen = ref(false);
 const deleteDialogSubmission = ref<SubmissionMetadataSlim | null>(null);
 const isReviewerAssignmentDialogOpen = ref(false);
-const reviewerAssignmentSnackbarOpen = ref(false);
+const isReviewerAssignmentSnackbarOpen = ref(false);
 const selectedSubmission = ref<SubmissionMetadataSlim | null>(null);
 const currentUser = stateRefs.user;
 const isTestFilter = ref(null);
@@ -138,7 +138,7 @@ async function addReviewer() {
     }
     await addSubmissionRole(selectedSubmission.value.id, reviewerOrcid.value, 'reviewer');
   });
-  reviewerAssignmentSnackbarOpen.value = true;
+  isReviewerAssignmentSnackbarOpen.value = true;
   reviewerOrcid.value = '';
   isReviewerAssignmentDialogOpen.value = false;
 }
@@ -434,7 +434,7 @@ async function addReviewer() {
       </v-card>
     </v-dialog>
     <v-snackbar
-      v-model="reviewerAssignmentSnackbarOpen"
+      v-model="isReviewerAssignmentSnackbarOpen"
       location="bottom"
       :color="assignReviewerRequest.error.value ? 'error' : 'success'"
       timeout="3000"
@@ -443,7 +443,7 @@ async function addReviewer() {
       <template #actions>
         <v-btn
           icon="mdi-close"
-          @click="reviewerAssignmentSnackbarOpen = false"
+          @click="isReviewerAssignmentSnackbarOpen = false"
         />
       </template>
     </v-snackbar>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -58,6 +58,7 @@ const options = ref({
 const isDeleteDialogOpen = ref(false);
 const deleteDialogSubmission = ref<SubmissionMetadataSlim | null>(null);
 const isReviewerAssignmentDialogOpen = ref(false);
+const reviewerAssignmentSnackbarOpen = ref(false);
 const selectedSubmission = ref<SubmissionMetadataSlim | null>(null);
 const currentUser = stateRefs.user;
 const isTestFilter = ref(null);
@@ -124,7 +125,8 @@ async function handleDelete(item: SubmissionMetadataSlim | null) {
 
 const reviewerOrcid = ref('');
 const orcidTextFieldRef = useTemplateRef<InstanceType<typeof VTextField>>('orcidTextField');
-    function openReviewerDialog(item: SubmissionMetadataSlim | null) {
+
+function openReviewerDialog(item: SubmissionMetadataSlim | null) {
   isReviewerAssignmentDialogOpen.value = true;
   selectedSubmission.value = item;
 }
@@ -136,6 +138,8 @@ async function addReviewer() {
     }
     await addSubmissionRole(selectedSubmission.value.id, reviewerOrcid.value, 'reviewer');
   });
+  reviewerAssignmentSnackbarOpen.value = true;
+  reviewerOrcid.value = '';
   isReviewerAssignmentDialogOpen.value = false;
 }
 
@@ -378,6 +382,33 @@ async function addReviewer() {
               />
             </v-col>
           </v-row>
+          <v-card
+            v-if="selectedSubmission?.reviewers?.length"
+            class="mt-4"
+            variant="outlined"
+          >
+            <v-card-title class="text-subtitle-1 pb-2">
+              Current reviewers
+            </v-card-title>
+            <v-card-text class="pt-0">
+              <div class="d-flex flex-wrap ga-2">
+                <v-chip
+                  v-for="reviewer in selectedSubmission?.reviewers"
+                  :key="reviewer"
+                  color="primary"
+                  variant="outlined"
+                >
+                  {{ reviewer }}
+                </v-chip>
+              </div>
+            </v-card-text>
+          </v-card>
+          <div
+            v-else
+            class="mt-4 text-body-2 text-medium-emphasis"
+          >
+            No reviewers have been added yet.
+          </div>
         </v-card-text>
         <v-card-actions
           class="pt-0"
@@ -402,5 +433,19 @@ async function addReviewer() {
         </v-card-actions>
       </v-card>
     </v-dialog>
+    <v-snackbar
+      v-model="reviewerAssignmentSnackbarOpen"
+      location="bottom"
+      :color="assignReviewerRequest.error.value ? 'error' : 'success'"
+      timeout="3000"
+    >
+      {{ assignReviewerRequest.error.value ? 'Something went wrong assigning a reviewer.' : 'Reviewer added successfully.' }}
+      <template #actions>
+        <v-btn
+          icon="mdi-close"
+          @click="reviewerAssignmentSnackbarOpen = false"
+        />
+      </template>
+    </v-snackbar>
   </div>
 </template>

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -141,6 +141,7 @@ async function addReviewer() {
   isReviewerAssignmentSnackbarOpen.value = true;
   reviewerOrcid.value = '';
   isReviewerAssignmentDialogOpen.value = false;
+  submission.refetch();
 }
 
 </script>


### PR DESCRIPTION
Resolves https://github.com/microbiomedata/nmdc-server/issues/1767

This PR adds two new UI elements to the `SubmissionList` relating to reviewer assignments.

The first addition is a snackbar that provides feedback on whether or not assigning a reviewer was successful. Currently if there was an error then no error code is reported since they didn't seem very human readable, it just says 'something went wrong' which might be too vague.

The second addition is a `v-card` within the add reviewer dialog that displays the reviewers that are already assigned to that submission. Part of adding this included refetching the submissions after adding a reviewer so that this displayed list included the new reviewer (in the case that multiple reviewers might be added at the same time, so the user would see the correct list immediately)