### PR TITLE
Fix amplicon data tables

### DIFF
--- a/web/src/components/AmpliconObjectDataTable.vue
+++ b/web/src/components/AmpliconObjectDataTable.vue
@@ -80,20 +80,22 @@ export default defineComponent({
 
 </script>
 <template>
-  <v-data-table
-    :headers="headers"
-    :items="items"
-  >
-    <!-- eslint-disable-next-line -->
-    <template #item.insdc_experiment_identifiers="{ item }">
-      <a
-        v-if="typeof getFirstInsdcExperimentIdentifier(item) === 'string'"
-        :href="makeInsdcHref(getFirstInsdcExperimentIdentifier(item))"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {{ getFirstInsdcExperimentIdentifier(item) }}
-      </a>
-    </template>
-  </v-data-table>
+  <v-card variant="outlined">
+    <v-data-table
+      :headers="headers"
+      :items="items"
+    >
+      <!-- eslint-disable-next-line -->
+      <template #item.insdc_experiment_identifiers="{ item }">
+        <a
+          v-if="typeof getFirstInsdcExperimentIdentifier(item) === 'string'"
+          :href="makeInsdcHref(getFirstInsdcExperimentIdentifier(item))"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{ getFirstInsdcExperimentIdentifier(item) }}
+        </a>
+      </template>
+    </v-data-table>
+  </v-card>
 </template>


### PR DESCRIPTION
Resolves #2247 

All other data object tables are wrapped in a `<v-card>` however the `<AmpliconObjectDataTable>` components were not. I've now added that wrapper so that the amplicon tables extend to the full width of the result box and have a border consistent with the other omics tables.

<img width="1757" height="534" alt="Screenshot 2026-07-17 at 2 56 59 PM" src="https://github.com/user-attachments/assets/8ca33654-bdf6-4830-aa74-9cc567020e54" />
