### PR TITLE
Prevent ingest from aborting when request for study image fails

### DIFF
--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -55,7 +55,7 @@ def transform_doi(doi: str) -> str:
 def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
     """
     Fetches and returns the data (bytes) from the URL in the "url" field of the first dictionary,
-    if any, in the specified list. If the list is empty or the request times out, returns `None`.
+    if any, in the specified list. If the list is empty or the request fails, returns `None`.
     Note: If the first list item lacks a "url" field, this function raises a `KeyError`.
     """
 
@@ -65,7 +65,7 @@ def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
             r = requests.get(url)
             if r.ok:
                 return r.content
-        except requests.ConnectTimeout as e:
+        except requests.RequestException as e:
             logger.error(f"Failed to download image from '{url}': {e}")
     return None
 

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -53,10 +53,20 @@ def transform_doi(doi: str) -> str:
 
 
 def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
+    """
+    Fetches and returns the data (bytes) from the URL in the "url" field of the first dictionary,
+    if any, in the specified list. If the list is empty or the request times out, returns `None`.
+    Note: If the first list item lacks an "url" field, this function raises a `KeyError`.
+    """
+
     if image_urls:
-        r = requests.get(image_urls[0]["url"])
-        if r.ok:
-            return r.content
+        url = image_urls[0]["url"]
+        try:
+            r = requests.get(url)
+            if r.ok:
+                return r.content
+        except requests.ConnectTimeout as e:
+            logger.error(f"Failed to download image from '{url}': {e}")
     return None
 
 

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -55,16 +55,21 @@ def transform_doi(doi: str) -> str:
 def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
     """
     Fetches and returns the data (bytes) from the URL in the "url" field of the first dictionary,
-    if any, in the specified list. If the list is empty or the request fails, returns `None`.
-    Note: If the first list item lacks a "url" field, this function raises a `KeyError`.
+    if any, in the `image_urls` list. If the list is empty or the request fails, returns `None`.
+
+    Note: If the first list item lacks a "url" field, this function raises a `KeyError`. I don't
+          know what's special about the first list item—that was the original behavior and was not
+          prepared to modify it.
     """
 
     if image_urls:
         url = image_urls[0]["url"]
         try:
-            r = requests.get(url)
-            if r.ok:
-                return r.content
+            response = requests.get(url)
+            response.raise_for_status()
+            return response.content
+        # Note: `requests.RequestException` accounts for not only `requests.HTTPError`, but also
+        #       `requests.Timeout` (which we've encountered in production) and other exceptions.
         except requests.RequestException as e:
             logger.error(f"Failed to download image from '{url}': {e}")
     return None

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -56,7 +56,7 @@ def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
     """
     Fetches and returns the data (bytes) from the URL in the "url" field of the first dictionary,
     if any, in the specified list. If the list is empty or the request times out, returns `None`.
-    Note: If the first list item lacks an "url" field, this function raises a `KeyError`.
+    Note: If the first list item lacks a "url" field, this function raises a `KeyError`.
     """
 
     if image_urls:

--- a/nmdc_server/ingest/study.py
+++ b/nmdc_server/ingest/study.py
@@ -58,7 +58,7 @@ def get_study_image_data(image_urls: List[dict[str, str]]) -> Optional[bytes]:
     if any, in the `image_urls` list. If the list is empty or the request fails, returns `None`.
 
     Note: If the first list item lacks a "url" field, this function raises a `KeyError`. I don't
-          know what's special about the first list item—that was the original behavior and was not
+          know what's special about the first list item—that was the original behavior and I am not
           prepared to modify it.
     """
 


### PR DESCRIPTION
On this branch, I made it so, when the ingester fails to fetch a study image, the ingester does not crash.

To achieve that, I wrapped the HTTP request that fetches a study image, in a `try/catch`, where the `catch` catches any `requests.RequestException`. The `catch` block **just log an error** and then allows the function to proceed to return `None`, which is a return value that complies with the function's original return type hint.

I also took this opportunity to add a docstring to the function. In the docstring, I mention another scenario in which the function would raise an exception. I consider fixing _that_ code path to be **out of scope** of this PR.

Fixes #2295