### PR TITLE
Add note about samples without lat long being excluded from the map

### DIFF
--- a/web/src/views/Search/DataTypesVisGroup.vue
+++ b/web/src/views/Search/DataTypesVisGroup.vue
@@ -21,7 +21,7 @@ const helpMap = `
     <li>Click on a cluster to zoom in.</li>
     <li>Click "Search this region" to filter results to the current map view.</li>
   </ul>
-  <strong>Note:</strong> Samples collected at the poles may not appear on the map due to projection limits,
+  <strong>Note:</strong> Samples collected at the poles may not appear on the map due to projection limits and samples with no latitude/longitude information will not be shown,
   but they are included in other visualizations and the biosample table.
 `;
 


### PR DESCRIPTION
Address #2271 

This PR just adds a note to the help tooltip saying samples with no lat long will not be in the map to help explain why the count of samples on the map differs from the total shown in the table.