### PR TITLE
Decrease number of times ingester retries HTTP requests

### DIFF
--- a/nmdc_server/ingest/common.py
+++ b/nmdc_server/ingest/common.py
@@ -33,11 +33,21 @@ EXCLUDED_FIELDS = {
 
 def make_requests_session() -> requests.Session:
     """
-    Returns a `requests.Session` configured to retry HTTP requests up to 10 times.
+    Returns a `requests.Session` configured to retry HTTP requests.
     Docs: https://docs.python-requests.org/en/latest/user/advanced/#example-automatic-retries
     """
     retry_strategy = Retry(
-        total=10,
+        # Note: With `total=6` and `backoff_factor=1`, the HTTP requests would be sent at the
+        #       following start times (if the responses were to arrive immediately, which is not
+        #       realistic, but is a useful condition for explaining what those two parameters do):
+        #       00:00 - Request #1
+        #       00:00 - Request #2 or "Retry #1" after waiting 0s
+        #       00:02 - Request #3 or "Retry #2" after waiting 2s
+        #       00:06 - Request #4 of "Retry #3" after waiting 4s
+        #       00:14 - Request #5 or "Retry #4" after waiting 8s
+        #       00:30 - Request #6 or "Retry #5" after waiting 16s
+        #       01:02 - Request #7 or "Retry #6" after waiting 32s
+        total=6,
         backoff_factor=1,
         allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,
         status_forcelist=[

--- a/nmdc_server/ingest/common.py
+++ b/nmdc_server/ingest/common.py
@@ -41,12 +41,12 @@ def make_requests_session() -> requests.Session:
         #       following start times (if the responses were to arrive immediately, which is not
         #       realistic, but is a useful condition for explaining what those two parameters do):
         #       00:00 - Request #1
-        #       00:00 - Request #2 or "Retry #1" after waiting 0s
-        #       00:02 - Request #3 or "Retry #2" after waiting 2s
-        #       00:06 - Request #4 of "Retry #3" after waiting 4s
-        #       00:14 - Request #5 or "Retry #4" after waiting 8s
-        #       00:30 - Request #6 or "Retry #5" after waiting 16s
-        #       01:02 - Request #7 or "Retry #6" after waiting 32s
+        #       00:00 - Request #2 (i.e. "Retry #1") after waiting 0s
+        #       00:02 - Request #3 (i.e. "Retry #2") after waiting 2s
+        #       00:06 - Request #4 (i.e. "Retry #3") after waiting 4s
+        #       00:14 - Request #5 (i.e. "Retry #4") after waiting 8s
+        #       00:30 - Request #6 (i.e. "Retry #5") after waiting 16s
+        #       01:02 - Request #7 (i.e. "Retry #6") after waiting 32s
         total=6,
         backoff_factor=1,
         allowed_methods=Retry.DEFAULT_ALLOWED_METHODS,


### PR DESCRIPTION
On this branch, I decreased the number of times the ingester retries HTTP requests; from 10 to 6.

With the configuration on this branch, which is `total=6` and `backoff_factor=1`: Hypothetically, if the error responses were to come back instantaneously, the last HTTP request would be sent about 1 minute after the first one.

In contrast, on `main`, where the configuration is `total=10` and `backoff_factor=1`, the last HTTP request would be sent about 17 minutes after the first one. I don't want to devote that much time to a single HTTP request. 

Note that this does _not_ affect the HTTP requests the ingester sends to fetch study images. Those use the base `requests` object instead of this `requests.Session` object.

As a reminder, HTTP request retrying was introduced earlier this month, via PR https://github.com/microbiomedata/nmdc-server/pull/2260. This newer PR is, in a sense, a "tuning" of that configuration.

Fixes #2296 