### PR TITLE
Fix duplicate workflow executions and data objects in Data Portal UI

### DIFF
--- a/nmdc_server/aggregations.py
+++ b/nmdc_server/aggregations.py
@@ -278,57 +278,58 @@ def get_data_object_aggregation(
         for workflow in WorkflowActivityTypeEnum
     }
 
-    # TODO: we could join this into one query with a union, but it might not be worthwhile
-    # aggregate workflows
-    workflow_rows_query = (
+    # A data object can be associated with multiple matching data generations
+    # (notably when a workflow is informed by pooled replicates). Deduplicate at
+    # the data object level before aggregating so both counts and byte totals are
+    # accurate.
+    data_objects_query = (
         db.query(
-            models.DataObject.workflow_type,
-            func.count(models.DataObject.id),
-            func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)),
-        )
-        .join(
-            models.omics_processing_output_association,
-            models.omics_processing_output_association.c.data_object_id == models.DataObject.id,
-        )
-        .filter(
-            models.DataObject.workflow_type != None,  # noqa: E711
-            subquery.c.id == models.omics_processing_output_association.c.omics_processing_id,
-            models.DataObject.url != None,  # noqa: E711
-        )
-    )
-    if not include_superseded_workflow_executions:
-        workflow_rows_query = workflow_rows_query.filter(
-            models.DataObject.id.notin_(superseded_dobj_ids_subquery)
-        )
-    for row in workflow_rows_query.group_by(models.DataObject.workflow_type):
-        agg[row[0]].count = row[1]
-        agg[row[0]].size = row[2]
-
-    # aggregate file_types
-    file_type_rows_query = (
-        db.query(
+            models.DataObject.id,
             models.DataObject.workflow_type,
             models.DataObject.file_type,
-            func.count(models.DataObject.id),
-            func.sum(func.coalesce(models.DataObject.file_size_bytes, 0)),
+            models.DataObject.file_size_bytes,
         )
         .join(
             models.omics_processing_output_association,
             models.omics_processing_output_association.c.data_object_id == models.DataObject.id,
         )
+        .join(
+            subquery,
+            subquery.c.id == models.omics_processing_output_association.c.omics_processing_id,
+        )
         .filter(
             models.DataObject.workflow_type != None,  # noqa: E711
-            models.DataObject.file_type != None,  # noqa: E711
-            subquery.c.id == models.omics_processing_output_association.c.omics_processing_id,
             models.DataObject.url != None,  # noqa: E711
         )
     )
     if not include_superseded_workflow_executions:
