### PR TITLE
Fix non-interactive sankey bug

### DIFF
--- a/web/src/components/EcosystemSankey.vue
+++ b/web/src/components/EcosystemSankey.vue
@@ -8,6 +8,7 @@ import { api, type Condition } from '@/data/api';
 import { makeTree } from '@/util';
 import useRequest from '@/use/useRequest';
 import LoadingOverlay from '@/components/LoadingOverlay.vue';
+import { GoogleChartWrapper, GoogleVizEvents } from 'vue-google-charts/dist/types';
 
 export interface EcosystemSankeyProps {
   conditions?: Condition[];
@@ -24,6 +25,7 @@ const emit = defineEmits(['selected']);
 const { loading, error, request } = useRequest();
 const errorMessage = computed(() => error.value ? 'Could not retrieve ecosystem data' : null);
 const chartRef = ref();
+const chartHeight = ref(500);
 
 const onChartReady = (chart: any) => {
   chartRef.value = chart;
@@ -55,14 +57,23 @@ const chartEvents = {
       }],
     });
   },
-};
+  addListener: (chart: GoogleChartWrapper) => {
+    chartRef.value = chart;
+  },
+  removeListener: () => {
+    chartRef.value = null;
+  },
+  removeAllListeners: () => {
+    chartRef.value = null;
+  },
+} as GoogleVizEvents;
 
 const sankeyOptions = computed(() => {
   // Guard against undefined sankeyData (async computed property)
   const dataLength = sankeyData.value?.length || 0;
   return {
     // Make the chart height dependent on the number of nodes with a minimum of 500px
-    height: Math.max(dataLength * 4, 500),
+    height: Math.max(dataLength * 4, chartHeight.value),
     sankey: {
       link: {
         colorMode: 'source',
@@ -105,9 +116,10 @@ watchEffect(async () => {
     <LoadingOverlay
       :loading="loading"
       :error="errorMessage"
-      :height="500"
+      :height="chartHeight"
     />
     <GChart
+      v-if="sankeyData && sankeyData.length > 1"
       ref="chart"
       :settings="{
         packages: ['sankey'],
@@ -115,8 +127,17 @@ watchEffect(async () => {
       type="Sankey"
       :data="sankeyData"
       :options="sankeyOptions"
-      :events="chartEvents as any"
+      :events="chartEvents"
       @ready="onChartReady"
     />
+    <div
+      v-else-if="!loading && (!sankeyData || sankeyData.length === 1)"
+      class="d-flex align-center justify-center"
+      :style="{ height: `${chartHeight}px` }"
+    >
+      <p class="text-grey">
+        No results or no ecosystem data for this search
+      </p>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
Resolves #2265 

The ecosystem sankey diagram would break if it didn't have any data. This was observed when the Amplicon filter was applied because some (perhaps all) of these data do not have ecosystem metadata on their biosample records. The sankey component is now configured to show a "No results or no ecosystem data for this search" message when this occurs. Previously it would show a stale (non-interactive) diagram or a blank panel.

<img width="1727" height="668" alt="Screenshot 2026-07-22 at 2 05 01 PM" src="https://github.com/user-attachments/assets/6b778578-5501-42c7-91f1-7e9133049698" />
