### PR TITLE
Fix download file selector overflow

### DIFF
--- a/web/src/components/BulkDownload.vue
+++ b/web/src/components/BulkDownload.vue
@@ -280,38 +280,48 @@ watch(
                   @close="treeMenuOpen = false"
                 />
               </div>
-              <v-dialog
-                v-model="bulkTermsDialog"
-                :width="400"
-              >
-                <template #activator="{ props: dialogProps }">
-                  <v-tooltip
-                    :disabled="!downloadProductsDisabledTooltip"
-                    location="top"
-                  >
-                    <template #activator="{ props: tooltipProps }">
-                      <span v-bind="tooltipProps">
-                        <v-btn
-                          class="mt-3"
-                          color="white"
-                          :disabled="!!downloadProductsDisabledTooltip"
-                          v-bind="dialogProps"
-                        >
-                          <v-icon class="pr-3">
-                            mdi-download
-                          </v-icon>
-                          Download Data Products Zip
-                        </v-btn>
-                      </span>
-                    </template>
-                    <span>{{ downloadProductsDisabledTooltip }}</span>
-                  </v-tooltip>
-                </template>
-                <DownloadDialog
-                  :loading="loading"
-                  @clicked="createAndDownload"
-                />
-              </v-dialog>
+              <div class="d-flex flex-row justify-space-between">
+                <v-btn
+                  class="mt-3"
+                  variant="outlined"
+                  :disabled="!!downloadProductsDisabledTooltip"
+                  @click="bulkDownloadSelected = []"
+                >
+                  Clear selection
+                </v-btn>
+                <v-dialog
+                  v-model="bulkTermsDialog"
+                  :width="400"
+                >
+                  <template #activator="{ props: dialogProps }">
+                    <v-tooltip
+                      :disabled="!downloadProductsDisabledTooltip"
+                      location="top"
+                    >
+                      <template #activator="{ props: tooltipProps }">
+                        <span v-bind="tooltipProps">
+                          <v-btn
+                            class="mt-3"
+                            color="primary"
+                            :disabled="!!downloadProductsDisabledTooltip"
+                            v-bind="dialogProps"
+                          >
+                            <v-icon class="pr-3">
+                              mdi-download
+                            </v-icon>
+                            Download Data Products Zip
+                          </v-btn>
+                        </span>
+                      </template>
+                      <span>{{ downloadProductsDisabledTooltip }}</span>
+                    </v-tooltip>
+                  </template>
+                  <DownloadDialog
+                    :loading="loading"
+                    @clicked="createAndDownload"
+                  />
+                </v-dialog>
+              </div>
             </div>
           </v-sheet>
         </v-tabs-window-item>
@@ -332,38 +342,48 @@ watch(
                 @close="treeMenuOpen = false"
               />
             </div>
-            <v-dialog
-              v-model="metadataTermsDialog"
-              :width="400"
-            >
-              <template #activator="{ props: dialogProps }">
-                <v-tooltip
-                  :disabled="!downloadMetadataDisabledTooltip"
-                  location="top"
-                >
-                  <template #activator="{ props: tooltipProps }">
-                    <span v-bind="tooltipProps">
-                      <v-btn
-                        class="mt-3"
-                        color="white"
-                        :disabled="!!downloadMetadataDisabledTooltip"
-                        v-bind="dialogProps"
-                      >
-                        <v-icon class="pr-3">
-                          mdi-download
-                        </v-icon>
-                        Download Metadata Zip
-                      </v-btn>
-                    </span>
-                  </template>
-                  <span>{{ downloadMetadataDisabledTooltip }}</span>
-                </v-tooltip>
-              </template>
-              <DownloadDialog
-                :loading="metadataDownloadLoading"
-                @clicked="downloadMetadata"
-              />
-            </v-dialog>
+            <div class="d-flex flex-row justify-space-between">
+              <v-btn
+                class="mt-3"
+                variant="outlined"
+                :disabled="!!downloadMetadataDisabledTooltip"
+                @click="metadataDownloadSelected = []"
+              >
+                Clear selection
+              </v-btn>
+              <v-dialog
+                v-model="metadataTermsDialog"
+                :width="400"
+              >
+                <template #activator="{ props: dialogProps }">
+                  <v-tooltip
+                    :disabled="!downloadMetadataDisabledTooltip"
+                    location="top"
+                  >
+                    <template #activator="{ props: tooltipProps }">
+                      <span v-bind="tooltipProps">
+                        <v-btn
+                          class="mt-3"
+                          color="primary"
+                          :disabled="!!downloadMetadataDisabledTooltip"
+                          v-bind="dialogProps"
+                        >
+                          <v-icon class="pr-3">
+                            mdi-download
+                          </v-icon>
+                          Download Metadata Zip
+                        </v-btn>
+                      </span>
+                    </template>
+                    <span>{{ downloadMetadataDisabledTooltip }}</span>
+                  </v-tooltip>
+                </template>
+                <DownloadDialog
+                  :loading="metadataDownloadLoading"
+                  @clicked="downloadMetadata"
+                />
+              </v-dialog>
+            </div>
           </v-sheet>
         </v-tabs-window-item>
       </v-tabs-window>
@@ -400,12 +420,30 @@ watch(
   />
 </template>
 
-<style scoped>
+<style lang="scss" scoped>
 .download-menu {
   width: 550px;
 }
 
 .vue3-treeselect {
   z-index: 2001;
+
+  :deep(.vue3-treeselect__control) {
+    display: flex;
+    height: auto;
+    max-height: 100px !important;
+    min-height: 36px;
+    overflow-y: auto;
+    align-items: center;
+  }
+
+  :deep(.vue3-treeselect__control-arrow-container) {
+    display: flex;
+    align-items: center;
+  }
+
+  :deep(.vue3-treeselect__placeholder) {
+    line-height: unset;
+  }
 }
 </style>

--- a/web/src/components/BulkDownload.vue
+++ b/web/src/components/BulkDownload.vue
@@ -284,7 +284,7 @@ watch(
                 <v-btn
                   class="mt-3"
                   variant="outlined"
-                  :disabled="!!downloadProductsDisabledTooltip"
+                  :disabled="bulkDownloadSelected.length === 0"
                   @click="bulkDownloadSelected = []"
                 >
                   Clear selection
@@ -346,7 +346,7 @@ watch(
               <v-btn
                 class="mt-3"
                 variant="outlined"
-                :disabled="!!downloadMetadataDisabledTooltip"
+                :disabled="metadataDownloadSelected.length === 0"
                 @click="metadataDownloadSelected = []"
               >
                 Clear selection


### PR DESCRIPTION
Resolve #2342 

While testing and fixing the ro-crate issues, I discovered a bug with the file selector menu when too many file types are selected. This PR implements a max-height on the selector input so that it becomes scrollable when many types are selected.

Doing this resulted in the selector's clear button to be difficult to find, so I added an extra button for explicitly clearing the selected file types. As a cascading effect, I moved the final download button to the right and made it the primary purple color.

<img width="630" height="306" alt="Screenshot 2026-08-25 at 5 43 07 PM" src="https://github.com/user-attachments/assets/9cd1550e-0a4f-423a-945d-de91fe3bd4f4" />