### PR TITLE
Send approved submission sample metadata to EMSL LIMS

### DIFF
--- a/docs/lims_export.md
+++ b/docs/lims_export.md
@@ -13,8 +13,9 @@ LIMS via the unchanged `l7-interface-api` (`POST {gateway}/lims/sample`, one req
   "send to LIMS" button. Requires the sample set to be in `ApprovedHeld` status and the caller to be
   an owner/reviewer of the submission (or a site admin). Persists results to
   `submission_sample_set.lims_export_results` / `lims_exported_at`.
-- Config (`nmdc_server/config.py`): `lims_gateway_url`, `lims_esp_username`, `lims_esp_token`,
-  `lims_export_enabled` (env-prefixed `NMDC_`).
+- Config (`nmdc_server/config.py`, env-prefixed `NMDC_`): `lims_gateway_url`, `lims_esp_username`,
+  `lims_esp_token`, `lims_export_enabled`, `lims_auth_in_header` (token in `Authorization` header vs
+  body), `project_directory_backend` (`nexus` | `pv2` | `synthesize`), `nexus_base_url`.
 
 ## Wire contract
 
@@ -22,10 +23,10 @@ Body per sample (mirrors the SMS portal / `l7-interface-api`):
 
 ```json
 {
-  "esp_token": "...", "esp_username": "nmdc-portal",
-  "project_id": "61258", "project_uuid": "<uuid>",
-  "shipment_uuid": "<sample_set id>", "shipment_tracking_number": "<...>",
-  "sample_type": "monet-soil", "shipment_name": "<sample set name>",
+  "esp_token": "...", "esp_username": "svcnmdcuser",
+  "project_id": "61258", "project_uuid": "<uuid from Nexus>",
+  "shipment_uuid": "<sample_set id>", "shipment_tracking_number": "",
+  "sample_type": "soil", "shipment_name": "<sample set name>",
   "sample_data": { "sample_name": "61258_2_C4", "...": "MIxS snake_case slots" }
 }
 ```
@@ -39,20 +40,33 @@ NMDC sample rows already use MIxS snake_case slot names that, after the receiver
 `field.replace('_',' ').title()`, match the ESP sample-type field names. The only rename needed is
 `samp_name` → `sample_name`.
 
+- **Slot → sample type** (`SLOT_TO_SAMPLE_TYPE`): `soil_data`→`soil`, `water_data`→`water`,
+  `sediment_data`→`sediment`, `plant_associated_data`→`plant`, `air_data`→`aerosol`,
+  `misc_envs_data`→`misc-envs`. Slots with no known ESP type (or non-environmental companion tabs like
+  `emsl_data`/`jgi_mg_data`) are **skipped**, not sent — mirrors EMSL SMS and avoids receiver 500-storms.
+- **Companion metadata**: `emsl_data` (and other non-env tabs) are merged into each environmental
+  sample by `samp_name` (EMSL logistics fields like `analysis_type` ride along), not sent as samples.
+- **project_uuid**: resolved from `studyNumber` (the 5-digit EMSL Proposal Number) via the project
+  directory (`nexus` backend today). Sample sets without a valid 5-digit `studyNumber` are not
+  EMSL-bound and are skipped.
+
 ## Trigger / delivery
 
 - Manual button (this endpoint), gated on `ApprovedHeld`.
 - Automatic fire on the status transition is a documented follow-up (gate on a date cutoff +
   `is_test_submission is False`); the hook point is `update_submission_sample_set_status`. Not wired.
 
-## Open gaps (confirm with EMSL before non-local use)
+## Resolved decisions / open confirmations
 
-- `project_uuid` — NMDC has no EMSL project UUID; currently a deterministic UUID5 placeholder.
-- `shipment_tracking_number` — NMDC captures none; currently `nmdc-sampleset:{id}` placeholder.
-- `sample_type` slug — `SLOT_TO_SAMPLE_TYPE` is an assumption; verify each NMDC env package maps to the
-  right ESP slug in `lims-dev/content/monet/inventory/emsl_sample_types.yml`.
-- `project_id` — assumed to be `multi_omics_form.studyNumber` (the "EMSL ID"); confirm it resolves in
-  Nexus as the numeric EMSL project id.
+- `project_id` = `multi_omics_form.studyNumber` — confirmed: it's the 5-digit EMSL Proposal Number,
+  resolves in Nexus. Sample sets without one are treated as not EMSL-bound and skipped.
+- `project_uuid` — resolved from `project_id` via the project directory (`nexus` backend;
+  `/projects/lookup?q={id}` → `[0].uuid`). Falls back to a deterministic synthesized UUID only if the
+  directory can't resolve it. Switchable to PV2 later via `project_directory_backend`.
+- `shipment_tracking_number` — NMDC captures none; sent empty (the receiver requires the field to be
+  present). Not synthesized.
+- `sample_type` slug mapping — evidence-based (NMDC generic MIxS → generic ESP type); confirm with EMSL,
+  esp. `soil`→`soil` (not `monet-soil`) and `misc_envs`→`misc-envs` (a dedicated schema was authored).
 
 ## Local end-to-end testing
 

--- a/docs/lims_export.md
+++ b/docs/lims_export.md
@@ -1,0 +1,61 @@
+# EMSL LIMS export (SMS → LIMS reimplementation)
+
+NMDC-side reimplementation of the EMSL SMS portal's "send samples to the L7|ESP LIMS" step. When an
+NMDC submission's sample set is approved for the user facility, its samples are pushed into the EMSL
+LIMS via the unchanged `l7-interface-api` (`POST {gateway}/lims/sample`, one request per sample).
+
+## Components
+
+- `nmdc_server/lims_export.py` — `build_lims_payloads(sample_set)` and
+  `send_sample_set_to_lims(sample_set)`. Flattens `sample_data["data"][slot]` rows into one wire
+  payload each, POSTs via httpx, retries idempotently, returns a per-sample result summary.
+- `POST /metadata_submission/sample_set/{id}/send-to-lims` (`nmdc_server/api.py`) — the manual
+  "send to LIMS" button. Requires the sample set to be in `ApprovedHeld` status and the caller to be
+  an owner/reviewer of the submission (or a site admin). Persists results to
+  `submission_sample_set.lims_export_results` / `lims_exported_at`.
+- Config (`nmdc_server/config.py`): `lims_gateway_url`, `lims_esp_username`, `lims_esp_token`,
+  `lims_export_enabled` (env-prefixed `NMDC_`).
+
+## Wire contract
+
+Body per sample (mirrors the SMS portal / `l7-interface-api`):
+
+```json
+{
+  "esp_token": "...", "esp_username": "nmdc-portal",
+  "project_id": "61258", "project_uuid": "<uuid>",
+  "shipment_uuid": "<sample_set id>", "shipment_tracking_number": "<...>",
+  "sample_type": "monet-soil", "shipment_name": "<sample set name>",
+  "sample_data": { "sample_name": "61258_2_C4", "...": "MIxS snake_case slots" }
+}
+```
+
+The receiver upserts (dedup by `lims_id`, else `sample:{name}`+`project:{id}` tags), so re-sending is
+idempotent — safe to retry. Response: `{"entity_id": "...", "entity_url": "..."}`.
+
+## Field mapping
+
+NMDC sample rows already use MIxS snake_case slot names that, after the receiver's
+`field.replace('_',' ').title()`, match the ESP sample-type field names. The only rename needed is
+`samp_name` → `sample_name`.
+
+## Trigger / delivery
+
+- Manual button (this endpoint), gated on `ApprovedHeld`.
+- Automatic fire on the status transition is a documented follow-up (gate on a date cutoff +
+  `is_test_submission is False`); the hook point is `update_submission_sample_set_status`. Not wired.
+
+## Open gaps (confirm with EMSL before non-local use)
+
+- `project_uuid` — NMDC has no EMSL project UUID; currently a deterministic UUID5 placeholder.
+- `shipment_tracking_number` — NMDC captures none; currently `nmdc-sampleset:{id}` placeholder.
+- `sample_type` slug — `SLOT_TO_SAMPLE_TYPE` is an assumption; verify each NMDC env package maps to the
+  right ESP slug in `lims-dev/content/monet/inventory/emsl_sample_types.yml`.
+- `project_id` — assumed to be `multi_omics_form.studyNumber` (the "EMSL ID"); confirm it resolves in
+  Nexus as the numeric EMSL project id.
+
+## Local end-to-end testing
+
+A zero-dependency mock receiver and seed script live outside this repo at
+`~/Dev/NMDC SMS to Lims Connection/local-ete/` (`mock_lims_receiver.py`, `seed_ete.py`). See
+`FINDINGS-and-local-ETE.md` there for the full runbook and results.

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 from starlette.background import BackgroundTask
 from starlette.responses import StreamingResponse
 
-from nmdc_server import crud, github, models, query, schemas, schemas_submission
+from nmdc_server import crud, github, lims_export, models, query, schemas, schemas_submission
 from nmdc_server.auth import admin_required, get_current_user, login_required_responses
 from nmdc_server.bulk_download_schema import BulkDownload, BulkDownloadCreate
 from nmdc_server.config import settings
@@ -2194,6 +2194,51 @@ def update_submission_sample_set_status(
 
     db.commit()
     return sample_set
+
+
+@router.post(
+    "/metadata_submission/sample_set/{sample_set_id}/send-to-lims",
+    tags=["metadata_submission"],
+    responses=login_required_responses,
+)
+def send_sample_set_to_lims_endpoint(
+    sample_set_id: str,
+    db: Session = Depends(get_db),
+    user: models.User = Depends(get_current_user),
+):
+    """Export a sample set's samples to the EMSL L7|ESP LIMS (manual "send to LIMS").
+
+    Reimplements the SMS portal's send-to-LIMS step for NMDC. Gated on the sample set being in the
+    ``ApprovedHeld`` status (ready for the EMSL user facility) and on the caller being an
+    owner/reviewer of the submission (or a site admin). One request is POSTed per sample; results
+    (entity_id / error) are persisted on the sample set.
+    """
+    if not settings.lims_export_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="LIMS export is disabled."
+        )
+
+    sample_set = crud.get_submission_sample_set_for_user(
+        db,
+        sample_set_id,
+        user,
+        allowed_roles=[SubmissionEditorRole.owner, SubmissionEditorRole.reviewer],
+    )
+
+    if sample_set.status != SubmissionStatusEnum.ApprovedHeld.text:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Sample set must be in the 'ApprovedHeld' status to export to LIMS "
+                f"(current status: '{sample_set.status}')."
+            ),
+        )
+
+    summary = lims_export.send_sample_set_to_lims(sample_set)
+    sample_set.lims_export_results = summary
+    sample_set.lims_exported_at = datetime.datetime.now(datetime.UTC)
+    db.commit()
+    return summary
 
 
 @router.delete(

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -2240,7 +2240,30 @@ def send_sample_set_to_lims_endpoint(
             ),
         )
 
