### PR TITLE
Fix sample set non-editable form issues

### DIFF
--- a/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
+++ b/web/src/views/SubmissionPortal/Components/TemplateChooser.vue
@@ -64,6 +64,7 @@ const checkboxDisabledReason = computed<Record<string, string | null>>(() => {
       </template>
     </PageTitle>
     <SubmissionForm
+      ref="formRef"
       in-sample-set-context
       @valid-state-changed="(state) => sampleEnvironmentForm.validation = state"
     >

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -242,6 +242,7 @@ function loadTemplateData(templateKey: TemplateName, template: HarmonizerTemplat
   harmonizerApi.loadData(templateData);
   harmonizerApi.setInvalidCells(store.sampleSet.forms.sampleData.validation?.invalidCells[templateKey] || {});
   harmonizerApi.changeVisibility(columnVisibility.value);
+  harmonizerApi.setTableReadOnly({ readOnly: !isEditable.value });
 }
 
 const validationErrors = computed(() => {
@@ -533,7 +534,7 @@ async function validateTemplate(
   template: HarmonizerTemplateInfo | null,
   { focusInvalidCell = true } = {},
 ) {
-  if (!templateKey || !template) {
+  if (!templateKey || !template || !isEditable.value) {
     return;
   }
 
@@ -804,11 +805,7 @@ async function fetchSuggestionsFromStudyDetails() {
 }
 
 watch(isEditable, (canEdit) => {
-  if (harmonizerApi.ready.value) {
-    if (!canEdit) {
-      harmonizerApi.setTableReadOnly();
-    }
-  }
+  harmonizerApi.setTableReadOnly({ readOnly: !canEdit });
 });
 
 onMounted(async () => {
@@ -833,8 +830,6 @@ onMounted(async () => {
     if (isEditable.value) {
       // Revive any stashed suggestions (in localstorage) for the active template
       store.sampleSet.suggestions = getPendingSuggestions(store.sampleSet.record!.id, activeTemplate.value?.schemaClass!);
-    } else {
-      harmonizerApi.setTableReadOnly();
     }
   }
 });

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -528,7 +528,7 @@ highlight(row?: number, col?: number) {
   }
 
   setTableReadOnly(options: { readOnly: boolean }) {
-    if (!this.dh || !this.dh.hot || !this.ready) {
+    if (!this.dh || !this.dh.hot || !this.ready.value) {
       return;
     }
     this.dh.hot.updateSettings(options);

--- a/web/src/views/SubmissionPortal/harmonizerApi.ts
+++ b/web/src/views/SubmissionPortal/harmonizerApi.ts
@@ -276,25 +276,25 @@ export default class HarmonizerApi {
 highlight(row?: number, col?: number) {
   const borders = this.dh.hot.getPlugin('customBorders');
   nextTick(() => borders.clearBorders());
-  
+
   if (row !== undefined && col !== undefined) {
     const hot = this.dh.hot;
     const totalRows = hot.countRows();
     const totalCols = hot.countCols();
-    
+
     // Create border definitions for the entire row and column
     const cellsToHighlight: number[][] = [];
-    
+
     // Add all cells in the row
     for (let c = 0; c < totalCols; c++) {
       cellsToHighlight.push([row, c, row, c]);
     }
-    
+
     // Add all cells in the column
     for (let r = 0; r < totalRows; r++) {
       cellsToHighlight.push([r, col, r, col]);
     }
-    
+
     nextTick(() => {
       // Apply a background to row and column
       borders.setBorders(cellsToHighlight, {
@@ -303,7 +303,7 @@ highlight(row?: number, col?: number) {
         top: { hide: false, width: 1, color: colors.purpleLightest },
         bottom: { hide: false, width: 1, color: colors.purpleLightest },
       });
-      
+
       // Highlight the target cell itself with a stronger border
       borders.setBorders([[row, col, row, col]], {
         left: { hide: false, width: 2, color: 'magenta' },
@@ -311,7 +311,7 @@ highlight(row?: number, col?: number) {
         top: { hide: false, width: 2, color: 'magenta' },
         bottom: { hide: false, width: 2, color: 'magenta' },
       });
-      
+
       hot.render();
     });
   }
@@ -527,8 +527,11 @@ highlight(row?: number, col?: number) {
     hot.updateSettings({ columns });
   }
 
-  setTableReadOnly() {
-    this.dh.hot.updateSettings({ readOnly: true });
+  setTableReadOnly(options: { readOnly: boolean }) {
+    if (!this.dh || !this.dh.hot || !this.ready) {
+      return;
+    }
+    this.dh.hot.updateSettings(options);
     this.dh.hot.render();
   }
 


### PR DESCRIPTION
Fixes #2289
Fixes #2290

These changes fix two distinct issues related to sample set pages picking up the read-only state.

* In `TemplateChooser.vue` somehow the `SubmissionForm` component lost it's template ref, so all the page logic that depended on the `SubmissionForms`'s disabled state didn't have access to it.
* In `HarmonizerView.vue` the issue was caused by not re-applying the `readOnly` setting after data changes. It was previously applied on mount and when the `isEditable` stated changed, but that doesn't cover when new data is loaded after changing tabs. These changes add a call to `loadTemplateData ` in `loadTemplateData`, which covers both the initial load and tab changes. I didn't track down exactly where this bug snuck in, but it might have been related to https://github.com/microbiomedata/nmdc-server/pull/2253.