### PR TITLE
Enable wastewater sludge interface on submission portal

### DIFF
--- a/nmdc_server/models.py
+++ b/nmdc_server/models.py
@@ -1375,6 +1375,7 @@ ENVIRONMENTAL_DATA_SLOTS = [
     "plant_associated_data",
     "sediment_data",
     "soil_data",
+    "wastewater_sludge_data",
     "water_data",
 ]
 

--- a/web/src/views/SubmissionPortal/types.ts
+++ b/web/src/views/SubmissionPortal/types.ts
@@ -93,6 +93,12 @@ export const HARMONIZER_TEMPLATES = {
     sampleDataSlot: 'water_data',
     status: 'published',
   },
+  'wastewater sludge': {
+    displayName: 'wastewater sludge',
+    schemaClass: 'WastewaterSludgeInterface',
+    sampleDataSlot: 'wastewater_sludge_data',
+    status: 'published',
+  },
   isolate: {
     displayName: 'isolate',
     schemaClass: 'IsolateInterface',


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-server/issues/2248.

Adds an entry for "wastewater sludge" to HARMONIZER_TEMPLATES in the types file for the submission portal.

WastewaterSludgeInterface already exists in the submission-schema, this is just letting it show up in the list of checkboxes in Sample Environment tab.