### PR TITLE
Update ingest script to send Slack message upon receiving `SIGTERM` signal

### DIFF
--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -5,6 +5,7 @@ import os
 import signal
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -172,6 +173,20 @@ def send_slack_message(text: str) -> bool:
     return is_sent
 
 
+def format_exception_for_notification(error: BaseException) -> str:
+    r"""
+    Returns the "exception" (i.e. not stack trace) part of the specified exception.
+
+    Note: I think of this as the one-liner _following_ the stack trace in the normal exception dump.
+
+    Docs: https://docs.python.org/3/library/traceback.html#traceback.format_exception_only
+
+    >>> format_exception_for_notification(ValueError("Invalid value"))
+    'ValueError: Invalid value'
+    """
+    return "".join(traceback.format_exception_only(error)).strip()
+
+
 def format_report_bullets(reports: Dict[str, ETLReport]) -> str:
     r"""
     Formats all bullets from all reports into a single string.
@@ -180,7 +195,7 @@ def format_report_bullets(reports: Dict[str, ETLReport]) -> str:
     ...     "biosamples": ETLReport(plural_subject="Biosamples"),
     ...     "studies": ETLReport(plural_subject="Studies"),
     ... })
-    '• Biosamples: extracted `0`, loaded `0`\n• Studies: extracted `0`, loaded `0`'
+    '• Biosamples: extracted and loaded `0`\n• Studies: extracted and loaded `0`'
     """
 
     all_bullets = []
@@ -304,7 +319,7 @@ def ingest(
                 f"❌ Ingest failed.\n"
                 f"• Environment: `{settings.environment_name_for_ingester}`\n"
                 f"• Start time: `{ingest_start_datetime_str}`\n"
-                f"• Error message: {e}"
+                f"• Error message: {format_exception_for_notification(e)}"
             )
 
             # Now that we've processed the Exception at this level, propagate it.

--- a/nmdc_server/cli.py
+++ b/nmdc_server/cli.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import math
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -20,6 +21,32 @@ from nmdc_server.ingest.common import ETLReport
 from nmdc_server.models import SubmissionImagesObject
 from nmdc_server.static_files import generate_submission_schema_files, initialize_static_directory
 from nmdc_server.storage import BucketName, storage
+
+
+class TerminationRequested(BaseException):
+    """
+    Custom Exception type that can be used to report that we received a request to terminate
+    ourselves (i.e. we received a `SIGTERM` signal).
+
+    Note: If ingest is running and Kubernetes wants to terminate it prematurely (e.g. to free up
+          resources on an existing node; which can happen when a higher-priority pod has nowhere
+          to run), Kubernetes will send it a `SIGTERM` signal.
+          Docs: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+
+    Note: This is one of the rare situations where I think inheriting from `BaseException` (as
+          opposed to `Exception`) is warranted. I do not want to spend the time going through all
+          the existing `except Exception` statements in the ingest code and try to infer which
+          exception types their author intended to catch. I will leave a TODO for that.
+          TODO: Update existing `except Exception` statements to be more specific, then
+                update this class to inherit from `Exception` instead of `BaseException`.
+    """
+
+    pass
+
+
+def on_receive_sigterm_signal(signal_number: int, frame) -> None:
+    """Signal handler that raises an exception."""
+    raise TerminationRequested("Received SIGTERM signal.")
 
 
 def swap_gcp_secret_values(gcp_project_id: str, secret_a_id: str, secret_b_id: str) -> None:
@@ -124,18 +151,21 @@ def send_slack_message(text: str) -> bool:
     # Check whether a Slack Incoming Webhook URL is defined.
     if isinstance(settings.slack_webhook_url_for_ingester, str):
         click.echo(f"Sending Slack message having text: {text}")
-        response = requests.post(
-            settings.slack_webhook_url_for_ingester,
-            json={"text": text},
-            headers={"Content-type": "application/json"},
-        )
-
-        # Check whether the message was sent successfully.
-        if response.status_code == 200:
-            click.echo("Sent Slack message.")
-            is_sent = True
-        else:
-            click.echo("Failed to send Slack message.", err=True)
+        try:
+            response = requests.post(
+                settings.slack_webhook_url_for_ingester,
+                json={"text": text},
+                headers={"Content-type": "application/json"},
+                timeout=15,
+            )
+            # Check whether the message was sent successfully.
+            if response.status_code == 200:
+                click.echo("Sent Slack message.")
+                is_sent = True
+            else:
+                click.echo("Failed to send Slack message.", err=True)
+        except requests.RequestException as e:
+            click.echo(f"Failed to send Slack message. Error: {e}", err=True)
     else:
         click.echo("No Slack Incoming Webhook URL is defined.", err=True)
 
@@ -247,6 +277,10 @@ def ingest(
         level = logging.DEBUG
     logging.basicConfig(level=level, format="%(message)s")
 
+    # Register a signal handler for the `SIGTERM` signal.
+    # Docs: https://docs.python.org/3/library/signal.html#signal.signal
+    signal.signal(signal.SIGTERM, on_receive_sigterm_signal)
+
     # Get the current time as a human-readable string that indicates the timezone.
     ingest_start_datetime = datetime.datetime.now(datetime.timezone.utc)
     ingest_start_datetime_str = ingest_start_datetime.isoformat(timespec="seconds")
@@ -265,7 +299,7 @@ def ingest(
     if not skip_etl:
         try:
             reports = jobs.do_ingest(function_limit, skip_annotation)
-        except Exception as e:
+        except (Exception, TerminationRequested) as e:
             send_slack_message(
                 f"❌ Ingest failed.\n"
                 f"• Environment: `{settings.environment_name_for_ingester}`\n"


### PR DESCRIPTION
This branch contains fixes for 2 issues.

### Catching `SIGTERM` and sending a Slack message / logging a message

Today, when Kubernetes sends a `SIGTERM` signal to the ingest pod (e.g. when the pod gets pre-empted by a higher-priority workload, which is something that occurs due to a separate issue not addressed in this repo), the ingest script does not send a Slack message or write anything into its logs.

On this branch, I made it so, when the ingest script receives a `SIGTERM` signal (technically, it's only when the `jobs.do_ingest` function is running; although that accounts for pretty much everything except for the secret-swapping part of the process), the ingest script will send a Slack message saying that that is the case. And, whenever it sends a Slack message, it also copies that message to its logs, so we can see it there also.

I tested the changes locally, as shown here:

<img width="658" height="225" alt="image" src="https://github.com/user-attachments/assets/506d4797-1682-4dc7-be9e-8831b6fc8f34" />

I expect this to save our team members time and energy that they would have spent digging into logs on GKE, trying to understand why an ingest run seemed to end abruptly. I spend an hour on that today.

Fixes #2356 (Termination by Kubernetes doesn't produce a Slack or log message)

---

### Updating the Slack messages so they mention the exception type

I also updated the Slack message so that its "Error message" line includes the exception _type_, not just the exception "message". The screenshot above reflects this.

```diff
- • Error message: Received SIGTERM signal.
+ • Error message: nmdc_server.cli.TerminationRequested: Received SIGTERM signal.
```

Fixes #2354 (Slack messages not showing the exception type)

---

I forgot to mention that I also defined a timeout duration for the Slack message HTTP request. By default, Kubernetes provides pods with a 30-second grace period to gracefully shut down before Kubernetes sends `SIGKILL` to the pod. I didn't want the Slack message HTTP request to eat up that entire grace period.