### PR TITLE
Bug fixes for suggestion panel

### DIFF
--- a/web/src/use/useRequest.ts
+++ b/web/src/use/useRequest.ts
@@ -10,23 +10,28 @@ export default function useRequest() {
     count: 0, // indicates number of successful calls
   });
 
+  let activeRequests = 0;
+
    /**
     * Helper function to wrap an async request and manage loading and error state.
     * Callers of this function can check state.error to determine if an error occurred.
     * If state.error is null, then an error has not (yet) occurred.
-    * @param func 
-    * @returns 
+    * @param func
+    * @returns
     */
   async function request<T>(func: () => Promise<T>) {
     try {
+      activeRequests += 1;
       state.loading = true;
       state.error = null;
       const val = await func();
       state.count += 1;
-      state.loading = false;
+      activeRequests -= 1;
+      if (activeRequests === 0) state.loading = false;
       return val;
     } catch (err) {
-      state.loading = false;
+      activeRequests -= 1;
+      if (activeRequests === 0) state.loading = false;
       state.error = String(err);
       return null;
     }

--- a/web/src/views/SubmissionPortal/Components/HarmonizerSidebar.vue
+++ b/web/src/views/SubmissionPortal/Components/HarmonizerSidebar.vue
@@ -36,6 +36,10 @@ interface HarmonizerSidebarProps {
    * Whether to show the badge on the Metadata Suggester tab icon.
    */
   showSuggesterBadge?: boolean;
+  /**
+   * Callback to fetch study-info-based suggestions, passed through to MetadataSuggester.
+   */
+  fetchStudyInfoSuggestions: () => Promise<void>;
 }
 
 withDefaults(defineProps<HarmonizerSidebarProps>(), {
@@ -48,7 +52,6 @@ const emit = defineEmits<{
   'export-xlsx': [];
   'import-xlsx': [file: File];
   'clear-suggester-badge': [];
-  'fetch-study-info-suggestions': [];
 }>();
 
 const tabModel = ref(0);
@@ -140,7 +143,7 @@ const handleImport = (file: File) => {
           :enabled="metadataEditingAllowed"
           :harmonizer-api="harmonizerApi"
           :schema-class-name="harmonizerTemplate.schemaClass || ''"
-          @fetch-study-info-suggestions="emit('fetch-study-info-suggestions')"
+          :fetch-study-info-suggestions="fetchStudyInfoSuggestions"
         />
       </v-window-item>
       <v-window-item>

--- a/web/src/views/SubmissionPortal/Components/HarmonizerSidebar.vue
+++ b/web/src/views/SubmissionPortal/Components/HarmonizerSidebar.vue
@@ -39,7 +39,7 @@ interface HarmonizerSidebarProps {
   /**
    * Callback to fetch study-info-based suggestions, passed through to MetadataSuggester.
    */
-  fetchStudyInfoSuggestions: () => Promise<void>;
+  fetchStudyInfoSuggestions: () => Promise<unknown>;
 }
 
 withDefaults(defineProps<HarmonizerSidebarProps>(), {

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -2,7 +2,7 @@
 /**
  * Component to display metadata suggestions and allow users to accept or reject them.
  */
-import { computed, ref, watchEffect } from 'vue';
+import { computed, ref, watch, watchEffect } from 'vue';
 import {
   CellData,
   MetadataSuggestion,
@@ -110,6 +110,14 @@ const pendingSuggestions = computed(() => (
         return a.slot.localeCompare(b.slot);
       })
 ));
+
+// If suggestions already exist when the component mounts (e.g. navigating back to this tab), show them
+// immediately without requiring the user to click "Suggest Metadata" again.
+watch(pendingSuggestions, (suggestions) => {
+  if (suggestions.length > 0) {
+    suggestionStarted.value = true;
+  }
+}, { immediate: true });
 
 const filteredSuggestions = computed(() => {
   let suggestions = pendingSuggestions.value;

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -51,12 +51,9 @@ const allFilterOptions = [
 ];
 
 const filterSelectionLabel = computed(() => {
-  const fillsAll = store.ui.suggestionFills.size === 0 || store.ui.suggestionFills.size === scopeOptions.length;
-  const typesAll = store.ui.suggestionTypes.size === 0 || store.ui.suggestionTypes.size === suggestionTypeOptions.length;
-  if (fillsAll && typesAll) return 'All';
   const parts = [
-    ...(typesAll ? [] : Array.from(store.ui.suggestionTypes).map((t) => suggestionTypeOptions.find((o) => o.value === t)?.label)),
-    ...(fillsAll ? [] : Array.from(store.ui.suggestionFills).map((f) => scopeOptions.find((o) => o.value === f)?.label)),
+    ...Array.from(store.ui.suggestionTypes).map((t) => suggestionTypeOptions.find((o) => o.value === t)?.label),
+    ...Array.from(store.ui.suggestionFills).map((f) => scopeOptions.find((o) => o.value === f)?.label),
   ].filter(Boolean);
   return parts.join(', ');
 });
@@ -426,9 +423,10 @@ function getSlotTitle(slot: string) {
               item-title="label"
               item-value="value"
               label="Filter"
+              placeholder="All"
+              persistent-placeholder
               hide-details
               clearable
-              persistent-placeholder
               multiple
               @update:model-value="onFilterUpdate"
             >

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -80,7 +80,6 @@ const emit = defineEmits<{
 }>();
 
 const rejectedSuggestions = ref([] as string[]);
-const onDemandSuggestionsLoading = ref(false);
 
 // When the route or schema class name changes (because of changing the active template tab), update the rejected
 // suggestions list from local storage.
@@ -316,34 +315,15 @@ function handleRejectAllSuggestions() {
 /**
  * Handle clicking the "Suggest Metadata" button.
  *
- * Fetches suggestions from study info, then marks suggestion as started.
+ * Fetches suggestions from study info and from all sample rows (for rule-based suggesters like
+ * elevation), then marks suggestion as started.
  */
-function handleStartSuggestion() {
+async function handleStartSuggestion() {
   emit('fetch-study-info-suggestions');
   suggestionStarted.value = true;
-}
-
-async function _handleSuggestForSelectedRows() {
-  onDemandSuggestionsLoading.value = true;
-  const selectedRanges = props.harmonizerApi.getSelectedCells();
-  // selectedRanges is an array of arrays, representing all (possibly discontinuous) ranges of selected cells. Each
-  // inner array is [startRow, startCol, endRow, endCol]. Reduce this to a flat array of row numbers contained in
-  // the selected ranges.
-  const rows = selectedRanges.reduce((acc, range) => {
-    if (range[0] === undefined || range[2] === undefined) {
-      return acc;
-    }
-    for (let i = range[0]; i <= range[2]; i += 1) {
-      acc.push(i);
-    }
-    return acc;
-  }, [] as number[]);
-  const changedRowData = props.harmonizerApi.getDataByRows(rows);
-  try {
-    await loadSuggestionsFromSampleRows(props.schemaClassName, changedRowData);
-  } finally {
-    onDemandSuggestionsLoading.value = false;
-  }
+  const allRows = props.harmonizerApi.exportJson().map((_: any, i: number) => i);
+  const allRowData = props.harmonizerApi.getDataByRows(allRows);
+  await loadSuggestionsFromSampleRows(props.schemaClassName, allRowData);
 }
 
 /**

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -28,6 +28,11 @@ interface MetadataSuggesterProps {
    * The schema class name for the active template.
    */
   schemaClassName: string;
+  /**
+   * Callback to fetch study-info-based suggestions. Called after row-based suggestions complete so
+   * the two operations are sequenced and don't overwrite each other.
+   */
+  fetchStudyInfoSuggestions: () => Promise<void>;
 }
 
 const store = useSubmissionStore();
@@ -72,9 +77,6 @@ function getSuggestionKey(suggestion: MetadataSuggestion) {
 }
 
 const props = defineProps<MetadataSuggesterProps>();
-const emit = defineEmits<{
-  'fetch-study-info-suggestions': [];
-}>();
 
 const rejectedSuggestions = ref([] as string[]);
 
@@ -324,11 +326,14 @@ function handleRejectAllSuggestions() {
  * elevation), then marks suggestion as started.
  */
 async function handleStartSuggestion() {
-  emit('fetch-study-info-suggestions');
   suggestionStarted.value = true;
+  // Run rule-based suggestions first (e.g. elevation), then AI suggestions so they don't
+  // overwrite each other — loadSuggestionsFromSampleRows drops all suggestions for each
+  // processed row, so it must finish before loadSuggestionsFromStudyInfo merges its results.
   const allRows = props.harmonizerApi.exportJson().map((_: any, i: number) => i);
   const allRowData = props.harmonizerApi.getDataByRows(allRows);
   await loadSuggestionsFromSampleRows(props.schemaClassName, allRowData);
+  await props.fetchStudyInfoSuggestions();
 }
 
 /**

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -111,7 +111,7 @@ const pendingSuggestions = computed(() => (
       })
 ));
 
-// If suggestions already exist when the component mounts (e.g. navigating back to this tab), show them
+// If suggestions already exist when the component mounts, show them
 // immediately without requiring the user to click "Suggest Metadata" again.
 watch(pendingSuggestions, (suggestions) => {
   if (suggestions.length > 0) {

--- a/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
+++ b/web/src/views/SubmissionPortal/Components/MetadataSuggester.vue
@@ -32,7 +32,7 @@ interface MetadataSuggesterProps {
    * Callback to fetch study-info-based suggestions. Called after row-based suggestions complete so
    * the two operations are sequenced and don't overwrite each other.
    */
-  fetchStudyInfoSuggestions: () => Promise<void>;
+  fetchStudyInfoSuggestions: () => Promise<unknown>;
 }
 
 const store = useSubmissionStore();

--- a/web/src/views/SubmissionPortal/HarmonizerView.vue
+++ b/web/src/views/SubmissionPortal/HarmonizerView.vue
@@ -1178,7 +1178,7 @@ const appBannerHeight = inject(AppBannerHeightKey);
             :harmonizer-template="activeTemplate!"
             :metadata-editing-allowed="isEditable"
             :show-suggester-badge="showSuggesterBadge"
-            @fetch-study-info-suggestions="fetchSuggestionsFromStudyDetails"
+            :fetch-study-info-suggestions="fetchSuggestionsFromStudyDetails"
             @import-xlsx="openFile"
             @export-xlsx="downloadSamples"
             @clear-suggester-badge="showSuggesterBadge = false"

--- a/web/src/views/SubmissionPortal/store/index.ts
+++ b/web/src/views/SubmissionPortal/store/index.ts
@@ -219,8 +219,8 @@ export const useSubmissionStore = defineStore('submission', () => {
     },
   });
   const ui = reactive<UiState>({
-    suggestionFills: new Set(Object.values(SuggestionFill)),
-    suggestionTypes: new Set([SuggestionType.ADDITIONS, SuggestionType.REPLACEMENTS]),
+    suggestionFills: new Set<SuggestionFill>(),
+    suggestionTypes: new Set<SuggestionType>(),
     pendingImageUploads: new Set(),
   });
   const submissionListFilters = reactive<SubmissionListFilterState>({


### PR DESCRIPTION
fixed the following:

- Elevation suggestions not triggering - wired them into the "Suggest Metadata" button click so they run alongside the AI suggestions.
- Loading spinner disappeared too early - when two requests run at the same time, the spinner was turning off as soon as the first one finished. Fixed it to wait until both are done.
- Filter field weirdness - changed the filter so "nothing selected" means "show all" (instead of needing everything checked to mean all). Now it shows "All" as a placeholder when nothing is selected, and you can pick individual options to narrow down. Options appear in clear text now
- Suggestions disappeared when switching tabs - coming back to the suggester tab reset it to the initial "click to start" state even if you already had suggestions. Now it checks if suggestions already exist and shows them right away. 

<img width="505" height="355" alt="Screenshot 2026-09-09 at 11 01 07 AM" src="https://github.com/user-attachments/assets/592dec61-1a71-4474-a9b9-22df2f404d74" />
<img width="454" height="393" alt="Screenshot 2026-09-09 at 11 01 02 AM" src="https://github.com/user-attachments/assets/394e75d1-7468-4fbd-9bd0-c335f7d68f9e" />
<img width="954" height="530" alt="Screenshot 2026-09-09 at 11 00 45 AM" src="https://github.com/user-attachments/assets/7cf7db0f-fac2-4fda-b789-2e8799e640cf" />
