### PR TITLE
Update ingester to retry HTTP requests it sends to third-party servers

### DIFF
--- a/nmdc_server/ingest/common.py
+++ b/nmdc_server/ingest/common.py
@@ -5,6 +5,7 @@ from time import perf_counter
 from typing import Any, Dict, List, Optional, Set, Union
 
 import requests
+from fastapi import status
 from pydantic import BaseModel
 from requests.adapters import HTTPAdapter, Retry
 from sqlalchemy.exc import IntegrityError
@@ -35,7 +36,17 @@ def make_requests_session() -> requests.Session:
     Returns a `requests.Session` configured to retry HTTP requests up to 10 times.
     Docs: https://docs.python-requests.org/en/latest/user/advanced/#example-automatic-retries
     """
-    retry_strategy = Retry(total=10, backoff_factor=1)
+    retry_strategy = Retry(
+        total=10,
+        backoff_factor=1,
+        allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,
+        status_forcelist=[
+            status.HTTP_502_BAD_GATEWAY,
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            status.HTTP_504_GATEWAY_TIMEOUT,
+            status.HTTP_429_TOO_MANY_REQUESTS,
+        ],
+    )
     http_adapter = HTTPAdapter(max_retries=retry_strategy)
     requests_session = requests.Session()
     requests_session.mount("http://", http_adapter)

--- a/nmdc_server/ingest/common.py
+++ b/nmdc_server/ingest/common.py
@@ -4,7 +4,9 @@ from datetime import datetime
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Set, Union
 
+import requests
 from pydantic import BaseModel
+from requests.adapters import HTTPAdapter, Retry
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.session import Session
 
@@ -26,6 +28,23 @@ EXCLUDED_FIELDS = {
     "igsn_biosample_identifiers",
     "img_identifiers",
 }
+
+
+def make_requests_session() -> requests.Session:
+    """
+    Returns a `requests.Session` configured to retry HTTP requests up to 10 times.
+    Docs: https://docs.python-requests.org/en/latest/user/advanced/#example-automatic-retries
+    """
+    retry_strategy = Retry(total=10, backoff_factor=1)
+    http_adapter = HTTPAdapter(max_retries=retry_strategy)
+    requests_session = requests.Session()
+    requests_session.mount("http://", http_adapter)
+    requests_session.mount("https://", http_adapter)
+    return requests_session
+
+
+# Make a `requests.Session` the ingester can use to submit HTTP requests, with automatic retries.
+requests_session = make_requests_session()
 
 
 class ETLReport:

--- a/nmdc_server/ingest/doi.py
+++ b/nmdc_server/ingest/doi.py
@@ -1,17 +1,12 @@
 import re
 
-import requests
-from requests.adapters import HTTPAdapter
 from requests.models import Response
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
-from urllib3.util.retry import Retry
 
+from nmdc_server.ingest.common import requests_session
 from nmdc_server.logger import get_logger
 from nmdc_server.models import DOIInfo, DOIType
-
-retry_strategy = Retry(total=10)
-adapter = HTTPAdapter(max_retries=retry_strategy)
 
 
 def get_doi_info(doi: str) -> Response:
@@ -19,9 +14,7 @@ def get_doi_info(doi: str) -> Response:
     headers = {
         "Accept": "application/vnd.citationstyles.csl+json",
     }
-    http = requests.Session()
-    http.mount("https://", adapter)
-    return requests.get(url, headers=headers, timeout=60)
+    return requests_session.get(url, headers=headers, timeout=60)
 
 
 def upsert_doi(db: Session, doi_value: str, doi_category: str, doi_provider: str = ""):

--- a/nmdc_server/ingest/kegg.py
+++ b/nmdc_server/ingest/kegg.py
@@ -2,10 +2,10 @@ import csv
 from pathlib import Path
 from typing import Dict, List, Union
 
-import requests
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+from nmdc_server.ingest.common import requests_session
 from nmdc_server.ingest.errors import errors
 from nmdc_server.models import (
     CogTermText,
@@ -180,9 +180,9 @@ def get_search_records():
             ingest_tree(child, hierarchy)
 
     for url in [MODULE_URL, ORTHOLOGY_URL]:
-        req = requests.get(url)
-        req.raise_for_status()
-        ingest_tree(req.json(), "ko")
+        resp = requests_session.get(url)
+        resp.raise_for_status()
+        ingest_tree(resp.json(), "ko")
 
     for file, keys in delimeted_files.items():
         for key_set in keys:
@@ -268,7 +268,7 @@ def ingest_go_search_records(db: Session) -> None:
     hierarchy could be done as follow-up work.
     """
     db.execute(text(f"truncate table {GoTermText.__tablename__}"))