-        file_type_rows_query = file_type_rows_query.filter(
+        data_objects_query = data_objects_query.filter(
             models.DataObject.id.notin_(superseded_dobj_ids_subquery)
         )
+    data_objects = data_objects_query.distinct().subquery()
+
+    # TODO: we could join this into one query with a union, but it might not be worthwhile
+    # aggregate workflows
+    workflow_rows_query = db.query(
+        data_objects.c.workflow_type,
+        func.count(data_objects.c.id),
+        func.sum(func.coalesce(data_objects.c.file_size_bytes, 0)),
+    )
+    for row in workflow_rows_query.group_by(data_objects.c.workflow_type):
+        agg[row[0]].count = int(row[1] or 0)
+        agg[row[0]].size = int(row[2] or 0)
+
+    # aggregate file_types
+    file_type_rows_query = db.query(
+        data_objects.c.workflow_type,
+        data_objects.c.file_type,
+        func.count(data_objects.c.id),
+        func.sum(func.coalesce(data_objects.c.file_size_bytes, 0)),
+    ).filter(
+        data_objects.c.file_type != None,  # noqa: E711
+    )
     for row in file_type_rows_query.group_by(
-        models.DataObject.workflow_type, models.DataObject.file_type
+        data_objects.c.workflow_type, data_objects.c.file_type
     ):
         agg[row[0]].file_types[row[1]] = schemas.DataObjectAggregationNode(
             count=row[2], size=row[3]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -133,6 +133,31 @@ def test_bulk_download_query(db: Session):
     assert data_object_agg_obj.count == 1
 
 
+def test_workflow_summary_deduplicates_data_objects_across_data_generations(
+    db: Session, client: TestClient
+):
+    sample = fakes.BiosampleFactory()
+    op1 = fakes.OmicsProcessingFactory(biosample_inputs=[sample])
+    op2 = fakes.OmicsProcessingFactory(biosample_inputs=[sample])
+    output = fakes.DataObjectFactory(
+        url="https://data.microbiomedata.org/data/shared",
+        file_size_bytes=123,
+        workflow_type=WorkflowActivityTypeEnum.metagenome_annotation.value,
+        file_type="Annotation GFF",
+    )
+    op1.outputs.append(output)
+    op2.outputs.append(output)
+    db.commit()
+
+    response = client.post("/api/data_object/workflow_summary")
+
+    assert response.status_code == 200
+    workflow_summary = response.json()[WorkflowActivityTypeEnum.metagenome_annotation.value]
+    assert workflow_summary["count"] == 1
+    assert workflow_summary["size"] == 123
+    assert workflow_summary["file_types"]["Annotation GFF"] == {"count": 1, "size": 123}
+
+
 def test_generate_bulk_download(db: Session, client: TestClient, logged_in_user):
     sample = fakes.BiosampleFactory()
     op1 = fakes.OmicsProcessingFactory(biosample_inputs=[sample])

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc_materialized_patterns.json';
 import { computed, reactive, ref, Ref, watch } from 'vue';
-import { flattenDeep, uniqBy } from 'lodash';
+import { flattenDeep, uniq, uniqBy } from 'lodash';
 
 import { DataTableHeader } from 'vuetify';
 import { humanFileSize } from '@/data/utils';
@@ -184,24 +184,39 @@ function getGroupName(omicsData: {id: string, name: string}): string {
   return `${props.omicsType} Analysis ${omicsData.id}`;
 }
 
-const items = computed(() => flattenDeep(
-  // A workflow execution can be informed by more than one data generation (for
-  // example, pooled replicates). The API consequently includes it under each
-  // data generation, but this biosample-wide table should display it only once.
-  uniqBy(
-    flattenDeep(props.omicsProcessing.map((p) => (getOmicsDataWithInputIds(p)))),
-    (omicsData) => omicsData.id,
-  )
-    .map((omics_data) => omics_data.outputs
-      .filter((data) => data.file_type && data.file_type_description)
-      .map((data_object, i) => ({
-        ...data_object,
-        omics_data,
-        /* TODO Hack to replace metagenome with omics type name */
-        group_name: getGroupName(omics_data),
-        newgroup: i === 0,
-      }))),
-));
+const items = computed(() => {
+  const allOmicsData: any[] = flattenDeep(
+    props.omicsProcessing.map((processing) => getOmicsDataWithInputIds(processing)),
+  );
+  // Concatenate the input IDs for each workflow execution so that we
+  // can display all associated biosample inputs in the table,
+  // even when the workflow execution is shared by multiple data generations.
+  const inputIdsByWorkflow: Record<string, string[]> = {};
+  allOmicsData.forEach((omicsData) => {
+    const inputIds = inputIdsByWorkflow[omicsData.id] ?? [];
+    inputIdsByWorkflow[omicsData.id] = uniq([...inputIds, ...omicsData.inputIds]);
+  });
+
+  return flattenDeep(
+    // A workflow execution can be informed by more than one data generation (for
+    // example, pooled replicates). The API consequently includes it under each
+    // data generation, but this biosample-wide table should display it only once.
+    uniqBy(allOmicsData, (omicsData) => omicsData.id)
+      .map((omicsData) => ({
+        ...omicsData,
+        inputIds: inputIdsByWorkflow[omicsData.id] ?? [],
+      }))
+      .map((omics_data) => omics_data.outputs
+        .filter((data: any) => data.file_type && data.file_type_description)
+        .map((data_object: any, i: number) => ({
+          ...data_object,
+          omics_data,
+          /* TODO Hack to replace metagenome with omics type name */
+          group_name: getGroupName(omics_data),
+          newgroup: i === 0,
+        }))),
+  );
+});
 
 function getRelatedBiosampleIds(omicsData: any) {
   if (!omicsData || !omicsData.inputIds) {

--- a/web/src/components/DataObjectTable.vue
+++ b/web/src/components/DataObjectTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import NmdcSchema from 'nmdc-schema/nmdc_schema/nmdc_materialized_patterns.json';
 import { computed, reactive, ref, Ref, watch } from 'vue';
-import { flattenDeep } from 'lodash';
+import { flattenDeep, uniqBy } from 'lodash';
 
 import { DataTableHeader } from 'vuetify';
 import { humanFileSize } from '@/data/utils';
@@ -185,7 +185,13 @@ function getGroupName(omicsData: {id: string, name: string}): string {
 }
 
 const items = computed(() => flattenDeep(
-  flattenDeep(props.omicsProcessing.map((p) => (getOmicsDataWithInputIds(p))))
+  // A workflow execution can be informed by more than one data generation (for
+  // example, pooled replicates). The API consequently includes it under each
+  // data generation, but this biosample-wide table should display it only once.
+  uniqBy(
+    flattenDeep(props.omicsProcessing.map((p) => (getOmicsDataWithInputIds(p)))),
+    (omicsData) => omicsData.id,
+  )
     .map((omics_data) => omics_data.outputs
       .filter((data) => data.file_type && data.file_type_description)
       .map((data_object, i) => ({


### PR DESCRIPTION
Resolves #2334 

There are some cases where the same WorkflowExecution is part of multiple DataGenerations. We were not handling this in the Data Portal UI previously. Now, wfe and dobjs are deduped before the data object tables are displayed. Also, they are deduped on the backend when calculating the download summary file counts and sizes.