### PR TITLE
Update `SubmissionList` with features to make navigating between submissions easier

### DIFF
--- a/web/src/views/SubmissionPortal/Components/SampleSetTable.vue
+++ b/web/src/views/SubmissionPortal/Components/SampleSetTable.vue
@@ -16,35 +16,51 @@ import {
 } from '@/views/SubmissionPortal/types.ts';
 import PageSection from '@/components/Presentation/PageSection.vue';
 
+const props = withDefaults(defineProps<{
+  sampleSets?: SubmissionSampleSetListItem[];
+  compact?: boolean;
+  showActions?: boolean;
+}>(), {
+  sampleSets: undefined,
+  compact: false,
+  showActions: true,
+});
 
-const headers: DataTableHeader[] = [
-  {
-    title: 'Sample Set Name',
-    value: 'name',
-    sortable: true,
-  },
-  {
-    title: 'Templates',
-    value: 'templates',
-    sortable: false,
-  },
-  {
-    title: 'Status',
-    value: 'status',
-    sortable: true,
-  },
-  {
-    title: 'Last Modified',
-    value: 'date_last_modified',
-    sortable: true,
-  },
-  {
-    title: '',
-    value: 'action',
-    align: 'end',
-    sortable: false,
-  },
-];
+const headers = computed<DataTableHeader[]>(() => {
+  const baseHeaders: DataTableHeader[] = [
+    {
+      title: 'Sample Set Name',
+      value: 'name',
+      sortable: true,
+    },
+    {
+      title: 'Templates',
+      value: 'templates',
+      sortable: false,
+    },
+    {
+      title: 'Status',
+      value: 'status',
+      sortable: true,
+    },
+    {
+      title: 'Last Modified',
+      value: 'date_last_modified',
+      sortable: true,
+    },
+  ];
+
+  if (props.showActions && !props.compact) {
+    baseHeaders.push({
+      title: '',
+      value: 'action',
+      align: 'end',
+      sortable: false,
+    });
+  }
+
+  return baseHeaders;
+});
 const router = useRouter();
 const store = useSubmissionStore();
 const isDeleteDialogOpen = ref(false);
