### PR TITLE
Add fallback study name to submission list

### DIFF
--- a/web/src/views/SubmissionPortal/Components/SubmissionList.vue
+++ b/web/src/views/SubmissionPortal/Components/SubmissionList.vue
@@ -262,7 +262,7 @@ async function addReviewer() {
                 :to="{ name: 'Submission Summary', params: { id: item.id } }"
                 class="text-primary text-decoration-none"
               >
-                {{ item.study_name }}
+                {{ item.study_name || "No Study Name Provided"}}
               </router-link>
               <v-chip
                 v-if="item.is_test_submission"


### PR DESCRIPTION
Resolves #2369 

Simple one line fix to add a placeholder study name if one isn't available.