-    summary = lims_export.send_sample_set_to_lims(sample_set)
+    # Facility eligibility: the `emsl` template marks a sample set as EMSL-bound. Without it the set
+    # is headed elsewhere (e.g. JGI-only), and its `ApprovedHeld` status does not imply EMSL.
+    if "emsl" not in (sample_set.templates or []):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Sample set is not EMSL-bound (no 'emsl' template); nothing to export to LIMS.",
+        )
+
+    # Never send test submissions to the real LIMS (mirrors the is_test_submission exclusion used
+    # for GitHub issue creation).
+    if (
+        sample_set.submission_metadata is not None
+        and sample_set.submission_metadata.is_test_submission
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Test submissions cannot be exported to the LIMS.",
+        )
+
+    try:
+        summary = lims_export.send_sample_set_to_lims(sample_set)
+    except lims_export.LimsExportError as e:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+
     sample_set.lims_export_results = summary
     sample_set.lims_exported_at = datetime.datetime.now(datetime.UTC)
     db.commit()

--- a/nmdc_server/api.py
+++ b/nmdc_server/api.py
@@ -2217,6 +2217,12 @@ def send_sample_set_to_lims_endpoint(
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="LIMS export is disabled."
         )
+    # Fail fast on misconfiguration rather than making a doomed request to the LIMS.
+    if not settings.lims_gateway_url or not settings.lims_esp_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="LIMS export is not configured (missing gateway URL or ESP token).",
+        )
 
     sample_set = crud.get_submission_sample_set_for_user(
         db,

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -121,6 +121,33 @@ class Settings(BaseSettings):
     max_submission_image_total_size_bytes: int = 1 * 1000 * 1000 * 1000  # 1 GB
     """The maximum total size of all submission image files for a single submission in bytes."""
 
+    # == EMSL LIMS export (SMS -> LIMS reimplementation; see docs/lims_export.md) ==
+    lims_gateway_url: str = "http://host.docker.internal:5006/lims"
+    """Base URL of the L7 LIMS interface API (the `/lims` gateway prefix). One sample is POSTed to
+    `{lims_gateway_url}/sample` per NMDC sample. In real environments this is the consolidation-API
+    external route (`https://api.emsl.pnnl.gov/external/lims`); locally it is the bundled mock."""
+
+    lims_esp_username: str = "nmdc-portal"
+    """ESP service-account username the portal authenticates to the LIMS with (forwarded to the
+    receiver). Portal-held service identity, NOT per-user."""
+
+    lims_esp_token: str = ""
+    """ESP service-account API token. Must be a valid L7 service-account token in real environments."""
+
+    lims_export_enabled: bool = True
+    """Master switch for the LIMS export endpoint. When False the endpoint returns 503."""
+
+    lims_auth_in_header: bool = False
+    """Send the ESP token in the `Authorization: Bearer <token>` header instead of the request body.
+    Flip to True once the upstream lims-interface-api header change lands."""
+
+    # Project directory used to resolve an EMSL project id (multi_omics_form.studyNumber) to its
+    # project UUID. Backends: "nexus" (current EMSL service), "pv2" (future; not implemented),
+    # "synthesize" (offline placeholder for local testing without network).
+    project_directory_backend: str = "nexus"
+    nexus_base_url: str = "https://api.emsl.pnl.gov/nexus"
+    """Base URL of the EMSL Nexus service (no trailing slash)."""
+
     @property
     def orcid_openid_config_url(self) -> str:
         r"""

--- a/nmdc_server/config.py
+++ b/nmdc_server/config.py
@@ -138,8 +138,9 @@ class Settings(BaseSettings):
     """Master switch for the LIMS export endpoint. When False the endpoint returns 503."""
 
     lims_auth_in_header: bool = False
-    """Send the ESP token in the `Authorization: Bearer <token>` header instead of the request body.
-    Flip to True once the upstream lims-interface-api header change lands."""
+    """When True, send the ESP token to the LIMS in an HTTP `Authorization: Bearer <token>` header
+    instead of in the JSON request body. Default False (token in body, current contract); flip to True
+    once the upstream lims-interface-api header change lands."""
 
     # Project directory used to resolve an EMSL project id (multi_omics_form.studyNumber) to its
     # project UUID. Backends: "nexus" (current EMSL service), "pv2" (future; not implemented),

--- a/nmdc_server/lims_export.py
+++ b/nmdc_server/lims_export.py
@@ -127,24 +127,30 @@ def slot_to_sample_type(slot: str) -> str | None:
     return slug
 
 
+class LimsExportError(Exception):
+    """Raised when a sample set cannot be exported (e.g. its project UUID cannot be resolved)."""
+
+
 def _resolve_project_uuid(project_id: str) -> str:
     """Resolve the EMSL project UUID for a project id via the configured project directory.
 
     Today this hits the EMSL Nexus service (`/projects/lookup?q={id}` -> `[0].uuid`), the same
-    registry the SMS portal and l7-interface-api receiver use. Swappable to PV2 later via config
-    (see project_directory.py). Falls back to a deterministic synthesized UUID only if the
-    directory cannot resolve the id (logged), so a lookup outage does not hard-fail the export.
+    registry the SMS portal and l7-interface-api receiver use. Swappable to PV2 later via config.
+
+    If a real directory (nexus/pv2) cannot resolve the id, we ABORT rather than invent a UUID:
+    proceeding with a fabricated UUID would associate the samples with a project that does not
+    exist in EMSL, turning a transient lookup failure into incorrect LIMS data. Only the offline
+    `synthesize` backend (local testing) deliberately returns a deterministic placeholder.
     """
     project_uuid = get_project_directory().get_project_uuid(project_id)
     if project_uuid:
         return project_uuid
-    fallback = str(uuid.uuid5(uuid.NAMESPACE_URL, f"nmdc-emsl-project:{project_id}"))
-    logger.warning(
-        "Could not resolve project_uuid for project_id %r; using synthesized fallback %s",
-        project_id,
-        fallback,
+    if settings.project_directory_backend == "synthesize":
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"nmdc-emsl-project:{project_id}"))
+    raise LimsExportError(
+        f"Could not resolve an EMSL project UUID for project_id {project_id!r} "
+        f"via the {settings.project_directory_backend!r} project directory; aborting export."
     )
-    return fallback
 
 
 def _tracking_number(sample_set: models.SubmissionSampleSet) -> str:

--- a/nmdc_server/lims_export.py
+++ b/nmdc_server/lims_export.py
@@ -1,0 +1,364 @@
+"""Export NMDC submission sample sets to the EMSL L7|ESP LIMS.
+
+This is the NMDC-side reimplementation of "Hop 1" of the EMSL SMS portal's send-to-LIMS
+flow (see the companion analysis doc `SMS-to-LIMS-metadata-flow.md`). It builds one wire
+payload per sample and POSTs each to the L7 LIMS interface API (`{gateway}/lims/sample`),
+which is unchanged from the SMS integration. Locally, the target is the bundled mock
+receiver; in real environments it is the shared EMSL API gateway.
+
+Design mirrors the observed receiver contract (`l7-interface-api/api.py`, `l7esp/info.py`):
+  * one POST per sample, JSON body per `build_payload`;
+  * the receiver upserts (dedup by `lims_id`, else `sample:{name}`+`project:{id}` tags), so
+    re-sending is idempotent and safe to retry;
+  * required-by-receiver fields: esp_username, esp_token, sample_type, project_id, sample_data;
+    project_uuid / shipment_uuid / shipment_tracking_number are read positionally by the
+    receiver and 400 if missing -> we always send them.
+
+GAPS (NMDC has no direct source; values are synthesized and flagged — resolve with EMSL):
+  * project_uuid           -- NMDC carries no EMSL project UUID. Synthesized placeholder.
+  * shipment_tracking_number -- NMDC ships TO the facility and captures no tracking number.
+                              Synthesized placeholder.
+  * sample_type slug       -- NMDC environmental-package slot -> ESP sample-type key mapping is
+                              an assumption (SLOT_TO_SAMPLE_TYPE). Verify against the ESP
+                              sample types registered in `lims-dev`.
+See docs/lims_export.md for the full gap writeup.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from nmdc_server import models
+from nmdc_server.config import settings
+from nmdc_server.logger import get_logger
+from nmdc_server.models import ENVIRONMENTAL_DATA_SLOTS
+from nmdc_server.project_directory import get_project_directory
+
+logger = get_logger(__name__)
+
+# Only environmental-package slots hold shippable samples. Real submissions also carry companion
+# tabs in sample_data["data"] — notably `emsl_data` (EMSL logistics: analysis_type, shipping,
+# store temp) and `jgi_mg_data` (JGI) — which ARE keyed by samp_name but are per-sample metadata,
+# NOT separate samples. Sending them would create bogus, wrong-typed LIMS samples. Restrict to the
+# model's canonical environmental-sample slot list (same set SubmissionSampleSet.sample_count uses).
+_ENV_SLOTS = set(ENVIRONMENTAL_DATA_SLOTS)
+
+# ---------------------------------------------------------------------------
+# Environmental-package slot -> ESP sample-type slug.
+#
+# NMDC stores samples under `sample_data["data"][<slot>]`, where <slot> is a MIxS
+# environmental-package key (see models.ENVIRONMENTAL_DATA_SLOTS). The LIMS `sample_type` must be
+# an existing ESP sample-type key (a slug registered in
+# lims-dev/content/monet/inventory/emsl_sample_types.yml).
+#
+# IMPORTANT (confirmed with the SMS author, 2026-08-24): the original SMS portal DELIBERATELY
+# filters out any sample type that has no corresponding L7/ESP type — otherwise the receiver's
+# Sample.create throws "sample can't be created", retries 5x, and finally returns a 500, spamming
+# the logs. We mirror that: a slot only produces samples if it maps to a KNOWN ESP slug; unmapped
+# slots are skipped (logged), never sent with an invented slug.
+# ---------------------------------------------------------------------------
+
+# ESP sample-type slugs that actually exist in the LIMS (from emsl_sample_types.yml).
+VALID_ESP_SAMPLE_TYPES: set[str] = {
+    "aerosol-arm", "aerosol", "soil", "monet-soil", "sediment", "plant",
+    "culture-environmental", "terraform", "field-deployed-terraform", "pure-culture",
+    "mixed-culture", "commercially-purchased", "synthesized-material", "water", "other-undescribed",
+    "misc-envs",  # dedicated schema authored 2026-08-24 (analysisapi data/misc-envs) — deploy + reseed lims
+}
+
+# NMDC environmental-package slot -> ESP sample-type slug.
+#
+# Evidence-based (2026-08-24; confirm with EMSL): NMDC submits GENERIC MIxS packages, so each maps to
+# EMSL's GENERIC AnalysisAPI schema, NOT the MONet/ARM-specific variants. Verified by comparing real
+# NMDC sample fields against each SC Data schema's `required` list (sc-data-dev/schema/manifest):
+#   soil_data  -> soil     (NMDC soil satisfies soil 9/11 required vs monet-soil only 11/26 — NMDC data
+#                           lacks the MONet-experiment fields: infiltration, ecoregion, soil_type_meth,
+#                           bulk_elect_conductivity, water_content, ...). NOTE: `soil` (not monet-soil)
+#                           also means the interface-api's monet-soil-only analysis-API mirror does not
+#                           fire — which is what was returning 500 on the monet-soil path.
+#   water_data -> water    (8/15 required; gaps are shipment-logistics fields supplied later)
+#   sediment_data -> sediment (8/11)
+#   plant_associated_data -> plant (9/13)
+#   air_data   -> aerosol  (generic; `aerosol-arm` is the ARM-program-specific schema)
+#   misc_envs_data -> misc-envs (dedicated flat schema authored 2026-08-24; EMSL chose a real type over
+#                     the other-undescribed catch-all. Requires deploy of analysisapi data/misc-envs +
+#                     regen of the ESP type + reseed lims — until then this slug won't exist in LIMS.)
+SLOT_TO_SAMPLE_TYPE: dict[str, str] = {
+    "soil_data": "soil",
+    "water_data": "water",
+    "sediment_data": "sediment",
+    "plant_associated_data": "plant",
+    "air_data": "aerosol",
+    "misc_envs_data": "misc-envs",  # dedicated schema (was other-undescribed catch-all) — EMSL chose B
+}
+
+
+def slot_to_sample_type(slot: str) -> str | None:
+    """Resolve an NMDC environmental-package slot to a KNOWN ESP sample-type slug, or None.
+
+    Returns None (and logs) when the slot has no mapping, or maps to a slug that does not exist in
+    the LIMS — so the caller skips it rather than triggering a 500-storm (see module note).
+    """
+    slug = SLOT_TO_SAMPLE_TYPE.get(slot)
+    if slug is None:
+        logger.warning("No ESP sample-type mapping for slot %r; skipping (needs EMSL rule)", slot)
+        return None
+    if slug not in VALID_ESP_SAMPLE_TYPES:
+        logger.warning("Mapped slug %r for slot %r is not a known ESP type; skipping", slug, slot)
+        return None
+    return slug
+
+
+def _resolve_project_uuid(project_id: str) -> str:
+    """Resolve the EMSL project UUID for a project id via the configured project directory.
+
+    Today this hits the EMSL Nexus service (`/projects/lookup?q={id}` -> `[0].uuid`), the same
+    registry the SMS portal and l7-interface-api receiver use. Swappable to PV2 later via config
+    (see project_directory.py). Falls back to a deterministic synthesized UUID only if the
+    directory cannot resolve the id (logged), so a lookup outage does not hard-fail the export.
+    """
+    project_uuid = get_project_directory().get_project_uuid(project_id)
+    if project_uuid:
+        return project_uuid
+    fallback = str(uuid.uuid5(uuid.NAMESPACE_URL, f"nmdc-emsl-project:{project_id}"))
+    logger.warning(
+        "Could not resolve project_uuid for project_id %r; using synthesized fallback %s",
+        project_id, fallback,
+    )
+    return fallback
+
+
+def _tracking_number(sample_set: models.SubmissionSampleSet) -> str:
+    """shipment_tracking_number. NMDC captures no tracking number.
+
+    Per Makena (2026-08-24): "leave it off" — do NOT synthesize a fake value. We send an empty
+    string because the receiver still reads the field positionally (missing -> 400). If/when the
+    receiver is updated to make it optional, this can be omitted from the payload entirely.
+    """
+    return ""
+
+
+def build_payload(
+    sample_set: models.SubmissionSampleSet,
+    slot: str,
+    row: dict[str, Any],
+    *,
+    project_id: str,
+    project_uuid: str,
+    sample_type: str,
+) -> dict[str, Any] | None:
+    """Build a single-sample wire payload from one NMDC sample row.
+
+    ``project_id`` / ``project_uuid`` / ``sample_type`` are resolved once per sample set/slot by
+    the caller. Returns None (and logs) if the row has no sample name — that sample is unshippable
+    because ``sample_name`` is the receiver's description + dedup key.
+    """
+    # NMDC sample rows use the MIxS slot key `samp_name`; the LIMS wire/ESP field is `sample_name`.
+    raw_name = row.get("samp_name") or row.get("sample_name")
+    if raw_name is None or str(raw_name).strip() == "":
+        logger.warning(
+            "Skipping sample in set %s slot %s: no samp_name/sample_name", sample_set.id, slot
+        )
+        return None
+    sample_name = str(raw_name).strip().lstrip("_")
+
+    # Copy the row's metadata as-is (MIxS snake_case slots), swap samp_name -> sample_name.
+    sample_data: dict[str, Any] = {k: v for k, v in row.items() if k != "samp_name"}
+    sample_data["sample_name"] = sample_name
+
+    return {
+        "esp_token": settings.lims_esp_token,
+        "esp_username": settings.lims_esp_username,
+        "project_id": project_id,
+        "project_uuid": project_uuid,
+        "shipment_uuid": str(sample_set.id),
+        "shipment_tracking_number": _tracking_number(sample_set),
+        "sample_type": sample_type,
+        "shipment_name": sample_set.name,
+        "sample_data": sample_data,
+    }
+
+
+def _companion_metadata_by_name(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Index non-environmental companion-tab rows (e.g. emsl_data, jgi_mg_data) by samp_name.
+
+    These tabs carry per-sample metadata (EMSL: analysis_type, sample_shipped, emsl_store_temp;
+    JGI: sequencing details) that belongs on the LIMS sample. They are keyed to the environmental
+    samples by samp_name.
+    """
+    by_name: dict[str, dict[str, Any]] = {}
+    for slot, rows in data.items():
+        if slot in _ENV_SLOTS or not isinstance(rows, list):
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            name = row.get("samp_name") or row.get("sample_name")
+            if not name:
+                continue
+            merged = by_name.setdefault(str(name).strip().lstrip("_"), {})
+            for k, v in row.items():
+                if k in ("samp_name", "sample_name"):
+                    continue
+                merged.setdefault(k, v)  # first companion tab wins; env row still wins later
+    return by_name
+
+
+def build_lims_payloads(sample_set: models.SubmissionSampleSet) -> list[dict[str, Any]]:
+    """Flatten a sample set into one wire payload per environmental sample.
+
+    Only ENVIRONMENTAL_DATA_SLOTS produce samples; companion metadata tabs (emsl_data, jgi_mg_data,
+    ...) are merged into each sample by samp_name rather than sent as their own (bogus) samples.
+    """
+    data = (
+        sample_set.sample_data.get("data", {})
+        if isinstance(sample_set.sample_data, dict)
+        else {}
+    )
+    # Resolve project id/uuid ONCE per sample set (constant across all samples; avoids a project
+    # directory / Nexus call per sample).
+    multi_omics = sample_set.multi_omics_form or {}
+    project_id = str(multi_omics.get("studyNumber") or "").strip()
+    project_uuid = _resolve_project_uuid(project_id)
+
+    companions = _companion_metadata_by_name(data)
+    payloads: list[dict[str, Any]] = []
+    for slot, rows in data.items():
+        if slot not in _ENV_SLOTS or not isinstance(rows, list):
+            continue
+        # Skip whole slot if its ESP sample-type is unknown (mirrors SMS; avoids 500-storm).
+        sample_type = slot_to_sample_type(slot)
+        if sample_type is None:
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            name = row.get("samp_name") or row.get("sample_name")
+            # Overlay companion metadata under the env row (env row wins on key conflicts).
+            enriched = row
+            if name:
+                extra = companions.get(str(name).strip().lstrip("_"))
+                if extra:
+                    enriched = {**extra, **row}
+            payload = build_payload(
+                sample_set, slot, enriched,
+                project_id=project_id, project_uuid=project_uuid, sample_type=sample_type,
+            )
+            if payload is not None:
+                payloads.append(payload)
+    return payloads
+
+
+def _sample_url() -> str:
+    return f"{settings.lims_gateway_url.rstrip('/')}/sample"
+
+
+def send_sample_set_to_lims(
+    sample_set: models.SubmissionSampleSet,
+    *,
+    max_retries: int = 5,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Send every sample in the set to the LIMS, one POST per sample.
+
+    Awaits and checks each response; retries idempotently on network/5xx errors (the receiver
+    upserts, so retry is safe). Returns a summary dict with per-sample results. Does NOT commit;
+    the caller persists `sample_set.lims_export_results` / `lims_exported_at`.
+
+    This is deliberately synchronous (blocking the request) rather than fire-and-forget: the
+    original SMS portal fire-and-forgot and never surfaced failures — we fix that here.
+    """
+    url = _sample_url()
+    payloads = build_lims_payloads(sample_set)
+    results: list[dict[str, Any]] = []
+    sent = 0
+    failed = 0
+
+    # Auth transport: by default the ESP token rides in the body (current contract). When
+    # lims_auth_in_header is enabled (after the upstream header change lands), send it as an
+    # Authorization: Bearer header instead and drop it from the body. esp_username stays in the body.
+    headers: dict[str, str] | None = None
+    if settings.lims_auth_in_header:
+        headers = {"Authorization": f"Bearer {settings.lims_esp_token}"}
+        for payload in payloads:
+            payload.pop("esp_token", None)
+
+    with httpx.Client(timeout=timeout) as client:
+        for payload in payloads:
+            sample_name = payload["sample_data"]["sample_name"]
+            last_error: str | None = None
+            outcome: dict[str, Any] | None = None
+
+            for attempt in range(1, max_retries + 1):
+                if attempt > 1:
+                    # Bounded exponential backoff between retries (0.5s, 1s, 2s, ... capped 5s).
+                    time.sleep(min(0.5 * 2 ** (attempt - 2), 5.0))
+                try:
+                    resp = client.post(url, json=payload, headers=headers)
+                except httpx.HTTPError as e:
+                    last_error = f"network error: {e}"
+                    logger.warning(
+                        "LIMS send %s attempt %d/%d failed: %s",
+                        sample_name, attempt, max_retries, last_error,
+                    )
+                    continue
+
+                if resp.status_code == 200:
+                    body = resp.json()
+                    outcome = {
+                        "sample_name": sample_name,
+                        "sample_type": payload["sample_type"],
+                        "status": "ok",
+                        "entity_id": body.get("entity_id"),
+                        "entity_url": body.get("entity_url"),
+                        "attempts": attempt,
+                    }
+                    break
+
+                # 4xx are deterministic (bad contract) — do not retry; 5xx retry.
+                try:
+                    detail = resp.json().get("error")
+                except Exception:
+                    detail = resp.text
+                last_error = f"HTTP {resp.status_code}: {detail}"
+                if 400 <= resp.status_code < 500:
+                    logger.warning("LIMS send %s rejected (no retry): %s", sample_name, last_error)
+                    break
+                logger.warning(
+                    "LIMS send %s attempt %d/%d server error: %s",
+                    sample_name, attempt, max_retries, last_error,
+                )
+
+            if outcome is None:
+                outcome = {
+                    "sample_name": sample_name,
+                    "sample_type": payload["sample_type"],
+                    "status": "error",
+                    "error": last_error or "unknown error",
+                }
+
+            if outcome["status"] == "ok":
+                sent += 1
+            else:
+                failed += 1
+            results.append(outcome)
+
+    summary = {
+        "sample_set_id": str(sample_set.id),
+        "gateway_url": url,
+        "total": len(payloads),
+        "sent": sent,
+        "failed": failed,
+        "results": results,
+        "exported_at": datetime.now(UTC).isoformat(),
+    }
+    logger.info(
+        "LIMS export for sample set %s: %d/%d sent, %d failed",
+        sample_set.id, sent, len(payloads), failed,
+    )
+    return summary

--- a/nmdc_server/lims_export.py
+++ b/nmdc_server/lims_export.py
@@ -14,18 +14,19 @@ Design mirrors the observed receiver contract (`l7-interface-api/api.py`, `l7esp
     project_uuid / shipment_uuid / shipment_tracking_number are read positionally by the
     receiver and 400 if missing -> we always send them.
 
-GAPS (NMDC has no direct source; values are synthesized and flagged — resolve with EMSL):
-  * project_uuid           -- NMDC carries no EMSL project UUID. Synthesized placeholder.
-  * shipment_tracking_number -- NMDC ships TO the facility and captures no tracking number.
-                              Synthesized placeholder.
-  * sample_type slug       -- NMDC environmental-package slot -> ESP sample-type key mapping is
-                              an assumption (SLOT_TO_SAMPLE_TYPE). Verify against the ESP
-                              sample types registered in `lims-dev`.
-See docs/lims_export.md for the full gap writeup.
+Field resolution (see docs/lims_export.md for the full writeup):
+  * project_uuid           -- resolved from the EMSL project id (multi_omics_form.studyNumber) via the
+                              configured project directory (Nexus today, PV2-swappable). Falls back to
+                              a deterministic synthesized UUID only if the directory can't resolve it.
+  * shipment_tracking_number -- NMDC captures none; sent empty (the receiver still reads the field, so
+                              it must be present). Left off deliberately, not synthesized.
+  * sample_type slug       -- NMDC environmental-package slot -> ESP sample-type key via
+                              SLOT_TO_SAMPLE_TYPE; slots with no known ESP type are skipped, not sent.
 """
 
 from __future__ import annotations
 
+import re
 import time
 import uuid
 from datetime import UTC, datetime
@@ -224,6 +225,17 @@ def build_lims_payloads(sample_set: models.SubmissionSampleSet) -> list[dict[str
     # directory / Nexus call per sample).
     multi_omics = sample_set.multi_omics_form or {}
     project_id = str(multi_omics.get("studyNumber") or "").strip()
+
+    # An EMSL-bound submission carries a 5-digit EMSL Proposal Number as studyNumber. Without one,
+    # the sample set is not headed to EMSL — sending would produce empty-project_id payloads that
+    # the receiver rejects per sample. Skip entirely (log) rather than send junk.
+    if not re.fullmatch(r"\d{5}", project_id):
+        logger.warning(
+            "Sample set %s has no valid EMSL project number (studyNumber=%r); not exporting to LIMS",
+            sample_set.id, project_id,
+        )
+        return []
+
     project_uuid = _resolve_project_uuid(project_id)
 
     companions = _companion_metadata_by_name(data)
@@ -309,7 +321,17 @@ def send_sample_set_to_lims(
                     continue
 
                 if resp.status_code == 200:
-                    body = resp.json()
+                    try:
+                        body = resp.json()
+                    except ValueError:
+                        # 200 with a non-JSON body: treat as a failed, retryable attempt rather
+                        # than letting json() raise and abort the whole export.
+                        last_error = f"HTTP 200 with non-JSON body: {resp.text[:200]}"
+                        logger.warning(
+                            "LIMS send %s attempt %d/%d: %s",
+                            sample_name, attempt, max_retries, last_error,
+                        )
+                        continue
                     outcome = {
                         "sample_name": sample_name,
                         "sample_type": payload["sample_type"],

--- a/nmdc_server/lims_export.py
+++ b/nmdc_server/lims_export.py
@@ -66,9 +66,21 @@ _ENV_SLOTS = set(ENVIRONMENTAL_DATA_SLOTS)
 
 # ESP sample-type slugs that actually exist in the LIMS (from emsl_sample_types.yml).
 VALID_ESP_SAMPLE_TYPES: set[str] = {
-    "aerosol-arm", "aerosol", "soil", "monet-soil", "sediment", "plant",
-    "culture-environmental", "terraform", "field-deployed-terraform", "pure-culture",
-    "mixed-culture", "commercially-purchased", "synthesized-material", "water", "other-undescribed",
+    "aerosol-arm",
+    "aerosol",
+    "soil",
+    "monet-soil",
+    "sediment",
+    "plant",
+    "culture-environmental",
+    "terraform",
+    "field-deployed-terraform",
+    "pure-culture",
+    "mixed-culture",
+    "commercially-purchased",
+    "synthesized-material",
+    "water",
+    "other-undescribed",
     "misc-envs",  # dedicated schema authored 2026-08-24 (analysisapi data/misc-envs) — deploy + reseed lims
 }
 
@@ -129,7 +141,8 @@ def _resolve_project_uuid(project_id: str) -> str:
     fallback = str(uuid.uuid5(uuid.NAMESPACE_URL, f"nmdc-emsl-project:{project_id}"))
     logger.warning(
         "Could not resolve project_uuid for project_id %r; using synthesized fallback %s",
-        project_id, fallback,
+        project_id,
+        fallback,
     )
     return fallback
 
@@ -217,13 +230,13 @@ def build_lims_payloads(sample_set: models.SubmissionSampleSet) -> list[dict[str
     ...) are merged into each sample by samp_name rather than sent as their own (bogus) samples.
     """
     data = (
-        sample_set.sample_data.get("data", {})
-        if isinstance(sample_set.sample_data, dict)
-        else {}
+        sample_set.sample_data.get("data", {}) if isinstance(sample_set.sample_data, dict) else {}
     )
     # Resolve project id/uuid ONCE per sample set (constant across all samples; avoids a project
     # directory / Nexus call per sample).
-    multi_omics = sample_set.multi_omics_form or {}
+    multi_omics = (
+        sample_set.multi_omics_form if isinstance(sample_set.multi_omics_form, dict) else {}
+    )
     project_id = str(multi_omics.get("studyNumber") or "").strip()
 
     # An EMSL-bound submission carries a 5-digit EMSL Proposal Number as studyNumber. Without one,
@@ -232,7 +245,8 @@ def build_lims_payloads(sample_set: models.SubmissionSampleSet) -> list[dict[str
     if not re.fullmatch(r"\d{5}", project_id):
         logger.warning(
             "Sample set %s has no valid EMSL project number (studyNumber=%r); not exporting to LIMS",
-            sample_set.id, project_id,
+            sample_set.id,
+            project_id,
         )
         return []
 
@@ -258,8 +272,12 @@ def build_lims_payloads(sample_set: models.SubmissionSampleSet) -> list[dict[str
                 if extra:
                     enriched = {**extra, **row}
             payload = build_payload(
-                sample_set, slot, enriched,
-                project_id=project_id, project_uuid=project_uuid, sample_type=sample_type,
+                sample_set,
+                slot,
+                enriched,
+                project_id=project_id,
+                project_uuid=project_uuid,
+                sample_type=sample_type,
             )
             if payload is not None:
                 payloads.append(payload)
@@ -268,6 +286,91 @@ def build_lims_payloads(sample_set: models.SubmissionSampleSet) -> list[dict[str
 
 def _sample_url() -> str:
     return f"{settings.lims_gateway_url.rstrip('/')}/sample"
+
+
+def _send_one_sample(
+    client: httpx.Client,
+    url: str,
+    payload: dict[str, Any],
+    headers: dict[str, str] | None,
+    max_retries: int,
+) -> dict[str, Any]:
+    """POST one sample payload to the LIMS, retrying on network/5xx errors.
+
+    Returns a per-sample result dict with keys: sample_name, sample_type, status, and either
+    entity_id/entity_url (on success) or error (on failure).
+    """
+    sample_name = payload["sample_data"]["sample_name"]
+    last_error: str | None = None
+    outcome: dict[str, Any] | None = None
+
+    for attempt in range(1, max_retries + 1):
+        if attempt > 1:
+            # Bounded exponential backoff between retries (0.5s, 1s, 2s, ... capped 5s).
+            time.sleep(min(0.5 * 2 ** (attempt - 2), 5.0))
+        try:
+            resp = client.post(url, json=payload, headers=headers)
+        except httpx.HTTPError as e:
+            last_error = f"network error: {e}"
+            logger.warning(
+                "LIMS send %s attempt %d/%d failed: %s",
+                sample_name,
+                attempt,
+                max_retries,
+                last_error,
+            )
+            continue
+
+        if resp.status_code == 200:
+            try:
+                body = resp.json()
+            except ValueError:
+                # 200 with a non-JSON body: treat as a failed, retryable attempt rather
+                # than letting json() raise and abort the whole export.
+                last_error = f"HTTP 200 with non-JSON body: {resp.text[:200]}"
+                logger.warning(
+                    "LIMS send %s attempt %d/%d: %s",
+                    sample_name,
+                    attempt,
+                    max_retries,
+                    last_error,
+                )
+                continue
+            outcome = {
+                "sample_name": sample_name,
+                "sample_type": payload["sample_type"],
+                "status": "ok",
+                "entity_id": body.get("entity_id"),
+                "entity_url": body.get("entity_url"),
+                "attempts": attempt,
+            }
+            break
+
+        # 4xx are deterministic (bad contract) — do not retry; 5xx retry.
+        try:
+            detail = resp.json().get("error")
+        except Exception:
+            detail = resp.text
+        last_error = f"HTTP {resp.status_code}: {detail}"
+        if 400 <= resp.status_code < 500:
+            logger.warning("LIMS send %s rejected (no retry): %s", sample_name, last_error)
+            break
+        logger.warning(
+            "LIMS send %s attempt %d/%d server error: %s",
+            sample_name,
+            attempt,
+            max_retries,
+            last_error,
+        )
+
+    if outcome is None:
+        outcome = {
+            "sample_name": sample_name,
+            "sample_type": payload["sample_type"],
+            "status": "error",
+            "error": last_error or "unknown error",
+        }
+    return outcome
 
 
 def send_sample_set_to_lims(
@@ -293,7 +396,7 @@ def send_sample_set_to_lims(
 
     # Auth transport: by default the ESP token rides in the body (current contract). When
     # lims_auth_in_header is enabled (after the upstream header change lands), send it as an
-    # Authorization: Bearer header instead and drop it from the body. esp_username stays in the body.
+    # Authorization: ****** instead and drop it from the body. esp_username stays in the body.
     headers: dict[str, str] | None = None
     if settings.lims_auth_in_header:
         headers = {"Authorization": f"Bearer {settings.lims_esp_token}"}
@@ -302,68 +405,7 @@ def send_sample_set_to_lims(
 
     with httpx.Client(timeout=timeout) as client:
         for payload in payloads:
-            sample_name = payload["sample_data"]["sample_name"]
-            last_error: str | None = None
-            outcome: dict[str, Any] | None = None
-
-            for attempt in range(1, max_retries + 1):
-                if attempt > 1:
-                    # Bounded exponential backoff between retries (0.5s, 1s, 2s, ... capped 5s).
-                    time.sleep(min(0.5 * 2 ** (attempt - 2), 5.0))
-                try:
-                    resp = client.post(url, json=payload, headers=headers)
-                except httpx.HTTPError as e:
-                    last_error = f"network error: {e}"
-                    logger.warning(
-                        "LIMS send %s attempt %d/%d failed: %s",
-                        sample_name, attempt, max_retries, last_error,
-                    )
-                    continue
-
-                if resp.status_code == 200:
-                    try:
-                        body = resp.json()
-                    except ValueError:
-                        # 200 with a non-JSON body: treat as a failed, retryable attempt rather
-                        # than letting json() raise and abort the whole export.
-                        last_error = f"HTTP 200 with non-JSON body: {resp.text[:200]}"
-                        logger.warning(
-                            "LIMS send %s attempt %d/%d: %s",
-                            sample_name, attempt, max_retries, last_error,
-                        )
-                        continue
-                    outcome = {
-                        "sample_name": sample_name,
-                        "sample_type": payload["sample_type"],
-                        "status": "ok",
-                        "entity_id": body.get("entity_id"),
-                        "entity_url": body.get("entity_url"),
-                        "attempts": attempt,
-                    }
-                    break
-
-                # 4xx are deterministic (bad contract) — do not retry; 5xx retry.
-                try:
-                    detail = resp.json().get("error")
-                except Exception:
-                    detail = resp.text
-                last_error = f"HTTP {resp.status_code}: {detail}"
-                if 400 <= resp.status_code < 500:
-                    logger.warning("LIMS send %s rejected (no retry): %s", sample_name, last_error)
-                    break
-                logger.warning(
-                    "LIMS send %s attempt %d/%d server error: %s",
-                    sample_name, attempt, max_retries, last_error,
-                )
-
-            if outcome is None:
-                outcome = {
-                    "sample_name": sample_name,
-                    "sample_type": payload["sample_type"],
-                    "status": "error",
-                    "error": last_error or "unknown error",
-                }
-
+            outcome = _send_one_sample(client, url, payload, headers, max_retries)
             if outcome["status"] == "ok":
                 sent += 1
             else:
@@ -381,6 +423,9 @@ def send_sample_set_to_lims(
     }
     logger.info(
         "LIMS export for sample set %s: %d/%d sent, %d failed",
-        sample_set.id, sent, len(payloads), failed,
+        sample_set.id,
+        sent,
+        len(payloads),
+        failed,
     )
     return summary

--- a/nmdc_server/migrations/versions/b2c3d4e5f6a7_add_lims_export_columns.py
+++ b/nmdc_server/migrations/versions/b2c3d4e5f6a7_add_lims_export_columns.py
@@ -23,7 +23,9 @@ depends_on: Optional[str] = None
 
 def upgrade():
     op.add_column("submission_sample_set", sa.Column("lims_export_results", JSONB(), nullable=True))
-    op.add_column("submission_sample_set", sa.Column("lims_exported_at", sa.DateTime(), nullable=True))
+    op.add_column(
+        "submission_sample_set", sa.Column("lims_exported_at", sa.DateTime(), nullable=True)
+    )
 
 
 def downgrade():

--- a/nmdc_server/migrations/versions/b2c3d4e5f6a7_add_lims_export_columns.py
+++ b/nmdc_server/migrations/versions/b2c3d4e5f6a7_add_lims_export_columns.py
@@ -1,0 +1,31 @@
+"""add lims export columns to submission_sample_set
+
+Revision ID: b2c3d4e5f6a7
+Revises: da7be44d437c
+Create Date: 2026-08-26
+
+Adds bookkeeping columns for the NMDC -> EMSL LIMS export:
+  * lims_export_results (JSONB) -- per-sample send results returned by the LIMS receiver.
+  * lims_exported_at   (timestamp) -- when the most recent export was attempted.
+"""
+
+from typing import Optional
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Optional[str] = "da7be44d437c"
+branch_labels: Optional[str] = None
+depends_on: Optional[str] = None
+
+
+def upgrade():
+    op.add_column("submission_sample_set", sa.Column("lims_export_results", JSONB(), nullable=True))
+    op.add_column("submission_sample_set", sa.Column("lims_exported_at", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("submission_sample_set", "lims_exported_at")
+    op.drop_column("submission_sample_set", "lims_export_results")

--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1533,6 +1533,12 @@ class SubmissionSampleSet(Base):
     sample_data = Column(JSONB, nullable=False)
     submission_metadata = relationship("SubmissionMetadata", viewonly=True)
 
+    # EMSL LIMS export bookkeeping (SMS -> LIMS reimplementation). Populated by the
+    # send-to-LIMS endpoint: per-sample results (entity_id / error) plus the timestamp of the
+    # most recent export attempt. See lims_export.py.
+    lims_export_results = Column(JSONB, nullable=True)
+    lims_exported_at = Column(DateTime, nullable=True)
+
     @property
     def sample_count(self) -> int:
         if not isinstance(self.sample_data, dict):

--- a/nmdc_server/project_directory.py
+++ b/nmdc_server/project_directory.py
@@ -38,9 +38,11 @@ class ProjectDirectory(Protocol):
 
     def get_project(self, project_id: str) -> Optional[dict[str, Any]]:
         """Return a normalized project dict ({"uuid", "project_type", "id", ...}) or None."""
+        ...
 
     def get_project_uuid(self, project_id: str) -> Optional[str]:
         """Return the project UUID for the given EMSL project id, or None if not resolvable."""
+        ...
 
 
 class NexusProjectDirectory:

--- a/nmdc_server/project_directory.py
+++ b/nmdc_server/project_directory.py
@@ -1,0 +1,105 @@
+"""Resolve an EMSL project id to its project UUID (and type) for LIMS export.
+
+NMDC submissions carry the EMSL Proposal Number as ``multi_omics_form.studyNumber`` (a 5-digit
+id). The LIMS wire contract needs the corresponding project **UUID** (and, for the receiver's
+workgroup naming, the project **type** + PI). NMDC does not store these — they live in EMSL's
+project registry. This module fetches them.
+
+Backends (selected by ``settings.project_directory_backend``):
+  * ``nexus``      -- the current EMSL Nexus service. ``GET /nexus/projects/lookup?q={id}`` returns
+                      a list whose first element has ``uuid`` and ``project_type``. This is the same
+                      registry the SMS portal and the l7-interface-api receiver use today.
+  * ``pv2``        -- the Nexus replacement (sc-project ``project_tracking.projects``, which pairs
+                      ``project_id`` <-> ``project_uuid``). NOT YET IMPLEMENTED — no production PV2
+                      exists yet. When PV2 is production-ready, implement ``Pv2ProjectDirectory`` and
+                      flip the config; call sites do not change.
+  * ``synthesize`` -- offline fallback for local testing with no network: a deterministic UUID5.
+
+Nexus is being deprecated (~1 year). The abstraction here is deliberate so the eventual Nexus->PV2
+switch is a config change plus one new class, not a change to lims_export.
+"""
+
+from __future__ import annotations
+
+import uuid
+from functools import lru_cache
+from typing import Any, Optional, Protocol
+
+import httpx
+
+from nmdc_server.config import settings
+from nmdc_server.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ProjectDirectory(Protocol):
+    """Resolves an EMSL project id to project metadata."""
+
+    def get_project(self, project_id: str) -> Optional[dict[str, Any]]:
+        """Return a normalized project dict ({"uuid", "project_type", "id", ...}) or None."""
+
+    def get_project_uuid(self, project_id: str) -> Optional[str]:
+        """Return the project UUID for the given EMSL project id, or None if not resolvable."""
+
+
+class NexusProjectDirectory:
+    """EMSL Nexus service backend."""
+
+    def __init__(self, base_url: str, timeout: float = 10.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def get_project(self, project_id: str) -> Optional[dict[str, Any]]:
+        if not project_id:
+            return None
+        url = f"{self.base_url}/projects/lookup"
+        try:
+            resp = httpx.get(url, params={"q": project_id}, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+        except (httpx.HTTPError, ValueError) as e:
+            logger.warning("Nexus project lookup failed for %s: %s", project_id, e)
+            return None
+        if not isinstance(data, list) or not data:
+            logger.warning("Nexus project lookup for %s returned no matches", project_id)
+            return None
+        # The lookup is a fuzzy search; prefer an exact id match, else take the first result.
+        match = next((p for p in data if str(p.get("id")) == str(project_id)), data[0])
+        return {
+            "id": str(match.get("id", project_id)),
+            "uuid": match.get("uuid"),
+            "project_type": match.get("project_type"),
+            "title": match.get("title"),
+            "raw": match,
+        }
+
+    def get_project_uuid(self, project_id: str) -> Optional[str]:
+        project = self.get_project(project_id)
+        return project.get("uuid") if project else None
+
+
+class SynthesizeProjectDirectory:
+    """Offline fallback: deterministic placeholder UUID (no real registry)."""
+
+    def get_project(self, project_id: str) -> Optional[dict[str, Any]]:
+        return {"id": project_id, "uuid": self.get_project_uuid(project_id), "project_type": None}
+
+    def get_project_uuid(self, project_id: str) -> Optional[str]:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"nmdc-emsl-project:{project_id}"))
+
+
+@lru_cache(maxsize=1)
+def get_project_directory() -> ProjectDirectory:
+    """Return the configured project-directory backend (cached singleton)."""
+    backend = settings.project_directory_backend
+    if backend == "nexus":
+        return NexusProjectDirectory(settings.nexus_base_url)
+    if backend == "synthesize":
+        return SynthesizeProjectDirectory()
+    if backend == "pv2":
+        raise NotImplementedError(
+            "PV2 project directory backend is not implemented yet (no production PV2). "
+            "Set project_directory_backend to 'nexus' for now."
+        )
+    raise ValueError(f"Unknown project_directory_backend: {backend!r}")

--- a/tests/test_lims_export.py
+++ b/tests/test_lims_export.py
@@ -1,0 +1,154 @@
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from nmdc_schema.nmdc import SubmissionStatusEnum
+from sqlalchemy.orm import Session
+
+from nmdc_server import lims_export, models
+from nmdc_server.config import settings
+from nmdc_server.models import SubmissionEditorRole
+from tests import fakes
+
+
+def _sample_set(**overrides) -> models.SubmissionSampleSet:
+    """A minimal SubmissionSampleSet object (no DB) for build_lims_payloads unit tests."""
+    defaults = dict(
+        id=uuid4(),
+        submission_metadata_id=uuid4(),
+        name="Sample Set",
+        status=SubmissionStatusEnum.ApprovedHeld.text,
+        templates=[],
+        sample_environment_form={},
+        sender_shipping_info_form={},
+        multi_omics_form={"studyNumber": "61258"},
+        sample_data={"data": {}},
+    )
+    defaults.update(overrides)
+    return models.SubmissionSampleSet(**defaults)
+
+
+# --------------------------------------------------------------------------- build_lims_payloads
+
+
+def test_build_payloads_env_slot_and_companion_merge(monkeypatch):
+    monkeypatch.setattr(lims_export, "_resolve_project_uuid", lambda pid: "resolved-uuid")
+    ss = _sample_set(
+        sample_data={
+            "data": {
+                "soil_data": [{"samp_name": "S1", "env_medium": "soil [ENVO:1]"}],
+                # companion tab: merged by samp_name, NOT sent as its own sample
+                "emsl_data": [{"samp_name": "S1", "analysis_type": ["metagenomics"]}],
+            }
+        }
+    )
+    payloads = lims_export.build_lims_payloads(ss)
+
+    assert len(payloads) == 1  # only the soil sample, emsl_data merged in
+    p = payloads[0]
+    assert p["sample_type"] == "soil"
+    assert p["project_id"] == "61258"
+    assert p["project_uuid"] == "resolved-uuid"
+    assert p["shipment_tracking_number"] == ""  # left off, not synthesized
+    # samp_name -> sample_name; companion analysis_type merged onto the sample
+    assert p["sample_data"]["sample_name"] == "S1"
+    assert "samp_name" not in p["sample_data"]
+    assert p["sample_data"]["analysis_type"] == ["metagenomics"]
+
+
+def test_build_payloads_skips_unmapped_slot(monkeypatch):
+    monkeypatch.setattr(lims_export, "_resolve_project_uuid", lambda pid: "u")
+    # host_associated_data has no ESP sample-type mapping -> skipped (no bogus sample)
+    ss = _sample_set(sample_data={"data": {"host_associated_data": [{"samp_name": "H1"}]}})
+    assert lims_export.build_lims_payloads(ss) == []
+
+
+def test_build_payloads_skips_when_not_emsl_bound(monkeypatch):
+    monkeypatch.setattr(lims_export, "_resolve_project_uuid", lambda pid: "u")
+    # no 5-digit EMSL proposal number -> not EMSL-bound -> nothing exported
+    ss = _sample_set(
+        multi_omics_form={},
+        sample_data={"data": {"soil_data": [{"samp_name": "S1"}]}},
+    )
+    assert lims_export.build_lims_payloads(ss) == []
+
+
+def test_slot_to_sample_type_known_and_unknown():
+    assert lims_export.slot_to_sample_type("soil_data") == "soil"
+    assert lims_export.slot_to_sample_type("misc_envs_data") == "misc-envs"
+    assert lims_export.slot_to_sample_type("host_associated_data") is None
+
+
+# --------------------------------------------------------------------------- endpoint
+
+
+def _owned_sample_set(db, user, *, status=SubmissionStatusEnum.ApprovedHeld.text):
+    submission = fakes.SubmissionMetadataFactory(author=user, author_orcid=user.orcid)
+    fakes.SubmissionRoleFactory(
+        submission=submission,
+        submission_id=submission.id,
+        user_orcid=user.orcid,
+        role=SubmissionEditorRole.owner,
+    )
+    sample_set = fakes.SubmissionSampleSetFactory(
+        submission_metadata_id=submission.id, status=status
+    )
+    db.commit()
+    return sample_set
+
+
+@pytest.fixture(autouse=True)
+def _configured(monkeypatch):
+    # Ensure the endpoint sees a configured, enabled export for the happy-path tests.
+    monkeypatch.setattr(settings, "lims_export_enabled", True)
+    monkeypatch.setattr(settings, "lims_gateway_url", "http://lims.test/lims")
+    monkeypatch.setattr(settings, "lims_esp_token", "test-token")
+
+
+def test_send_to_lims_happy_path(db: Session, client: TestClient, logged_in_user, monkeypatch):
+    sample_set = _owned_sample_set(db, logged_in_user)
+    summary = {"total": 1, "sent": 1, "failed": 0, "results": []}
+    monkeypatch.setattr(lims_export, "send_sample_set_to_lims", lambda ss: summary)
+
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+
+    assert resp.status_code == 200
+    assert resp.json()["sent"] == 1
+    refreshed = db.get(models.SubmissionSampleSet, sample_set.id)
+    assert refreshed.lims_export_results == summary
+    assert refreshed.lims_exported_at is not None
+
+
+def test_send_to_lims_wrong_status_409(db: Session, client: TestClient, logged_in_user, monkeypatch):
+    sample_set = _owned_sample_set(db, logged_in_user, status=SubmissionStatusEnum.InProgress.text)
+    monkeypatch.setattr(lims_export, "send_sample_set_to_lims", lambda ss: {})
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+    assert resp.status_code == 409
+
+
+def test_send_to_lims_disabled_503(db: Session, client: TestClient, logged_in_user, monkeypatch):
+    sample_set = _owned_sample_set(db, logged_in_user)
+    monkeypatch.setattr(settings, "lims_export_enabled", False)
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+    assert resp.status_code == 503
+
+
+def test_send_to_lims_unconfigured_503(db: Session, client: TestClient, logged_in_user, monkeypatch):
+    sample_set = _owned_sample_set(db, logged_in_user)
+    monkeypatch.setattr(settings, "lims_esp_token", "")
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+    assert resp.status_code == 503
+
+
+def test_send_to_lims_forbidden_for_non_member(
+    db: Session, client: TestClient, logged_in_user, monkeypatch
+):
+    monkeypatch.setattr(lims_export, "send_sample_set_to_lims", lambda ss: {})
+    # Sample set on a submission the logged-in user has no role on.
+    other = fakes.SubmissionMetadataFactory()
+    sample_set = fakes.SubmissionSampleSetFactory(
+        submission_metadata_id=other.id, status=SubmissionStatusEnum.ApprovedHeld.text
+    )
+    db.commit()
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+    assert resp.status_code in (403, 404)

--- a/tests/test_lims_export.py
+++ b/tests/test_lims_export.py
@@ -138,7 +138,8 @@ def test_send_to_lims_happy_path(db: Session, client: TestClient, logged_in_user
 
     assert resp.status_code == 200
     assert resp.json()["sent"] == 1
-    refreshed = db.get(models.SubmissionSampleSet, sample_set.id)
+    db.expire_all()
+    refreshed = db.get(models.SubmissionSampleSet, sample_set.id)  # type: ignore[attr-defined]
     assert refreshed.lims_export_results == summary
     assert refreshed.lims_exported_at is not None
 

--- a/tests/test_lims_export.py
+++ b/tests/test_lims_export.py
@@ -73,6 +73,21 @@ def test_build_payloads_skips_when_not_emsl_bound(monkeypatch):
     assert lims_export.build_lims_payloads(ss) == []
 
 
+def test_resolve_project_uuid_aborts_instead_of_synthesizing(monkeypatch):
+    class _FakeDir:
+        def get_project_uuid(self, pid):
+            return None
+
+    monkeypatch.setattr(lims_export, "get_project_directory", lambda: _FakeDir())
+    # Real backend that can't resolve -> abort (do not fabricate a UUID).
+    monkeypatch.setattr(settings, "project_directory_backend", "nexus")
+    with pytest.raises(lims_export.LimsExportError):
+        lims_export._resolve_project_uuid("61258")
+    # Offline synthesize backend deliberately returns a deterministic placeholder.
+    monkeypatch.setattr(settings, "project_directory_backend", "synthesize")
+    assert lims_export._resolve_project_uuid("61258")
+
+
 def test_slot_to_sample_type_known_and_unknown():
     assert lims_export.slot_to_sample_type("soil_data") == "soil"
     assert lims_export.slot_to_sample_type("misc_envs_data") == "misc-envs"
@@ -82,8 +97,17 @@ def test_slot_to_sample_type_known_and_unknown():
 # --------------------------------------------------------------------------- endpoint
 
 
-def _owned_sample_set(db, user, *, status=SubmissionStatusEnum.ApprovedHeld.text):
-    submission = fakes.SubmissionMetadataFactory(author=user, author_orcid=user.orcid)
+def _owned_sample_set(
+    db,
+    user,
+    *,
+    status=SubmissionStatusEnum.ApprovedHeld.text,
+    templates=("emsl",),
+    is_test_submission=False,
+):
+    submission = fakes.SubmissionMetadataFactory(
+        author=user, author_orcid=user.orcid, is_test_submission=is_test_submission
+    )
     fakes.SubmissionRoleFactory(
         submission=submission,
         submission_id=submission.id,
@@ -91,7 +115,7 @@ def _owned_sample_set(db, user, *, status=SubmissionStatusEnum.ApprovedHeld.text
         role=SubmissionEditorRole.owner,
     )
     sample_set = fakes.SubmissionSampleSetFactory(
-        submission_metadata_id=submission.id, status=status
+        submission_metadata_id=submission.id, status=status, templates=list(templates)
     )
     db.commit()
     return sample_set
@@ -142,6 +166,25 @@ def test_send_to_lims_unconfigured_503(
     monkeypatch.setattr(settings, "lims_esp_token", "")
     resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
     assert resp.status_code == 503
+
+
+def test_send_to_lims_not_emsl_bound_409(
+    db: Session, client: TestClient, logged_in_user, monkeypatch
+):
+    # ApprovedHeld but no `emsl` template -> not EMSL-bound.
+    sample_set = _owned_sample_set(db, logged_in_user, templates=("soil",))
+    monkeypatch.setattr(lims_export, "send_sample_set_to_lims", lambda ss: {})
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+    assert resp.status_code == 409
+
+
+def test_send_to_lims_test_submission_409(
+    db: Session, client: TestClient, logged_in_user, monkeypatch
+):
+    sample_set = _owned_sample_set(db, logged_in_user, is_test_submission=True)
+    monkeypatch.setattr(lims_export, "send_sample_set_to_lims", lambda ss: {})
+    resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
+    assert resp.status_code == 409
 
 
 def test_send_to_lims_forbidden_for_non_member(

--- a/tests/test_lims_export.py
+++ b/tests/test_lims_export.py
@@ -119,7 +119,9 @@ def test_send_to_lims_happy_path(db: Session, client: TestClient, logged_in_user
     assert refreshed.lims_exported_at is not None
 
 
-def test_send_to_lims_wrong_status_409(db: Session, client: TestClient, logged_in_user, monkeypatch):
+def test_send_to_lims_wrong_status_409(
+    db: Session, client: TestClient, logged_in_user, monkeypatch
+):
     sample_set = _owned_sample_set(db, logged_in_user, status=SubmissionStatusEnum.InProgress.text)
     monkeypatch.setattr(lims_export, "send_sample_set_to_lims", lambda ss: {})
     resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")
@@ -133,7 +135,9 @@ def test_send_to_lims_disabled_503(db: Session, client: TestClient, logged_in_us
     assert resp.status_code == 503
 
 
-def test_send_to_lims_unconfigured_503(db: Session, client: TestClient, logged_in_user, monkeypatch):
+def test_send_to_lims_unconfigured_503(
+    db: Session, client: TestClient, logged_in_user, monkeypatch
+):
     sample_set = _owned_sample_set(db, logged_in_user)
     monkeypatch.setattr(settings, "lims_esp_token", "")
     resp = client.post(f"/api/metadata_submission/sample_set/{sample_set.id}/send-to-lims")


### PR DESCRIPTION
Implements the NMDC side of the Sample Metadata Submission → EMSL L7|ESP LIMS connector (the "NMDC connector"), mirroring EMSL's SMS flow.

Closes #2350
Umbrella / tracking: microbiomedata/issues#1791

## What
- `lims_export.py` — flatten a sample set into one wire payload per **environmental** sample (`ENVIRONMENTAL_DATA_SLOTS` only); map slot → ESP sample type (soil→soil, water→water, sediment→sediment, plant→plant, air→aerosol, misc_envs→misc-envs); **skip unmapped/non-EMSL** types (mirrors EMSL SMS, avoids receiver 500-storms); merge companion `emsl_data` metadata by `samp_name`; resolve `project_uuid` via a project directory (Nexus now, PV2-swappable by config).
- `project_directory.py` — EMSL project-id → project-uuid resolver (Nexus backend).
- `POST /metadata_submission/sample_set/{id}/send-to-lims` — gated on `ApprovedHeld` + owner/reviewer/admin; one POST per sample; awaits + idempotent retry (not fire-and-forget); persists per-sample results.
- `SubmissionSampleSet.lims_export_results` / `lims_exported_at` columns + alembic migration (parent `da7be44d437c`).
- Config: gateway URL, ESP service-account creds, project-directory backend, `lims_auth_in_header` flag.

## Verified
Locally end-to-end against real lims-dev — soil + water samples created with correct type/metadata; field mapping, idempotency, status/auth gating, and unmapped-slot skipping all exercised. Compiles on current `main`.

## Draft — dependencies before merge/deploy
- ESP token moves to `Authorization` header once lims-interface-api's header change lands (flag `lims_auth_in_header`, default off).
- Depends on: consolidation-API external route (nexus-restx-api !175), `misc-envs` schema/seed (analysisapi !1037 + lims-dev !280), NMDC L7 service account (`svcnmdcuser`, Anton).

## Placement
The endpoint operates on the `SubmissionSampleSet` Postgres tables/ORM (nmdc-server) + the existing status-transition endpoint, so it lives here rather than nmdc-runtime. Flagging for reviewer confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)