@@ -72,7 +88,11 @@ const isContributor = computed(() => {
 
 const sampleSet = ref<SubmissionSampleSetListItem[]>([]);
 onMounted(async () => {
-  sampleSet.value = store.submission.record!.sample_sets;
+  if (props.sampleSets) {
+    sampleSet.value = props.sampleSets;
+    return;
+  }
+  sampleSet.value = store.submission.record?.sample_sets ?? [];
 });
 
 watch(
@@ -206,7 +226,39 @@ async function handleStatusChange(item: SubmissionSampleSetListItem | null, newS
 
 </script>
 <template>
-  <PageSection>
+  <div v-if="compact">
+    <v-card variant="outlined">
+      <v-data-table
+        :headers="headers"
+        :items="sampleSet"
+        hide-default-footer
+        density="compact"
+      >
+        <template #[`item.name`]="{ item }">
+          {{ item.name }}
+        </template>
+
+        <template #[`item.templates`]="{ item }">
+          {{ Array.isArray(item.templates) ? item.templates.join(' + ') : item.templates }}
+        </template>
+
+        <template #[`item.status`]="{ item }">
+          <div class="d-flex align-center">
+            <v-chip
+              :color="getStatus(item.status as SubmissionStatusKey).color"
+            >
+              {{ getStatus(item.status as SubmissionStatusKey).text }}
+            </v-chip>
+          </div>
+        </template>
+
+        <template #[`item.date_last_modified`]="{ item }">
+          {{ new Date(item.date_last_modified + 'Z').toLocaleString() }}
+        </template>
+      </v-data-table>
+    </v-card>
+  </div>
+  <PageSection v-else>
     <v-card variant="outlined">
       <v-data-table
         :headers="headers"

--- a/web/src/views/SubmissionPortal/Components/SampleSetTable.vue
+++ b/web/src/views/SubmissionPortal/Components/SampleSetTable.vue
@@ -96,6 +96,16 @@ onMounted(async () => {
 });
 
 watch(
+  () => props.sampleSets,
+  (newList) => {
+    if (newList) {
+      sampleSet.value = newList;
+    }
+  },
+  { immediate: true }
+);
+
+watch(
   sampleSet,
   (newList) => {
     const editableStatuses = ['InProgress', 'UpdatesRequired'];

--- a/web/src/views/SubmissionPortal/Components/SampleSetTable.vue
+++ b/web/src/views/SubmissionPortal/Components/SampleSetTable.vue
@@ -14,53 +14,36 @@ import {
   SubmissionSampleSetListItem,
   StatusOption,
 } from '@/views/SubmissionPortal/types.ts';
-import PageSection from '@/components/Presentation/PageSection.vue';
 
-const props = withDefaults(defineProps<{
-  sampleSets?: SubmissionSampleSetListItem[];
-  compact?: boolean;
-  showActions?: boolean;
-}>(), {
-  sampleSets: undefined,
-  compact: false,
-  showActions: true,
-});
 
-const headers = computed<DataTableHeader[]>(() => {
-  const baseHeaders: DataTableHeader[] = [
-    {
-      title: 'Sample Set Name',
-      value: 'name',
-      sortable: true,
-    },
-    {
-      title: 'Templates',
-      value: 'templates',
-      sortable: false,
-    },
-    {
-      title: 'Status',
-      value: 'status',
-      sortable: true,
-    },
-    {
-      title: 'Last Modified',
-      value: 'date_last_modified',
-      sortable: true,
-    },
-  ];
-
-  if (props.showActions && !props.compact) {
-    baseHeaders.push({
-      title: '',
-      value: 'action',
-      align: 'end',
-      sortable: false,
-    });
-  }
-
-  return baseHeaders;
-});
+const headers: DataTableHeader[] = [
+  {
+    title: 'Sample Set Name',
+    value: 'name',
+    sortable: true,
+  },
+  {
+    title: 'Templates',
+    value: 'templates',
+    sortable: false,
+  },
+  {
+    title: 'Status',
+    value: 'status',
+    sortable: true,
+  },
+  {
+    title: 'Last Modified',
+    value: 'date_last_modified',
+    sortable: true,
+  },
+  {
+    title: '',
+    value: 'action',
+    align: 'end',
+    sortable: false,
+  },
+];
 const router = useRouter();
 const store = useSubmissionStore();
 const isDeleteDialogOpen = ref(false);
@@ -88,22 +71,8 @@ const isContributor = computed(() => {
 
 const sampleSet = ref<SubmissionSampleSetListItem[]>([]);
 onMounted(async () => {
-  if (props.sampleSets) {
-    sampleSet.value = props.sampleSets;
-    return;
-  }
-  sampleSet.value = store.submission.record?.sample_sets ?? [];
+  sampleSet.value = store.submission.record!.sample_sets;
 });
-
-watch(
-  () => props.sampleSets,
-  (newList) => {
-    if (newList) {
-      sampleSet.value = newList;
-    }
-  },
-  { immediate: true }
-);
 
 watch(
   sampleSet,
@@ -236,117 +205,83 @@ async function handleStatusChange(item: SubmissionSampleSetListItem | null, newS
 
 </script>
 <template>
-  <div v-if="compact">
-    <v-card variant="outlined">
-      <v-data-table
-        :headers="headers"
-        :items="sampleSet"
-        hide-default-footer
-        density="compact"
-      >
-        <template #[`item.name`]="{ item }">
-          {{ item.name }}
-        </template>
+  <v-card variant="outlined">
+    <v-data-table
+      :headers="headers"
+      :items="sampleSet"
+      hide-default-footer
+    >
+      <template #[`item.name`]="{ item }">
+        {{ item.name }}
+      </template>
 
-        <template #[`item.templates`]="{ item }">
-          {{ Array.isArray(item.templates) ? item.templates.join(' + ') : item.templates }}
-        </template>
+      <template #[`item.templates`]="{ item }">
+        {{ Array.isArray(item.templates) ? item.templates.join(' + ') : item.templates }}
+      </template>
 
-        <template #[`item.status`]="{ item }">
-          <div class="d-flex align-center">
-            <v-chip
-              :color="getStatus(item.status as SubmissionStatusKey).color"
-            >
-              {{ getStatus(item.status as SubmissionStatusKey).text }}
-            </v-chip>
-          </div>
-        </template>
+      <template #[`item.status`]="{ item }">
+        <div class="d-flex align-center">
+          <v-chip
+            :color="getStatus(item.status as SubmissionStatusKey).color"
+          >
+            {{ getStatus(item.status as SubmissionStatusKey).text }}
+          </v-chip>
+        </div>
+      </template>
 
-        <template #[`item.date_last_modified`]="{ item }">
-          {{ new Date(item.date_last_modified + 'Z').toLocaleString() }}
-        </template>
-      </v-data-table>
-    </v-card>
-  </div>
-  <PageSection v-else>
-    <v-card variant="outlined">
-      <v-data-table
-        :headers="headers"
-        :items="sampleSet"
-        hide-default-footer
-      >
-        <template #[`item.name`]="{ item }">
-          {{ item.name }}
-        </template>
-
-        <template #[`item.templates`]="{ item }">
-          {{ Array.isArray(item.templates) ? item.templates.join(' + ') : item.templates }}
-        </template>
-
-        <template #[`item.status`]="{ item }">
-          <div class="d-flex align-center">
-            <v-chip
-              :color="getStatus(item.status as SubmissionStatusKey).color"
-            >
-              {{ getStatus(item.status as SubmissionStatusKey).text }}
-            </v-chip>
-          </div>
-        </template>
-
-        <template #[`item.date_last_modified`]="{ item }">
-          {{ new Date(item.date_last_modified + 'Z').toLocaleString() }}
-        </template>
-        <template #[`item.action`]="{ item }">
-          <div class="d-flex align-center">
-            <v-spacer />
-            <v-btn
-              size="small"
-              color="primary"
-              @click="() => resume(item)"
-            >
-              <span v-if="sampleSetEditableState[item.id] && isContributor">
-                Resume
-                <v-icon class="pl-1">mdi-arrow-right-circle</v-icon>
-              </span>
-              <span v-else>
-                <v-icon class="pl-1">mdi-eye</v-icon>
-                View
-              </span>
-            </v-btn>
-            <v-menu
-              offset-x
-            >
-              <template #activator="{ props }">
-                <v-btn
-                  variant="text"
-                  icon
-                  class="ml-1"
-                  v-bind="props"
-                >
-                  <v-icon>
-                    mdi-dots-vertical
-                  </v-icon>
-                </v-btn>
-              </template>
-              <v-list>
-                <v-list-item
-                  @click="() => handleOpenDeleteDialog(item)"
-                >
-                  <v-list-item-title>Delete</v-list-item-title>
-                </v-list-item>
-                <v-list-item
-                  v-if="currentUser?.is_admin || isReviewerForSubmission()"
-                  @click="() => handleOpenStatusDialog(item)"
-                >
-                  <v-list-item-title>Set Status</v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
-          </div>
-        </template>
-      </v-data-table>
-    </v-card>
-  </PageSection>
+      <template #[`item.date_last_modified`]="{ item }">
+        {{ new Date(item.date_last_modified + 'Z').toLocaleString() }}
+      </template>
+      <template #[`item.action`]="{ item }">
+        <div class="d-flex align-center">
+          <v-spacer />
+          <v-btn
+            size="small"
+            color="primary"
+            @click="() => resume(item)"
+          >
+            <span v-if="sampleSetEditableState[item.id] && isContributor">
+              Resume
+              <v-icon class="pl-1">mdi-arrow-right-circle</v-icon>
+            </span>
+            <span v-else>
+              <v-icon class="pl-1">mdi-eye</v-icon>
+              View
+            </span>
+          </v-btn>
+          <v-menu
+            offset-x
+          >
+            <template #activator="{ props }">
+              <v-btn
+                variant="text"
+                icon
+                class="ml-1"
+                v-bind="props"
+              >
+                <v-icon>
+                  mdi-dots-vertical
+                </v-icon>
+              </v-btn>
+            </template>
+            <v-list>
+              <v-list-item
+                @click="() => handleOpenDeleteDialog(item)"
+              >
+                <v-list-item-title>Delete</v-list-item-title>
+              </v-list-item>
+              <v-list-item
+                v-if="currentUser?.is_admin || isReviewerForSubmission()"
+                @click="() => handleOpenStatusDialog(item)"
+              >
+                <v-list-item-title>Set Status</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </div>
+      </template>
+    </v-data-table>
+  </v-card>
   <v-dialog
     v-model="isDeleteDialogOpen"
     :width="550"

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { ref, useTemplateRef, watch } from 'vue';
-import { useRouter } from 'vue-router';
+import { onMounted, ref, useTemplateRef, watch } from 'vue';
+import { useSubmissionStore } from '../store';
 import { DataTableHeader } from 'vuetify';
 import { VTextField } from 'vuetify/components';
 import usePaginatedResults from '@/use/usePaginatedResults';
 import * as api from '../store/api';
 import OrcidId from '../../../components/Presentation/OrcidId.vue';
-import SampleSetTable from './SampleSetTable.vue';
 import TitleBanner from '@/views/SubmissionPortal/Components/TitleBanner.vue';
 import IconBar from '@/views/SubmissionPortal/Components/IconBar.vue';
 import IntroBlurb from '@/views/SubmissionPortal/Components/IntroBlurb.vue';
@@ -15,7 +14,6 @@ import { SearchParams } from '@/data/api';
 import { addSubmissionRole, deleteSubmission } from '../store/api';
 import {
   PaginatedResponse,
-  SubmissionMetadata,
   SubmissionMetadataSlim,
 } from '@/views/SubmissionPortal/types';
 import { stateRefs } from '@/store';
@@ -46,7 +44,7 @@ const headers: DataTableHeader[] = [
   },
 ];
 
-const router = useRouter();
+const store = useSubmissionStore();
 const itemsPerPage = 10;
 const defaultSortBy = 'date_last_modified';
 const defaultSortOrder = 'desc';
@@ -61,31 +59,30 @@ const isDeleteDialogOpen = ref(false);
 const deleteDialogSubmission = ref<SubmissionMetadataSlim | null>(null);
 const isReviewerAssignmentDialogOpen = ref(false);
 const isReviewerAssignmentSnackbarOpen = ref(false);
-const isSampleSetPreviewDialogOpen = ref(false);
-const sampleSetPreviewSubmission = ref<SubmissionMetadata | null>(null);
 const selectedSubmission = ref<SubmissionMetadataSlim | null>(null);
 const currentUser = stateRefs.user;
-const isTestFilter = ref(null);
 const testFilterValues = [
   { text: 'Show all submissions', val: null },
   { text: 'Show only test submissions', val: true },
   { text: 'Hide test submissions', val: false }];
-const searchText = ref('');
-const resumeContextMenuId = ref<string | null>(null);
+
+function saveFilters() {
+  store.saveSubmissionListFilters();
+}
+
+function restoreFilters() {
+  store.restoreSubmissionListFilters();
+}
+
+onMounted(() => {
+  restoreFilters();
+  saveFilters();
+});
 
 async function getSubmissions(params: SearchParams): Promise<PaginatedResponse<SubmissionMetadataSlim>> {
-  return api.listSubmissions(params, isTestFilter.value, searchText.value);
+  return api.listSubmissions(params, store.submissionListFilters.isTestFilter, store.submissionListFilters.searchText);
 }
 
-
-async function resume(item: SubmissionMetadataSlim) {
-  router?.push({ name: 'Submission Summary', params: { id: item.id } });
-}
-
-function resumeNewTab(item: SubmissionMetadataSlim) {
-  const url = router.resolve({ name: 'Submission Summary', params: { id: item.id } }).href;
-  window.open(url, '_blank');
-}
 
 const submission = usePaginatedResults(ref([]), getSubmissions, ref([]), itemsPerPage);
 
@@ -104,13 +101,15 @@ function updateTableOptions(newOptions: any) {
   applySortOptions();
 }
 
-watch(isTestFilter, () => {
+watch(() => store.submissionListFilters.isTestFilter, () => {
+  saveFilters();
   options.value.page = 1;
   submission.setPage(options.value.page);
   applySortOptions();
 }, { deep: true });
 
-watch(searchText, () => {
+watch(() => store.submissionListFilters.searchText, () => {
+  saveFilters();
   options.value.page = 1;
   submission.setPage(options.value.page);
   applySortOptions();
@@ -139,14 +138,6 @@ const orcidTextFieldRef = useTemplateRef<InstanceType<typeof VTextField>>('orcid
 function openReviewerDialog(item: SubmissionMetadataSlim | null) {
   isReviewerAssignmentDialogOpen.value = true;
   selectedSubmission.value = item;
-}
-
-async function openSampleSetPreviewDialog(item: SubmissionMetadataSlim | null) {
-  if (!item) {
-    return;
-  }
-  isSampleSetPreviewDialogOpen.value = true;
-  sampleSetPreviewSubmission.value = await api.getSubmission(item.id);
 }
 
 async function addReviewer() {
@@ -234,7 +225,7 @@ async function addReviewer() {
             cols="3"
           >
             <v-text-field
-              v-model="searchText"
+              v-model="store.submissionListFilters.searchText"
               label="Search"
               variant="outlined"
               class="pr-2"
@@ -246,7 +237,7 @@ async function addReviewer() {
           </v-col>
           <v-col>
             <v-select
-              v-model="isTestFilter"
+              v-model="store.submissionListFilters.isTestFilter"
               :items="testFilterValues"
               item-title="text"
               item-value="val"
@@ -267,9 +258,15 @@ async function addReviewer() {
             @update:options="updateTableOptions"
           >
             <template #[`item.study_name`]="{ item }">
-              {{ item.study_name }}
+              <router-link
+                :to="{ name: 'Submission Summary', params: { id: item.id } }"
+                class="text-primary text-decoration-none"
+              >
+                {{ item.study_name }}
+              </router-link>
               <v-chip
                 v-if="item.is_test_submission"
+                class="ml-2"
                 color="orange"
                 text-color="white"
                 small
@@ -292,45 +289,6 @@ async function addReviewer() {
               <div class="d-flex align-center">
                 <v-spacer />
                 <v-menu
-                  :model-value="resumeContextMenuId === item.id"
-                  @update:model-value="(val) => resumeContextMenuId = val ? item.id : null"
-                  location="bottom"
-                  offset-y
-                >
-                  <template #activator="{ props }">
-                    <div
-                      v-bind="props"
-                      @contextmenu.prevent="() => { resumeContextMenuId = resumeContextMenuId === item.id ? null : item.id; }"
-                      style="display: inline-block;"
-                    >
-                      <v-btn
-                        size="small"
-                        color="primary"
-                        @click="() => resume(item)"
-                      >
-                        Resume
-                        <v-icon class="pl-1">
-                          mdi-arrow-right-circle
-                        </v-icon>
-                      </v-btn>
-                    </div>
-                  </template>
-                  <v-list>
-                    <v-list-item @click="() => resume(item)">
-                      <v-list-item-title>
-                        <v-icon class="mr-2" size="small">mdi-arrow-right-circle</v-icon>
-                        Resume in this tab
-                      </v-list-item-title>
-                    </v-list-item>
-                    <v-list-item @click="() => resumeNewTab(item)">
-                      <v-list-item-title>
-                        <v-icon class="mr-2" size="small">mdi-open-in-new</v-icon>
-                        Resume in new tab
-                      </v-list-item-title>
-                    </v-list-item>
-                  </v-list>
-                </v-menu>
-                <v-menu
                   offset-x
                 >
                   <template #activator="{ props }">
@@ -352,11 +310,6 @@ async function addReviewer() {
                       <v-list-item-title>Delete</v-list-item-title>
                     </v-list-item>
                     <v-list-item
-                      @click="() => openSampleSetPreviewDialog(item)"
-                    >
-                      <v-list-item-title>Sample Set Preview</v-list-item-title>
-                    </v-list-item>
-                    <v-list-item
                       v-if="currentUser?.is_admin"
                       @click="() => openReviewerDialog(item)"
                     >
@@ -370,38 +323,6 @@ async function addReviewer() {
         </v-card>
       </v-card>
     </v-container>
-    <v-dialog
-      v-model="isSampleSetPreviewDialogOpen"
-      max-width="900px"
-    >
-      <v-card>
-        <v-card-title class="text-h5">
-          Sample Set Preview
-        </v-card-title>
-        <v-card-text>
-          <SampleSetTable
-            v-if="sampleSetPreviewSubmission"
-            :sample-sets="sampleSetPreviewSubmission.sample_sets"
-            compact
-          />
-          <div
-            v-else
-            class="text-body-2 text-medium-emphasis"
-          >
-            No sample sets are available for this submission.
-          </div>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn
-            class="ma-3"
-            @click="isSampleSetPreviewDialogOpen = false"
-          >
-            Close
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
     <v-dialog
       v-model="isDeleteDialogOpen"
       :width="550"

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -67,6 +67,7 @@ const testFilterValues = [
   { text: 'Show only test submissions', val: true },
   { text: 'Hide test submissions', val: false }];
 const searchText = ref('');
+const resumeContextMenuId = ref<string | null>(null);
 
 async function getSubmissions(params: SearchParams): Promise<PaginatedResponse<SubmissionMetadataSlim>> {
   return api.listSubmissions(params, isTestFilter.value, searchText.value);
@@ -75,6 +76,11 @@ async function getSubmissions(params: SearchParams): Promise<PaginatedResponse<S
 
 async function resume(item: SubmissionMetadataSlim) {
   router?.push({ name: 'Submission Summary', params: { id: item.id } });
+}
+
+function resumeNewTab(item: SubmissionMetadataSlim) {
+  const url = router.resolve({ name: 'Submission Summary', params: { id: item.id } }).href;
+  window.open(url, '_blank');
 }
 
 const submission = usePaginatedResults(ref([]), getSubmissions, ref([]), itemsPerPage);
@@ -273,16 +279,45 @@ async function addReviewer() {
             <template #[`item.action`]="{ item }">
               <div class="d-flex align-center">
                 <v-spacer />
-                <v-btn
-                  size="small"
-                  color="primary"
-                  @click="() => resume(item)"
+                <v-menu
+                  :model-value="resumeContextMenuId === item.id"
+                  @update:model-value="(val) => resumeContextMenuId = val ? item.id : null"
+                  location="bottom"
+                  offset-y
                 >
-                  Resume
-                  <v-icon class="pl-1">
-                    mdi-arrow-right-circle
-                  </v-icon>
-                </v-btn>
+                  <template #activator="{ props }">
+                    <div
+                      v-bind="props"
+                      @contextmenu.prevent="() => { resumeContextMenuId = resumeContextMenuId === item.id ? null : item.id; }"
+                      style="display: inline-block;"
+                    >
+                      <v-btn
+                        size="small"
+                        color="primary"
+                        @click="() => resume(item)"
+                      >
+                        Resume
+                        <v-icon class="pl-1">
+                          mdi-arrow-right-circle
+                        </v-icon>
+                      </v-btn>
+                    </div>
+                  </template>
+                  <v-list>
+                    <v-list-item @click="() => resume(item)">
+                      <v-list-item-title>
+                        <v-icon class="mr-2" size="small">mdi-arrow-right-circle</v-icon>
+                        Resume in this tab
+                      </v-list-item-title>
+                    </v-list-item>
+                    <v-list-item @click="() => resumeNewTab(item)">
+                      <v-list-item-title>
+                        <v-icon class="mr-2" size="small">mdi-open-in-new</v-icon>
+                        Resume in new tab
+                      </v-list-item-title>
+                    </v-list-item>
+                  </v-list>
+                </v-menu>
                 <v-menu
                   offset-x
                 >

--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -6,6 +6,7 @@ import { VTextField } from 'vuetify/components';
 import usePaginatedResults from '@/use/usePaginatedResults';
 import * as api from '../store/api';
 import OrcidId from '../../../components/Presentation/OrcidId.vue';
+import SampleSetTable from './SampleSetTable.vue';
 import TitleBanner from '@/views/SubmissionPortal/Components/TitleBanner.vue';
 import IconBar from '@/views/SubmissionPortal/Components/IconBar.vue';
 import IntroBlurb from '@/views/SubmissionPortal/Components/IntroBlurb.vue';
@@ -14,6 +15,7 @@ import { SearchParams } from '@/data/api';
 import { addSubmissionRole, deleteSubmission } from '../store/api';
 import {
   PaginatedResponse,
+  SubmissionMetadata,
   SubmissionMetadataSlim,
 } from '@/views/SubmissionPortal/types';
 import { stateRefs } from '@/store';
@@ -59,6 +61,8 @@ const isDeleteDialogOpen = ref(false);
 const deleteDialogSubmission = ref<SubmissionMetadataSlim | null>(null);
 const isReviewerAssignmentDialogOpen = ref(false);
 const isReviewerAssignmentSnackbarOpen = ref(false);
+const isSampleSetPreviewDialogOpen = ref(false);
+const sampleSetPreviewSubmission = ref<SubmissionMetadata | null>(null);
 const selectedSubmission = ref<SubmissionMetadataSlim | null>(null);
 const currentUser = stateRefs.user;
 const isTestFilter = ref(null);
@@ -135,6 +139,14 @@ const orcidTextFieldRef = useTemplateRef<InstanceType<typeof VTextField>>('orcid
 function openReviewerDialog(item: SubmissionMetadataSlim | null) {
   isReviewerAssignmentDialogOpen.value = true;
   selectedSubmission.value = item;
+}
+
+async function openSampleSetPreviewDialog(item: SubmissionMetadataSlim | null) {
+  if (!item) {
+    return;
+  }
+  isSampleSetPreviewDialogOpen.value = true;
+  sampleSetPreviewSubmission.value = await api.getSubmission(item.id);
 }
 
 async function addReviewer() {
@@ -340,6 +352,11 @@ async function addReviewer() {
                       <v-list-item-title>Delete</v-list-item-title>
                     </v-list-item>
                     <v-list-item
+                      @click="() => openSampleSetPreviewDialog(item)"
+                    >
+                      <v-list-item-title>Sample Set Preview</v-list-item-title>
+                    </v-list-item>
+                    <v-list-item
                       v-if="currentUser?.is_admin"
                       @click="() => openReviewerDialog(item)"
                     >
@@ -353,6 +370,38 @@ async function addReviewer() {
         </v-card>
       </v-card>
     </v-container>
+    <v-dialog
+      v-model="isSampleSetPreviewDialogOpen"
+      max-width="900px"
+    >
+      <v-card>
+        <v-card-title class="text-h5">
+          Sample Set Preview
+        </v-card-title>
+        <v-card-text>
+          <SampleSetTable
+            v-if="sampleSetPreviewSubmission"
+            :sample-sets="sampleSetPreviewSubmission.sample_sets"
+            compact
+          />
+          <div
+            v-else
+            class="text-body-2 text-medium-emphasis"
+          >
+            No sample sets are available for this submission.
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            class="ma-3"
+            @click="isSampleSetPreviewDialogOpen = false"
+          >
+            Close
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-dialog
       v-model="isDeleteDialogOpen"
       :width="550"

--- a/web/src/views/SubmissionPortal/Components/SubmissionSummary.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionSummary.vue
@@ -108,6 +108,7 @@ async function createNewSampleSet() {
   >
     <v-btn
       color="primary"
+      class="mb-2"
       @click="createNewSampleSet"
     >
       <v-icon>mdi-plus</v-icon>

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -40,6 +40,8 @@ import { stateRefs } from '@/store';
 import { getPendingSuggestions, setPendingSuggestions } from '@/store/localStorage.ts';
 import HarmonizerApi from '@/views/SubmissionPortal/harmonizerApi.ts';
 
+const SUBMISSION_LIST_FILTERS_KEY = 'storage.submissionListFilters';
+
 const EDITABLE_SAMPLE_SET_STATUSES = [
   SubmissionStatusEnum.InProgress.text,
   SubmissionStatusEnum.UpdatesRequired.text,
@@ -170,6 +172,11 @@ type UiState = {
   pendingImageUploads: Set<SubmissionImageType>
 }
 
+type SubmissionListFilterState = {
+  searchText: string;
+  isTestFilter: boolean | null;
+}
+
 /* STATE-FREE HELPERS */
 function createEmptySubmissionForms(): SubmissionForms {
   return {
@@ -213,6 +220,10 @@ export const useSubmissionStore = defineStore('submission', () => {
     suggestionFills: new Set(Object.values(SuggestionFill)),
     suggestionTypes: new Set([SuggestionType.ADDITIONS, SuggestionType.REPLACEMENTS]),
     pendingImageUploads: new Set(),
+  });
+  const submissionListFilters = reactive<SubmissionListFilterState>({
+    searchText: '',
+    isTestFilter: null,
   });
 
   /* GETTERS */
@@ -516,6 +527,39 @@ export const useSubmissionStore = defineStore('submission', () => {
   });
 
   /* HELPERS */
+  /** 
+   * Save current submission list filters to session storage that they can be persisted through page transitions
+  */
+  function saveSubmissionListFilters() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.sessionStorage.setItem(SUBMISSION_LIST_FILTERS_KEY, JSON.stringify(submissionListFilters));
+  }
+
+  /**
+   * Load previously saved filters for the submission list
+   */
+  function restoreSubmissionListFilters() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const savedFilters = window.sessionStorage.getItem(SUBMISSION_LIST_FILTERS_KEY);
+    if (!savedFilters) {
+      return;
+    }
+
+    const parsedFilters = JSON.parse(savedFilters) as Partial<SubmissionListFilterState>;
+    if (typeof parsedFilters.searchText === 'string') {
+      submissionListFilters.searchText = parsedFilters.searchText;
+    }
+
+    if (parsedFilters.isTestFilter === null || typeof parsedFilters.isTestFilter === 'boolean') {
+      submissionListFilters.isTestFilter = parsedFilters.isTestFilter;
+    }
+  }
+
   /**
    * Populate the submission state with data from the server.
    *
@@ -1072,6 +1116,7 @@ export const useSubmissionStore = defineStore('submission', () => {
     submission,
     sampleSet,
     ui,
+    submissionListFilters,
 
     /* GETTERS */
     studyName,
@@ -1082,6 +1127,8 @@ export const useSubmissionStore = defineStore('submission', () => {
     hasPendingImageUploads,
 
     /* ACTIONS */
+    saveSubmissionListFilters,
+    restoreSubmissionListFilters,
     loadSubmission,
     createSubmission,
     createSubmissionSampleSet,


### PR DESCRIPTION
Resolves #2309 

These changes add some changes for reviewers (and other users) to use that provide some ease of use.

This PR updates `SubmissionList` to use route links instead of the resume button, and adds filter persistence. 
The first change is more in line with the data portal, adding consistency. It also allows users to open submissions in new tabs and windows.
The second change allows users to keep their selected filter values in `SubmissionList` if they navigate back to that page (in the case of a misclick on the wrong submission or any other reason).

Both of these changes should alleviate some user feedback associated with the linked issue.

<img width="1790" height="782" alt="Screenshot 2026-08-07 at 12 53 08 PM" src="https://github.com/user-attachments/assets/5bd81dad-8595-48ec-99a9-b16e3bff7993" />
