### PR TITLE
Send `permission_level` of `owner` with submission creation response

### DIFF
--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -1775,7 +1775,11 @@ async def submit_metadata(
     db.add(owner_role)
     db.commit()
     crud.try_get_submission_lock(db, submission.id, user.id)
-    return submission
+    submission_metadata_schema = schemas_submission.SubmissionMetadataSchema.model_validate(
+        submission
+    )
+    submission_metadata_schema.permission_level = models.SubmissionEditorRole.owner.value
+    return submission_metadata_schema
 
 
 @router.post(

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -90,6 +90,7 @@ def test_create_submission(db: Session, client: TestClient, logged_in_user):
     assert body["study_form"]["studyName"] == study_name
     assert body["study_form"]["piEmail"] == pi_email
     assert body["author_orcid"] == logged_in_user.orcid
+    assert body["permission_level"] == SubmissionEditorRole.owner.value
 
     # Verify there is a new SubmissionMetadata record in the database
     submission_id = body["id"]


### PR DESCRIPTION
Fixes #2257 

Currently in `main` only the `GET /api/metadata_submission/{id}` endpoint calculates the permission level for a given submission and user combination, then populates the `permission_level` field. With the reworking of the submission state store in #2240, that `GET` request is no longer made after creating a submission. Instead the response from the `POST /api/metadata_submission` request directly hydrates the submission record in the store. That's good because it's one less unnecessary API request. However it was leaving `permission_level` unset and causing the user-facing bug described in the issue.

The fix here is to set the `permission_level` field on the response of `POST /api/metadata_submission`. In this case the value does not have to be calculated. The user who initiated the request is by definition the owner of the submission.

An existing test of the `POST /api/metadata_submission` endpoint has been updated to add the new expecation.