### PR TITLE
Preserve submission last modified date during ingest

### DIFF
--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1524,6 +1524,12 @@ def update_submission_sample_set_timestamps(session: Session, _flush_context, _i
             continue
 
         is_new = obj in session.new
+        # The "new" incoming sample set already has a date_last_modified timestamp. This is an
+        # expected scenario during ingest where existing sample sets are copied from one database
+        # to the other. Do not update the sample set or parent submission timestamps in this case.
+        if is_new and obj.date_last_modified is not None:
+            continue
+
         if not is_new and not any(
             get_history(obj, column_name).has_changes()
             for column_name in SUBMISSION_SAMPLE_SET_MUTABLE_COLUMNS

--- a/tests/test_submission_timestamps.py
+++ b/tests/test_submission_timestamps.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from nmdc_schema.nmdc import SubmissionStatusEnum
+from sqlalchemy.orm import Session
+
+from nmdc_server import models
+from nmdc_server.ingest.common import merge_download_artifact
+
+
+def make_sample_set(
+    submission_id: UUID, *, date_last_modified: datetime | None = None
+) -> models.SubmissionSampleSet:
+    return models.SubmissionSampleSet(
+        id=uuid4(),
+        submission_metadata_id=submission_id,
+        name="Sample Set",
+        created=datetime(2020, 1, 1),
+        date_last_modified=date_last_modified,
+        status=SubmissionStatusEnum.InProgress.text,
+        templates=[],
+        sample_environment_form={},
+        sender_shipping_info_form={},
+        multi_omics_form={},
+        sample_data={},
+    )
+
+
+def test_merge_preserves_submission_timestamps(db: Session):
+    """
+    Test that the ingest's merge_download_artifact function preserves the date_last_modified
+    timestamps of submissions and sample sets.
+    """
+    original_timestamp = datetime(2020, 1, 2)
+    submission = models.SubmissionMetadata(
+        id=uuid4(),
+        author_orcid="test",
+        created=datetime(2020, 1, 1),
+        date_last_modified=original_timestamp,
+    )
+    sample_set = make_sample_set(
+        submission.id,
+        date_last_modified=original_timestamp,
+    )
+
+    merge_download_artifact(db, [submission])
+    merge_download_artifact(db, [sample_set])
+
+    copied_submission = db.get(models.SubmissionMetadata, submission.id)
+    copied_sample_set = db.get(models.SubmissionSampleSet, sample_set.id)
+
+    assert copied_submission is not None
+    assert copied_sample_set is not None
+    assert copied_submission.date_last_modified == original_timestamp
+    assert copied_sample_set.date_last_modified == original_timestamp
+
+
+def test_new_sample_set_without_timestamp_updates_parent(db: Session):
+    """
+    Test that creating a new sample set without a date_last_modified timestamp (simulating how a new
+    sample set created through the Submission Portal would look) updates the parent submission's
+    date_last_modified timestamp.
+    """
+    submission = models.SubmissionMetadata(author_orcid="test")
+    db.add(submission)
+    db.commit()
+    original_submission_timestamp = submission.date_last_modified
+
+    sample_set = make_sample_set(submission.id)
+    db.add(sample_set)
+    db.commit()
+    db.refresh(submission)
+
+    assert sample_set.date_last_modified is not None
+    assert submission.date_last_modified == sample_set.date_last_modified
+    assert submission.date_last_modified >= original_submission_timestamp
+
+
+def test_mutating_sample_set_updates_parent_timestamp(db: Session):
+    """
+    Test that mutating a sample set updates the parent submission's date_last_modified timestamp.
+    """
+    original_timestamp = datetime(2020, 1, 2)
+    submission = models.SubmissionMetadata(
+        author_orcid="test",
+        date_last_modified=original_timestamp,
+    )
+    db.add(submission)
+    db.commit()
+    sample_set = make_sample_set(
+        submission.id,
+        date_last_modified=original_timestamp,
+    )
+    db.add(sample_set)
+    db.commit()
+
+    sample_set.name = "Updated Sample Set"
+    db.commit()
+    db.refresh(submission)
+
+    assert sample_set.date_last_modified > original_timestamp
+    assert submission.date_last_modified == sample_set.date_last_modified

--- a/tests/test_submission_timestamps.py
+++ b/tests/test_submission_timestamps.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from nmdc_schema.nmdc import SubmissionStatusEnum
 from sqlalchemy.orm import Session
@@ -9,7 +9,7 @@ from nmdc_server.ingest.common import merge_download_artifact
 
 
 def make_sample_set(
-    submission_id: UUID, *, date_last_modified: datetime | None = None
+    submission_id: str, *, date_last_modified: datetime | None = None
 ) -> models.SubmissionSampleSet:
     return models.SubmissionSampleSet(
         id=uuid4(),
@@ -46,8 +46,8 @@ def test_merge_preserves_submission_timestamps(db: Session):
     merge_download_artifact(db, [submission])
     merge_download_artifact(db, [sample_set])
 
-    copied_submission = db.get(models.SubmissionMetadata, submission.id)
-    copied_sample_set = db.get(models.SubmissionSampleSet, sample_set.id)
+    copied_submission = db.get(models.SubmissionMetadata, submission.id)  # type: ignore[attr-defined]
+    copied_sample_set = db.get(models.SubmissionSampleSet, sample_set.id)  # type: ignore[attr-defined]
 
     assert copied_submission is not None
     assert copied_sample_set is not None


### PR DESCRIPTION
Fixes #2286 

The event listener (`update_submission_sample_set_timestamps`) which attempts to keep a submission's last modified date updated when one of its sample sets changes was being a little overeager. The last step of the ingest process copies the contents of the sample set table from the live database into the ingest database. As far as SQLAlchemy is concerned each of those copied rows represented "new" sample sets and therefore the event listener logic allowed the related submission's last modified date to be updated.

The fix here is to differentiate a _truly_ new sample set (i.e. as created by a user operation in the Submission Portal) from the not-really-new-during-ingest ones by looking to see if `date_last_modified` is already populated. If the sample set object is not already part of the SQLAlchemy session but `date_last_modified` is already populated, just preserve that value and don't touch the parent submission.