### PR TITLE
Prevent sample set routes from rendering before store is hydrated

### DIFF
--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -71,6 +71,7 @@ const router = createRouter({
           path: '',
           props: (route) => ({
             id: getRouteParamString(route.params.id) ?? null,
+            sampleSetId: getRouteParamString(route.params.sampleSetId) ?? null,
           }),
           children: [
             {

--- a/web/src/views/SubmissionPortal/StepperView.vue
+++ b/web/src/views/SubmissionPortal/StepperView.vue
@@ -10,6 +10,7 @@ import { useSubmissionStore } from './store';
 
 const props = defineProps<{
   id: string | null;
+  sampleSetId: string | null;
 }>();
 
 useEventListener('beforeunload', () => {
@@ -20,7 +21,16 @@ useEventListener('beforeunload', () => {
 
 const store = useSubmissionStore();
 const route = useRoute();
-const sampleSetLoading = computed(() => store.sampleSet.requests.loading.loading);
+
+// Sample-set route data is ready once no request is in progress and either no
+// sample set was requested or the loaded record matches the requested ID.
+// Checking the ID prevents the route component from mounting in the gap between
+// the request settling and the store being hydrated, when SubmissionForm could
+// erroneously validate the default values.
+const sampleSetReady = computed(() =>
+  !store.sampleSet.requests.loading.loading &&
+  (props.sampleSetId === null || store.sampleSet.record?.id === props.sampleSetId)
+);
 const sampleSetError = computed(() => store.sampleSet.requests.loading.error);
 const useFullWidthLayout = computed(() => route.meta.fullWidth === true);
 </script>
@@ -42,12 +52,12 @@ const useFullWidthLayout = computed(() => route.meta.fullWidth === true);
     </v-alert>
   </v-container>
 
-  <!-- Unless a sample set is loading, render the router view directly if the route
-       requested a full-width layout, otherwise wrap it in a v-container -->
+  <!-- Once sample-set route data is ready, render the router view directly if the
+       route requested a full-width layout; otherwise wrap it in a v-container. -->
   <router-view
-    v-else-if="!sampleSetLoading && useFullWidthLayout"
+    v-else-if="sampleSetReady && useFullWidthLayout"
   />
   <v-container v-else-if="!useFullWidthLayout">
-    <router-view v-if="!sampleSetLoading" />
+    <router-view v-if="sampleSetReady" />
   </v-container>
 </template>


### PR DESCRIPTION
I noticed a bug where, when a sample set-based route is rendered for the first time for a given submission (i.e. navigate from Submission Summary page to Multi-omics Data page), the `SubmissionForm` on the destination page would sometimes show an erroneous validation message. For example, it might show "You must select if data has been generated" beneath the first question, even though that question had previously been answered.

The cause of this issue was a timing issue where the `SubmissionForm` component's validation on mount: https://github.com/microbiomedata/nmdc-server/blob/2750762b3b2ae336f8df3760c794ed7a05e29cb0/web/src/views/SubmissionPortal/Components/SubmissionForm.vue#L54-L56

Was running after the `getSampleSet` API request settled: https://github.com/microbiomedata/nmdc-server/blob/8de20b461c8eaa8d81d467cfe7e7cad7852d7a72/web/src/views/SubmissionPortal/store/index.ts#L871

But before the store record was hydrated: https://github.com/microbiomedata/nmdc-server/blob/8de20b461c8eaa8d81d467cfe7e7cad7852d7a72/web/src/views/SubmissionPortal/store/index.ts#L557

This caused `SubmissionForm` to validate the default sample set state and there is no re-validation when the hydration completes. 

The fix is to update `StepperView` so that it checks both the request loading state **and** confirms hydration is finished before rendering the router outlet (which includes `SubmissionForm`).