### PR TITLE
Fix disconnected upstream workflows included in ro-crate

### DIFF
--- a/nmdc_server/rocrate.py
+++ b/nmdc_server/rocrate.py
@@ -319,9 +319,7 @@ def generate_rocrate_for_bulk_download(  # noqa: C901
     # not describe anything included in this archive. Only emit workflow nodes for
     # executions that actually generated one of the downloaded files.
     workflow_rows = {
-        id_: row
-        for id_, row in discovered_workflow_rows.items()
-        if id_ in archived_workflow_ids
+        id_: row for id_, row in discovered_workflow_rows.items() if id_ in archived_workflow_ids
     }
     informing_data_generations_by_workflow: dict[str, list[str]] = {}
     for data_generation_id, workflow_ids in archived_workflows_by_data_generation.items():

--- a/nmdc_server/rocrate.py
+++ b/nmdc_server/rocrate.py
@@ -295,7 +295,7 @@ def generate_rocrate_for_bulk_download(  # noqa: C901
             dict.fromkeys(id_ for id_ in input_ids if id_ not in visited_output_ids)
         )
 
-    workflow_rows = {
+    discovered_workflow_rows = {
         id_: row
         for id_, row in dg_and_wfe_rows.items()
         if row.high_level_type == "nmdc:WorkflowExecution"
@@ -309,6 +309,20 @@ def generate_rocrate_for_bulk_download(  # noqa: C901
     archived_workflows_by_data_generation = _get_archived_workflows_by_data_generation(
         bulk_download, list(data_generation_rows)
     )
+    archived_workflow_ids = {
+        workflow_id
+        for workflow_ids in archived_workflows_by_data_generation.values()
+        for workflow_id in workflow_ids
+    }
+    # The recursive lookup above follows inputs back to their DataGeneration. It can
+    # encounter upstream WorkflowExecutions along the way, but those executions do
+    # not describe anything included in this archive. Only emit workflow nodes for
+    # executions that actually generated one of the downloaded files.
+    workflow_rows = {
+        id_: row
+        for id_, row in discovered_workflow_rows.items()
+        if id_ in archived_workflow_ids
+    }
     informing_data_generations_by_workflow: dict[str, list[str]] = {}
     for data_generation_id, workflow_ids in archived_workflows_by_data_generation.items():
         for workflow_id in workflow_ids:
@@ -318,7 +332,8 @@ def generate_rocrate_for_bulk_download(  # noqa: C901
 
     related_rows = [
         *data_object_rows.values(),
-        *dg_and_wfe_rows.values(),
+        *data_generation_rows.values(),
+        *workflow_rows.values(),
     ]
     biosample_ids = list(
         dict.fromkeys(biosample_id for row in related_rows for biosample_id in row.biosample_ids)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -289,6 +289,30 @@ def test_generate_rocrate_for_bulk_download_includes_compact_related_graph(db: S
             downstream_neighbor_ids=[],
         ),
         models.BiosampleRelatedDocument(
+            id="nmdc:wfrqc-upstream",
+            biosample_ids=["nmdc:bsm-1"],
+            high_level_type="nmdc:WorkflowExecution",
+            document={
+                "id": "nmdc:wfrqc-upstream",
+                "type": "nmdc:ReadQcAnalysis",
+                "has_input": ["nmdc:dobj-raw"],
+                "has_output": ["nmdc:dobj-intermediate"],
+            },
+            downstream_neighbor_ids=["nmdc:dobj-intermediate"],
+        ),
+        models.BiosampleRelatedDocument(
+            id="nmdc:wfasmb-upstream",
+            biosample_ids=["nmdc:bsm-1"],
+            high_level_type="nmdc:WorkflowExecution",
+            document={
+                "id": "nmdc:wfasmb-upstream",
+                "type": "nmdc:MetagenomeAssembly",
+                "has_input": ["nmdc:dobj-intermediate"],
+                "has_output": ["nmdc:dobj-raw"],
+            },
+            downstream_neighbor_ids=["nmdc:dobj-raw"],
+        ),
+        models.BiosampleRelatedDocument(
             id="nmdc:dobj-1",
             biosample_ids=["nmdc:bsm-1"],
             high_level_type="nmdc:DataObject",
@@ -339,6 +363,8 @@ def test_generate_rocrate_for_bulk_download_includes_compact_related_graph(db: S
 
     assert "nmdc:dobj-1" not in nodes
     assert "nmdc:dobj-unrelated" not in nodes
+    assert "nmdc:wfrqc-upstream" not in nodes
+    assert "nmdc:wfasmb-upstream" not in nodes
     assert crate["@context"][1]["prov"] == "http://www.w3.org/ns/prov#"
     assert nodes["nmdc:sty-1"]["hasPart"] == [{"@id": "nmdc:bsm-1"}]
     assert nodes["nmdc:dgns-1"]["prov:used"] == [{"@id": "nmdc:bsm-1"}]


### PR DESCRIPTION
Some upstream workflow executions were getting included in the final ro-crate if they were found by the DataGeneration query, even if their output does not contain a file included in the archive. Now, we check to ensure that the workflow nodes are all part of the archive.