-    resp = requests.get(GO_URL)
+    resp = requests_session.get(GO_URL)
     resp.raise_for_status()
     data = resp.json()
     nodes = data["graphs"][0]["nodes"]

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -1,14 +1,13 @@
 import re
 from typing import List, Optional
 
-import requests
 from pydantic import model_validator
 from pydantic.v1 import validator
 from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 
 from nmdc_server.crud import create_study, get_doi
-from nmdc_server.ingest.common import ETLReport, extract_extras, extract_value
+from nmdc_server.ingest.common import ETLReport, extract_extras, extract_value, requests_session
 from nmdc_server.ingest.doi import upsert_doi
 from nmdc_server.logger import get_logger
 from nmdc_server.models import PrincipalInvestigator
@@ -25,7 +24,7 @@ def get_or_create_pi(db: Session, name: str, url: Optional[str], orcid: Optional
     image_data = None
     if url:
         try:
-            r = requests.get(url)
+            r = requests_session.get(url)
             r.raise_for_status()
         except Exception as e:
             logger.error(f"Failed to download image for {name} from {url} : {e}")
@@ -54,7 +53,7 @@ def transform_doi(doi: str) -> str:
 
 def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
     if image_urls:
-        r = requests.get(image_urls[0]["url"])
+        r = requests_session.get(image_urls[0]["url"])
         if r.ok:
             return r.content
     return None

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -1,13 +1,14 @@
 import re
 from typing import List, Optional
 
+import requests
 from pydantic import model_validator
 from pydantic.v1 import validator
 from pymongo.cursor import Cursor
 from sqlalchemy.orm import Session
 
 from nmdc_server.crud import create_study, get_doi
-from nmdc_server.ingest.common import ETLReport, extract_extras, extract_value, requests_session
+from nmdc_server.ingest.common import ETLReport, extract_extras, extract_value
 from nmdc_server.ingest.doi import upsert_doi
 from nmdc_server.logger import get_logger
 from nmdc_server.models import PrincipalInvestigator
@@ -24,7 +25,7 @@ def get_or_create_pi(db: Session, name: str, url: Optional[str], orcid: Optional
     image_data = None
     if url:
         try:
-            r = requests_session.get(url)
+            r = requests.get(url)
             r.raise_for_status()
         except Exception as e:
             logger.error(f"Failed to download image for {name} from {url} : {e}")
@@ -53,7 +54,7 @@ def transform_doi(doi: str) -> str:
 
 def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
     if image_urls:
-        r = requests_session.get(image_urls[0]["url"])
+        r = requests.get(image_urls[0]["url"])
         if r.ok:
             return r.content
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "sqlparse",
     "starlette",
     "traitlets",
-    "urllib3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2058,7 +2058,6 @@ dependencies = [
     { name = "sqlparse" },
     { name = "starlette" },
     { name = "traitlets" },
-    { name = "urllib3" },
 ]
 
 [package.dev-dependencies]
@@ -2115,7 +2114,6 @@ requires-dist = [
     { name = "sqlparse" },
     { name = "starlette" },
     { name = "traitlets" },
-    { name = "urllib3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
On this branch, I updated the ingester so that it retries the HTTP requests it sends to third-party servers.

It will retry them up to 10 times, backing off some number of seconds each time (see formula below, and note that I have set the `backoff_factor` to `1`).

> <img width="716" height="183" alt="image" src="https://github.com/user-attachments/assets/c274b83b-a025-4a4c-9048-3fdb4bfc6a75" />

Since the author wrote "most errors are resolved immediately by a second try without any delay", I interpret that to mean that the sequence of events will be: try 1, **no delay**, [try 2 or] **retry 1**, wait 2s, retry 2, wait 4s, retry 3, wait 8s, retry 4, etc.

It will only retry the request if the response code was one of these:

```py
        status_forcelist=[
            status.HTTP_502_BAD_GATEWAY,
            status.HTTP_503_SERVICE_UNAVAILABLE,
            status.HTTP_504_GATEWAY_TIMEOUT,
            status.HTTP_429_TOO_MANY_REQUESTS,
        ],
```

Fixes https://github.com/microbiomedata/nmdc-server/issues/2234